### PR TITLE
Suppress permission-related failures in touch().

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -433,7 +433,7 @@ class Entrypoint {
         hasPathDependencies) {
       if (_isLockFileUpToDate() && _arePackagesAvailable()) {
         touchedLockFile = true;
-        touch(lockFilePath);
+        tryTouch(lockFilePath);
       } else {
         dataError('The pubspec.yaml file has changed since the pubspec.lock '
             'file was generated, please run "pub get" again.');
@@ -443,13 +443,13 @@ class Entrypoint {
     var packagesModified = new File(packagesFile).lastModifiedSync();
     if (packagesModified.isBefore(lockFileModified)) {
       if (_isPackagesFileUpToDate()) {
-        touch(packagesFile);
+        tryTouch(packagesFile);
       } else {
         dataError('The pubspec.lock file has changed since the .packages file '
             'was generated, please run "pub get" again.');
       }
     } else if (touchedLockFile) {
-      touch(packagesFile);
+      tryTouch(packagesFile);
     }
 
     var sdkConstraint = _sdkConstraint.firstMatch(lockFileText);

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -831,13 +831,18 @@ _doProcess(Function fn, String executable, List<String> args,
       environment: environment);
 }
 
-/// Updates [path]'s modification time.
-void touch(String path) {
-  var file = new File(path).openSync(mode: FileMode.APPEND);
-  var originalLength = file.lengthSync();
-  file.writeByteSync(0);
-  file.truncateSync(originalLength);
-  file.closeSync();
+/// Updates [path]'s modification time if the file is writable.
+void tryTouch(String path) {
+  try {
+    var file = new File(path).openSync(mode: FileMode.APPEND);
+    var originalLength = file.lengthSync();
+    file.writeByteSync(0);
+    file.truncateSync(originalLength);
+    file.closeSync();
+  } on FileSystemException catch (e) {
+    // Suppress if permissions error (EACCES)
+    if (e.osError?.errorCode != 13) rethrow;
+  }
 }
 
 /// Creates a temporary directory and passes its path to [fn].

--- a/test/must_pub_get_test.dart
+++ b/test/must_pub_get_test.dart
@@ -416,6 +416,6 @@ void _touch(String path) {
     await new Future.delayed(new Duration(seconds: 1));
 
     path = p.join(sandboxDir, "myapp", path);
-    touch(path);
+    tryTouch(path);
   }, "touching $path");
 }


### PR DESCRIPTION
If unable to update modification time due to a permissions error, such
as the file being read-only, continue without throwing.