### PR TITLE
Disable passing "--uname" and "--gname" to tar on non-Linux.

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -1048,7 +1048,12 @@ ByteStream createTarGz(List contents, {String baseDir}) {
       } else {
         // BSD tar flags.
         // https://www.freebsd.org/cgi/man.cgi?query=bsdtar&sektion=1
-        args.addAll(["--uname=pub", "--gname=pub"]);
+        // TODO(rnystrom): These flags are, alas, not supported by the version
+        // of tar on OS X. Passing them causes tar to exit with an error. For
+        // now, we'll just not handle large UIDs on Mac until we can come up
+        // with something.
+        // See: https://github.com/dart-lang/pub/issues/1442
+        // args.addAll(["--uname=pub", "--gname=pub"]);
       }
 
       var process = await startProcess("tar", args);


### PR DESCRIPTION
That hits OS X too, and the version of tar on OS X doesn't support
those. :(