### PR TITLE
Add a `pub cache path` command for printing the path

### DIFF
--- a/lib/src/command/cache.dart
+++ b/lib/src/command/cache.dart
@@ -5,6 +5,7 @@
 import '../command.dart';
 import 'cache_add.dart';
 import 'cache_list.dart';
+import 'cache_path.dart';
 import 'cache_repair.dart';
 
 /// Handles the `cache` pub command.
@@ -17,6 +18,7 @@ class CacheCommand extends PubCommand {
   CacheCommand() {
     addSubcommand(new CacheAddCommand());
     addSubcommand(new CacheListCommand());
+    addSubcommand(new CachePathCommand());
     addSubcommand(new CacheRepairCommand());
   }
 }

--- a/lib/src/command/cache_path.dart
+++ b/lib/src/command/cache_path.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../command.dart';
+
+/// Handles the `cache path` pub command.
+class CachePathCommand extends PubCommand {
+  String get name => "path";
+  String get description => "Prints the location of the pub cache";
+  String get invocation => "pub cache path";
+  bool get hidden => true;
+  bool get takesArguments => false;
+
+  void run() {
+    print(cache.rootDir);
+  }
+}


### PR DESCRIPTION
Without this there is no easy way to get the path
pub is uses for its cache (which seems like a very
reasonable thing for the tool to be able to tell
the user).

Happy to expose this in a different way.