### PR TITLE
Add github version range support

### DIFF
--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -308,7 +308,7 @@ class GitSource extends CachedSource {
       var result = await git.run(["rev-list", "--max-count=1", ref],
           workingDir: _repoCachePath(id));
       return result.first;
-    } on git.GitException catch (e) {
+    } on git.GitException {
       if (ref == id.version.toString()) {
         // Try again with a "v" before the ref in case this was a version tag
         ref = 'v$ref';
@@ -316,7 +316,7 @@ class GitSource extends CachedSource {
             workingDir: _repoCachePath(id));
         return result.first;
       }
-      throw e;
+      rethrow;
     }
   }
 

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -257,11 +257,11 @@ class GitSource extends CachedSource {
   ///
   /// Returns a future that completes with true if the repo was cloned, and
   /// false if the repo clone already exists.
-  Future<bool> _ensureRepo(PackageRef ref) async {
+  Future<bool> _ensureRepo(PackageRef ref, {mirror: false}) async {
     String cachePath = _repoCachePath(ref);
     if (!entryExists(cachePath)) {
       // Must have the repo cloned in order to list its tags
-      await _clone(_getUrl(ref), cachePath);
+      await _clone(_getUrl(ref), cachePath, mirror: mirror);
       return true;
     }
     return false;
@@ -275,7 +275,7 @@ class GitSource extends CachedSource {
   /// [id].
   Future<String> _ensureRevision(PackageId id) async {
     PackageRef packageRef = id.toRef();
-    if (await _ensureRepo(packageRef)) {
+    if (await _ensureRepo(packageRef, mirror: true)) {
       return _getRev(id);
     }
 

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -54,7 +54,7 @@ class GitSource extends CachedSource {
     await _ensureRepo(ref);
 
     var cachePath = _repoCachePath(ref);
-    List results = await git.run(["tag", "-l"], workingDir: cachePath);
+    List results = await git.run(['tag', '-l', '*.*.*'], workingDir: cachePath);
     List<Pubspec> validVersions = [];
     for (String version in results) {
       // Strip preceding 'v' character so 'v1.0.0' can be parsed into a Version

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -56,16 +56,17 @@ class GitSource extends CachedSource {
     var cachePath = _repoCachePath(ref);
     List results = await git.run(['tag', '-l', '*.*.*'], workingDir: cachePath);
     List<Pubspec> validVersions = [];
-    for (String version in results) {
+    for (String tag in results) {
       // Strip preceding 'v' character so 'v1.0.0' can be parsed into a Version
-      if (version.startsWith('v')) {
-        version = version.substring(1);
+      String versionTag = tag;
+      if (versionTag.startsWith('v')) {
+        versionTag = versionTag.substring(1);
       }
       try {
         // Use Version.parse to determine valid version tags
-        Version validVersion = new Version.parse(version);
+        new Version.parse(versionTag);
         // Fetch the pubspec for this version
-        Pubspec pubspec = await _getPubspec(cachePath, validVersion.toString());
+        Pubspec pubspec = await _getPubspec(cachePath, tag);
         if (pubspec != null) {
           validVersions.add(pubspec);
         }

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -113,7 +113,7 @@ class GitSource extends CachedSource {
       await _clone(cachePath, revisionCachePath, mirror: false);
     }
 
-    var ref = _getEffectiveRef(id);
+    var ref = await _getRev(id);
     if (ref != 'HEAD') await _checkOut(revisionCachePath, ref);
 
     return new Package.load(id.name, revisionCachePath, systemCache.sources);


### PR DESCRIPTION
_I know this is not the proper way to submit contributions, but I want to get feedback from dart-lang folks and make sure it is something that could potentially be accepted before I spend any more time on this._

This is a fix for #1250. I work for Workiva (met some of you at the Dart Summit!) and we now have quite a few dart libraries in our Github organization. Some of these are public and OSS, but many of them cannot be. #1250 is a big issue for us for the private libraries as it requires us to update pubspecs all over the place anytime a patch version of some library is released, and consumers end up having a big list of dependency overrides while those transitions are in progress.

This PR implements version ranges for github dependencies with the following in a `pubspec.yaml`:

```yaml
dependencies:
  w_flux:
    version: "^1.0.0"
    git: git@github.com:Workiva/w_flux.git
```

It assumes that versions will exist as git tags on the repo, and uses `git tag -l` to list the tags. It then collects a list of the tags that are considered valid version strings using `Version.parse()`. 

The biggest issue I have had so far is dealing with git tags that include the "v" in the name, i.e. "v1.0.0". I can strip the "v" before giving it to the version solver, but then when it tries to get the ref (`_getRef`) it of course cannot find it without the "v" that was previously removed. At Workiva we do not use the preceding "v" in our tag names, but it seems like many people do so I am assuming this will be a big issue for this feature.

It seems like it would be possible for the Version class to accept "v" versions strings in its `parse` constructor, and keep track of it so that it can put it back when `toString()` is called. This would require a change to pub_semver, though.

I'm hoping to get some feedback from the Dart team on whether or not we should continue down this path. Please let me know your thoughts! 

@nex3 @kevmoo @munificent