### PR TITLE
Skip test "SDK constraint doesn't match the current SDK" that times out.

### DIFF
--- a/test/must_pub_get_test.dart
+++ b/test/must_pub_get_test.dart
@@ -284,7 +284,7 @@ foo:http://example.com/
 
       _requiresPubGet("Dart 0.1.2+3 is incompatible with your dependencies' "
           "SDK constraints. Please run \"pub get\" again.");
-    });
+    }, skip: "Times out. Issue https://github.com/dart-lang/pub/issues/1389");
 
     group("a path dependency's dependency doesn't match the lockfile", () {
       setUp(() {


### PR DESCRIPTION
Issue https://github.com/dart-lang/pub/issues/1389