### PR TITLE
Fix extractTarGz().

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -886,8 +886,8 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
     return await _extractTarGzWindows(stream, destination);
   }
 
-  var args = ["--extract", "--gunzip", "--directory", "--no-same-owner",
-              "--no-same-permissions", destination];
+  var args = ["--extract", "--gunzip", "--no-same-owner",
+              "--no-same-permissions", "--directory", destination];
   if (_noUnknownKeyword) {
     // BSD tar (the default on OS X) can insert strange headers to a tarfile
     // that GNU tar (the default on Linux) is unable to understand. This will


### PR DESCRIPTION
3fa5df4d55328628d8c91560f61cfb1f92a003b7 added new flags between the
"--directory" flag and the directory in question, which broke untarring.