### PR TITLE
eliminate test failure on mac

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -251,7 +251,7 @@ String createTempDir(String base, String prefix) {
 String createSystemTempDir() {
   var tempDir = Directory.systemTemp.createTempSync('pub_');
   log.io("Created temp directory ${tempDir.path}");
-  return tempDir.path;
+  return tempDir.resolveSymbolicLinksSync();
 }
 
 /// Lists the contents of [dir].


### PR DESCRIPTION
Where /var/ is really /private/var/

Eliminates two failures in test/run/package_api_test.dart