### PR TITLE
Fix for pub crashing in checked mode

### DIFF
--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -158,7 +158,7 @@ Future runInIsolate(String code, message, {packageRoot, String snapshot})
     async {
   if (snapshot != null && fileExists(snapshot)) {
     log.fine("Spawning isolate from $snapshot.");
-    if (packageRoot != null) packageRoot = packageRoot.toString();
+    if (packageRoot != null) packageRoot = Uri.parse(packageRoot.toString());
     try {
       await Isolate.spawnUri(path.toUri(snapshot), [], message,
           packageRoot: packageRoot);


### PR DESCRIPTION
Pub crash in checked mode because spawnUri requires packageRoot to be a Uri, while here it can also be a String.
