### PR TITLE
Change duration formatting in niceDuration

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -787,9 +787,10 @@ String nicePath(String inputPath) {
 
 /// Returns a human-friendly representation of [duration].
 String niceDuration(Duration duration) {
-  var result = duration.inMinutes > 0 ? "${duration.inMinutes}:" : "";
+  var hasMinutes = duration.inMinutes > 0;
+  var result = hasMinutes ? "${duration.inMinutes}:" : "";
 
-  var s = duration.inSeconds % 59;
+  var s = duration.inSeconds % 60;
   var ms = duration.inMilliseconds % 1000;
 
   // If we're using verbose logging, be more verbose but more accurate when
@@ -800,7 +801,7 @@ String niceDuration(Duration duration) {
     ms ~/= 100;
   }
 
-  return "$result$s.${ms}s";
+  return "$result${hasMinutes ? padLeft(s.toString(), 2, '0') : s}.${ms}s";
 }
 
 /// Decodes a URL-encoded string.

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -82,5 +82,20 @@ true: bool"""));
 a: {}
 b: {}"""));
     });
+
+  });
+
+  group('niceDuration()', () {
+    test('formats duration longer than a minute correctly', () {
+      expect(
+          niceDuration(new Duration(minutes: 3, seconds: 1, milliseconds: 337)),
+          equals("3:01.3s"));
+    });
+
+    test('does not display extra zero when duration is less than a minute', () {
+      expect(
+          niceDuration(new Duration(minutes: 0, seconds: 0, milliseconds: 400)),
+          equals("0.4s"));
+    });
   });
 }

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -97,5 +97,9 @@ b: {}"""));
           niceDuration(new Duration(minutes: 0, seconds: 0, milliseconds: 400)),
           equals("0.4s"));
     });
+
+    test('has reasonable output on minute boundary', () {
+      expect(niceDuration(new Duration(minutes: 1)), equals("1:00.0s"));
+    });
   });
 }


### PR DESCRIPTION
niceDuration used to display 61 second as "1:1" instead of "1:01". This patch fixes that and minute duration (which is 60 seconds last time I've checked) and adds couple of unit tests.