### PR TITLE
Support simple path rewrites to index.html for angular2

### DIFF
--- a/test/serve/rewrite_to_index_test.dart
+++ b/test/serve/rewrite_to_index_test.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+import 'utils.dart';
+
+main() {
+  integration("rewrites selected paths to index.html", () {
+    d.dir(appPath, [
+      d.appPubspec(),
+      d.dir("web", [
+        d.file("index.html", "index contents")
+      ])
+    ]).create();
+
+    pubGet();
+    pubServe(args: ['--rewrite-to-index', r'^a$']);
+    requestShouldSucceed("a", "index contents");
+    requestShould404("dne");
+    endPubServe();
+  });
+}


### PR DESCRIPTION
Fixes #1374.

This commit adds a serve option:<br>
  `pub serve`**`--rewrite-to-index`**_`<path-regexp>`_.<br>
A request that would yield 404 (not found), but whose path matches the regexp, will be directed to `/index.html`.

This will be useful while developing Angular 2 Dart apps with routing. In the simplest case, the empty string will match any path:

```
pub serve --rewrite-to-index ''
```

**All 1130 tests pass** (including the newly added test).

cc @kwalrath @kasperpeulen @zoechi
