### PR TITLE
First pass at strict dependencies

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -786,3 +786,7 @@ void fail(String message, [innerError, StackTrace innerTrace]) {
 ///
 /// This will report the error and cause pub to exit with [exit_codes.DATA].
 void dataError(String message) => throw new DataException(message);
+
+/// Returns an iterable combining [a] and [b].
+Iterable/*<T>*/ combineIterables/*<T>*/(Iterable/*<T>*/ a, Iterable/*<T>*/ b) =>
+  a.toList()..addAll(b);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -787,6 +787,8 @@ void fail(String message, [innerError, StackTrace innerTrace]) {
 /// This will report the error and cause pub to exit with [exit_codes.DATA].
 void dataError(String message) => throw new DataException(message);
 
-/// Returns an iterable combining [a] and [b].
-Iterable/*<T>*/ combineIterables/*<T>*/(Iterable/*<T>*/ a, Iterable/*<T>*/ b) =>
-  a.toList()..addAll(b);
+/// Returns an iterable that contains the elements of [iter1] followed by those
+/// of [iter2].
+Iterable/*<T>*/ combineIterables/*<T>*/(
+        Iterable/*<T>*/ iter1, Iterable/*<T>*/ iter2) =>
+    iter1.toList()..addAll(iter2);

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -1,0 +1,50 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../entrypoint.dart';
+import 'dart:async';
+import 'dart:io';
+
+import 'package:analyzer/analyzer.dart';
+import 'package:pub/src/solver/version_solver.dart';
+import 'package:pub/src/validator.dart';
+
+/// Returns a map of files -> package names imported or exported within [files].
+Map<String, Iterable<String>> _findUsedPackages(Iterable<String> files) {
+  var packageNames = <String, Iterable<String>>{};
+  for (var file in files) {
+    var usedPackages = <String>[];
+    var compilationUnit = parseDirectives(new File(file).readAsStringSync());
+    for (final directive in compilationUnit.directives) {
+      if (directive is UriBasedDirective) {
+        usedPackages
+            .add(Uri.parse(directive.uri.stringValue).pathSegments.first);
+      }
+    }
+    packageNames[file] = usedPackages.toSet();
+  }
+  return packageNames;
+}
+
+class StrictDependenciesValidator extends Validator {
+  StrictDependenciesValidator(Entrypoint entrypoint) : super(entrypoint);
+
+  @override
+  Future validate() {
+    return new Future.sync(() async {
+      var declared = new Set<String>()
+        ..addAll(entrypoint.root.dependencies.map((d) => d.name))
+        ..addAll(entrypoint.root.devDependencies.map((d) => d.name));
+      var allUsed = _findUsedPackages(entrypoint.root.listFiles());
+      allUsed.forEach((file, packageNames) {
+        for (var package in packageNames) {
+          if (!declared.contains(package)) {
+            warnings.add(
+                'Referenced "$package" in $file, but no dependency declared');
+          }
+        }
+      });
+    });
+  }
+}

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -5,73 +5,156 @@
 import 'dart:async';
 
 import 'package:analyzer/analyzer.dart';
-import 'package:path/path.dart' as path;
 import 'package:pub/src/dart.dart';
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/io.dart';
+import 'package:pub/src/log.dart';
 import 'package:pub/src/validator.dart';
 import 'package:source_span/source_span.dart';
 
+/// Validates that Dart source files only import declared dependencies.
 class StrictDependenciesValidator extends Validator {
-  static bool _isDartFile(String file) => path.extension(file) == '.dart';
+  static Iterable<String> _combine(Iterable<String> a, Iterable<String> b) {
+    return a.toList()..addAll(b);
+  }
 
   StrictDependenciesValidator(Entrypoint entrypoint) : super(entrypoint);
 
-  /// Returns all pub packages imported or exported within [files].
-  List<_DependencyUse> _findPackages(Iterable<String> files) {
-    var allUses = <_DependencyUse>[];
+  Set<String> _dependencies;
+
+  /// Lazily returns all dependency uses in [files].
+  ///
+  /// Files that do not parse are skipped.
+  ///
+  /// Directives that do not import package: URIs are skipped.
+  Iterable<_Usage> _findPackages(Iterable<String> files) sync* {
     for (var file in files) {
-      var dependencies = new List<_DependencyUse>();
+      List<UriBasedDirective> directives;
+      var contents = readTextFile(file);
       try {
-        var contents = readTextFile(file);
-        var directives = parseImportsAndExports(contents, name: file);
-        for (var directive in directives) {
-          var usage = new _DependencyUse(directive, file, contents);
-          if (usage.isPubPackage) {
-            dependencies.add(usage);
-          }
+        directives = parseImportsAndExports(contents, name: file);
+      } on AnalyzerErrorGroup catch (e, s) {
+        // Ignore files that do not parse.
+        exception(e, s);
+        continue;
+      }
+      for (var directive in directives) {
+        Uri uri;
+        try {
+          uri = Uri.parse(directive.uri.stringValue);
+        } on FormatException catch (_){}
+        var usage = new _Usage(file, contents, directive, uri);
+        if (usage.isPackageUrl) {
+          yield usage;
         }
-        allUses.addAll(dependencies);
-      } on AnalyzerErrorGroup catch (e) {
-        warnings.add('Failed parsing "$file": $e');
       }
     }
-    return allUses;
+  }
+
+  /// Returns whether [package] is listed under `dependencies: `.
+  ///
+  /// The current package is implicitly a dependency.
+  bool _isDependency(String package) {
+    if (_dependencies == null) {
+      _dependencies = entrypoint.root.dependencies
+          .map((d) => d.name)
+          .toSet();
+    }
+    return entrypoint.root.name == package || _dependencies.contains(package);
+  }
+
+  Set<String> _devDependencies;
+
+  /// Returns whether [package] is listed under `dev_dependencies: `.
+  bool _isDevDependency(String package) {
+    if (_devDependencies == null) {
+      _devDependencies = entrypoint.root.devDependencies
+          .map((d) => d.name)
+          .toSet();
+    }
+    return _devDependencies.contains(package);
   }
 
   Future validate() async {
-    var declared = new Set<String>()
-      ..addAll(entrypoint.root.dependencies.map((d) => d.name))
-      ..addAll(entrypoint.root.devDependencies.map((d) => d.name))
-      ..add(entrypoint.root.name);
-    var allUsed = _findPackages(entrypoint.root.listFiles().where(_isDartFile));
-    for (var usage in allUsed) {
-      if (!declared.contains(usage.package)) {
-        warnings.add(usage.toErrorMessage());
+    _validateLibBin();
+    _validateTestTool();
+  }
+
+  void _validateLibBin() {
+    var libFiles = entrypoint.root.listFiles(beneath: 'lib');
+    var binFiles = entrypoint.root.listFiles(beneath: 'bin');
+    for (var usage in _findPackages(_combine(libFiles, binFiles))) {
+      if (!usage.isUriValid) {
+        warnings.add(usage.uriInvalidMessage());
+      } else if (!_isDependency(usage.package)) {
+        if (_isDevDependency(usage.package)) {
+          warnings.add(usage.dependencyMisplaceMessage());
+        } else {
+          warnings.add(usage.dependencyMissingMessage());
+        }
+      }
+    }
+  }
+
+  void _validateTestTool() {
+    var testFiles = entrypoint.root.listFiles(beneath: 'test');
+    var toolFiles = entrypoint.root.listFiles(beneath: 'tool');
+    for (var usage in _findPackages(_combine(testFiles, toolFiles))) {
+      if (!usage.isUriValid) {
+        warnings.add(usage.uriInvalidMessage());
+      } else if (!_isDependency(usage.package) &&
+                 !_isDevDependency(usage.package)) {
+        warnings.add(usage.dependencyMissingMessage());
       }
     }
   }
 }
 
-class _DependencyUse {
+/// Represents a parsed import or export directive in a dart source file.
+class _Usage {
   final String _contents;
-  final UriBasedDirective _directive;
   final String _file;
-  final Uri _parsedUri;
+  final Uri _uri;
+  final UriBasedDirective _directive;
 
-  _DependencyUse(UriBasedDirective directive, this._file, this._contents)
-      : _parsedUri = Uri.parse(directive.uri.stringValue),
-        _directive = directive;
+  _Usage(this._file, this._contents, this._directive, this._uri);
 
-  bool get isPubPackage => _parsedUri.scheme == 'package';
+  /// Returns the package name if [isPackageUrl], otherwise `null`.
+  String get package => isPackageUrl ? _uri.pathSegments.first : null;
 
-  String get package => _parsedUri.pathSegments.first;
+  /// Returns whether the URI was parsable and correct in the directive.
+  bool get isUriValid => _uri != null && _uri.pathSegments.length >= 2;
 
-  String toErrorMessage() {
-    return new SourceFile(_contents, url: _file)
-        .span(_directive.offset, _directive.length)
-        .message(
-            '$_file imports $package, but this package doesn\'t depend '
-            'on $package');
+  /// Returns whether the directive references a pub package.
+  bool get isPackageUrl => _uri.scheme == 'package';
+
+  // Assumption is that normally all directives are valid and we won't see
+  // an error message - so a SourceFile is created lazily (on demand) to avoid
+  // parsing line endings in the case of only valid directives.
+  String _toMessage(String message) => new SourceFile(_contents, url: _file)
+      .span(_directive.offset, _directive.offset + _directive.length)
+      .message(message);
+
+  /// Returns an error message saying that the URI is invalid.
+  String uriInvalidMessage() {
+    assert(!isUriValid);
+    var uri = _directive.uri.stringValue;
+    return _toMessage('$_file references an invalid URI: $uri');
+  }
+
+  /// Returns an error message saying the package is not listed in dependencies.
+  String dependencyMissingMessage() {
+    return _toMessage(
+      '$_file imports $package, but this package doesn\'t depend on $package.'
+    );
+  }
+
+  /// Returns an error message saying the package should be in `dependencies`.
+  String dependencyMisplaceMessage() {
+    return _toMessage(
+      '$_file imports $package, but is only listed in `devDependencies`. Files '
+      'in the `lib` or `bin` folder must declare in `dependencies` - '
+      'devDependencies is only valid for files in `tool` or `test`.'
+    );
   }
 }

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -64,8 +64,11 @@ Descriptor appPubspec([Map dependencies]) {
 /// Describes a file named `pubspec.yaml` for a library package with the given
 /// [name], [version], and [deps]. If "sdk" is given, then it adds an SDK
 /// constraint on that version.
-Descriptor libPubspec(String name, String version, {Map deps, String sdk}) {
-  var map = packageMap(name, version, deps);
+Descriptor libPubspec(String name, String version, {
+    Map deps,
+    Map devDeps,
+    String sdk}) {
+  var map = packageMap(name, version, deps, devDeps);
   if (sdk != null) map["environment"] = {"sdk": sdk};
   return pubspec(map);
 }

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -599,7 +599,9 @@ void useMockClient(MockClient client) {
 
 /// Describes a map representing a library package with the given [name],
 /// [version], and [dependencies].
-Map packageMap(String name, String version, [Map dependencies]) {
+Map packageMap(String name, String version, [
+    Map dependencies,
+    Map devDependencies,]) {
   var package = <String, dynamic>{
     "name": name,
     "version": version,
@@ -609,7 +611,7 @@ Map packageMap(String name, String version, [Map dependencies]) {
   };
 
   if (dependencies != null) package["dependencies"] = dependencies;
-
+  if (devDependencies != null) package["dev_dependencies"] = devDependencies;
   return package;
 }
 

--- a/test/validator/strict_dependencies_test.dart
+++ b/test/validator/strict_dependencies_test.dart
@@ -22,26 +22,58 @@ main() {
 
     integration('looks normal', () => expectNoValidationError(strictDeps));
 
-    integration('declares an "import" as a dependency', () {
+    integration('declares an "import" as a dependency in lib/', () {
       d.dir(appPath, [
         d.libPubspec("test_pkg", "1.0.0", deps: {
           "silly_monkey": "^1.2.3"
         }, sdk: ">=1.8.0 <2.0.0"),
-        d.file(path.join('lib', 'library.dart'), r'''
-          import 'package:silly_monkey/silly_monkey.dart';
-        '''),
+        d.dir('lib', [
+          d.file('library.dart', r'''
+            import 'package:silly_monkey/silly_monkey.dart';
+          '''),
+        ]),
       ]).create();
       expectNoValidationError(strictDeps);
     });
 
-    integration('declares an "import" as a dev dependency', () {
+    integration('declares an "import" as a dependency in bin/', () {
+      d.dir(appPath, [
+        d.libPubspec("test_pkg", "1.0.0", deps: {
+          "silly_monkey": "^1.2.3"
+        }, sdk: ">=1.8.0 <2.0.0"),
+        d.dir('bin', [
+          d.file('library.dart', r'''
+            import 'package:silly_monkey/silly_monkey.dart';
+          '''),
+        ]),
+      ]).create();
+      expectNoValidationError(strictDeps);
+    });
+
+    integration('declares an "import" as a dev dependency in test/', () {
       d.dir(appPath, [
         d.libPubspec("test_pkg", "1.0.0", devDeps: {
           "silly_monkey": "^1.2.3"
         }, sdk: ">=1.8.0 <2.0.0"),
-        d.file(path.join('lib', 'library.dart'), r'''
-          import 'package:silly_monkey/silly_monkey.dart';
-        '''),
+        d.dir('test', [
+          d.file('library.dart', r'''
+            import 'package:silly_monkey/silly_monkey.dart';
+          '''),
+        ]),
+      ]).create();
+      expectNoValidationError(strictDeps);
+    });
+
+    integration('declares an "import" as a dev dependency in tool/', () {
+      d.dir(appPath, [
+        d.libPubspec("test_pkg", "1.0.0", devDeps: {
+          "silly_monkey": "^1.2.3"
+        }, sdk: ">=1.8.0 <2.0.0"),
+        d.dir('tool', [
+          d.file('library.dart', r'''
+            import 'package:silly_monkey/silly_monkey.dart';
+          '''),
+        ]),
       ]).create();
       expectNoValidationError(strictDeps);
     });
@@ -75,6 +107,15 @@ main() {
       ''').create();
       expectNoValidationError(strictDeps);
     });
+
+
+    integration('has a parse error preventing reading directives', () {
+      d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+        import not_supported_keyword 'dart:async';
+      ''').create();
+
+      expectNoValidationError(strictDeps);
+    });
   });
 
   group('should consider a package invalid if it', () {
@@ -88,19 +129,47 @@ main() {
       expectValidationWarning(strictDeps);
     });
 
-    integration('has a parse error preventing reading directives', () {
-      d.file(path.join(appPath, 'lib', 'library.dart'), r'''
-        import not_supported_keyword 'dart:async';
-      ''').create();
-
-      expectValidationWarning(strictDeps);
-    });
-
     integration('does not declare an "export" as a dependency', () {
       d.file(path.join(appPath, 'lib', 'library.dart'), r'''
         export 'package:silly_monkey/silly_monkey.dart';
       ''').create();
 
+      expectValidationWarning(strictDeps);
+    });
+
+    integration('has an invalid URI', () {
+      d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+        import 'package:/';
+      ''').create();
+
+      expectValidationWarning(strictDeps);
+    });
+
+    integration('declares an "import" as a devDependency for lib/', () {
+      d.dir(appPath, [
+        d.libPubspec("test_pkg", "1.0.0", devDeps: {
+          "silly_monkey": "^1.2.3"
+        }, sdk: ">=1.8.0 <2.0.0"),
+        d.dir('lib', [
+          d.file('library.dart', r'''
+            import 'package:silly_monkey/silly_monkey.dart';
+          '''),
+        ]),
+      ]).create();
+      expectValidationWarning(strictDeps);
+    });
+
+    integration('declares an "import" as a devDependency for bin/', () {
+      d.dir(appPath, [
+        d.libPubspec("test_pkg", "1.0.0", devDeps: {
+          "silly_monkey": "^1.2.3"
+        }, sdk: ">=1.8.0 <2.0.0"),
+        d.dir('bin', [
+          d.file('library.dart', r'''
+            import 'package:silly_monkey/silly_monkey.dart';
+          '''),
+        ]),
+      ]).create();
       expectValidationWarning(strictDeps);
     });
   });

--- a/test/validator/strict_dependencies_test.dart
+++ b/test/validator/strict_dependencies_test.dart
@@ -236,6 +236,17 @@ main() {
         ]).create();
         expectValidationWarning(strictDeps);
       });
+
+      integration('"package:/]"', () {
+        d.dir(appPath, [
+          d.dir('lib', [
+            d.file('library.dart', r'''
+            import 'package:/]';
+          '''),
+          ]),
+        ]).create();
+        expectValidationWarning(strictDeps);
+      });
     });
   });
 }

--- a/test/validator/strict_dependencies_test.dart
+++ b/test/validator/strict_dependencies_test.dart
@@ -12,9 +12,8 @@ import '../descriptor.dart' as d;
 import '../test_pub.dart';
 import 'utils.dart';
 
-Validator strictDeps(Entrypoint entrypoint) {
-  return new StrictDependenciesValidator(entrypoint);
-}
+Validator strictDeps(Entrypoint entrypoint) =>
+    new StrictDependenciesValidator(entrypoint);
 
 main() {
   group('should consider a package valid if it', () {
@@ -33,6 +32,7 @@ main() {
           '''),
         ]),
       ]).create();
+
       expectNoValidationError(strictDeps);
     });
 
@@ -47,6 +47,7 @@ main() {
           '''),
         ]),
       ]).create();
+
       expectNoValidationError(strictDeps);
     });
 
@@ -61,6 +62,7 @@ main() {
           '''),
         ]),
       ]).create();
+
       expectNoValidationError(strictDeps);
     });
 
@@ -75,6 +77,7 @@ main() {
           '''),
         ]),
       ]).create();
+
       expectNoValidationError(strictDeps);
     });
 
@@ -89,6 +92,7 @@ main() {
           '''),
         ]),
       ]).create();
+
       expectNoValidationError(strictDeps);
     });
 
@@ -98,6 +102,7 @@ main() {
         import 'dart:collection';
         import 'dart:typed_data';
       ''').create();
+
       expectNoValidationError(strictDeps);
     });
 
@@ -105,6 +110,7 @@ main() {
       d.file(path.join(appPath, 'lib', 'library.dart'), r'''
         import 'package:test_pkg/test_pkg.dart';
       ''').create();
+
       expectNoValidationError(strictDeps);
     });
 
@@ -112,6 +118,7 @@ main() {
       d.file(path.join(appPath, 'lib', 'library.dart'), r'''
         import 'some/relative/path.dart';
       ''').create();
+
       expectNoValidationError(strictDeps);
     });
 
@@ -119,6 +126,7 @@ main() {
       d.file(path.join(appPath, 'lib', 'library.dart'), r'''
         import 'file://shared/some/library.dart';
       ''').create();
+
       expectNoValidationError(strictDeps);
     });
 
@@ -127,6 +135,7 @@ main() {
       d.file(path.join(appPath, 'lib', 'library.dart'), r'''
         import not_supported_keyword 'dart:async';
       ''').create();
+
       expectNoValidationError(strictDeps);
     });
 
@@ -134,6 +143,7 @@ main() {
       d.file(path.join(appPath, 'top_level.dart'), r'''
         import 'package:';
       ''').create();
+
       expectNoValidationError(strictDeps);
     });
 
@@ -141,6 +151,7 @@ main() {
       d.file(path.join(appPath, 'lib', 'generator.dart.template'), r'''
         import 'package:';
       ''').create();
+
       expectNoValidationError(strictDeps);
     });
   });
@@ -183,6 +194,7 @@ main() {
           '''),
         ]),
       ]).create();
+
       expectValidationWarning(strictDeps);
     });
 
@@ -197,6 +209,7 @@ main() {
           '''),
         ]),
       ]).create();
+
       expectValidationWarning(strictDeps);
     });
 
@@ -209,6 +222,7 @@ main() {
           '''),
           ]),
         ]).create();
+
         expectValidationWarning(strictDeps);
       });
 
@@ -223,6 +237,7 @@ main() {
           '''),
           ]),
         ]).create();
+
         expectValidationWarning(strictDeps);
       });
 
@@ -234,6 +249,7 @@ main() {
           '''),
           ]),
         ]).create();
+
         expectValidationWarning(strictDeps);
       });
 
@@ -245,6 +261,7 @@ main() {
           '''),
           ]),
         ]).create();
+
         expectValidationWarning(strictDeps);
       });
     });

--- a/test/validator/strict_dependencies_test.dart
+++ b/test/validator/strict_dependencies_test.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:path/path.dart' as path;
+import 'package:pub/src/entrypoint.dart';
+import 'package:pub/src/validator.dart';
+import 'package:pub/src/validator/strict_dependencies.dart';
+import 'package:scheduled_test/scheduled_test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+import 'utils.dart';
+
+Validator strictDeps(Entrypoint entrypoint) {
+  return new StrictDependenciesValidator(entrypoint);
+}
+
+main() {
+  group('should consider a package valid if', () {
+    setUp(d.validPackage.create);
+
+    integration('looks normal', () => expectNoValidationError(strictDeps));
+
+    integration('declares an "import" as a dependency', () {
+      d.dir(appPath, [
+        d.libPubspec("test_pkg", "1.0.0", deps: {
+          "not_declared": "^1.2.3"
+        }, sdk: ">=1.8.0 <2.0.0")
+      ]).create();
+      d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+        import 'package:not_declared/not_declared.dart';
+      ''').create();
+      expectNoValidationError(strictDeps);
+    });
+  });
+
+  group('should consider a package invalid if', () {
+    setUp(d.validPackage.create);
+
+    integration('does not declare an "import" as a dependency', () {
+      d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+        import 'package:not_declared/not_declared.dart';
+      ''').create();
+
+      expectValidationWarning(strictDeps);
+    });
+  });
+}


### PR DESCRIPTION
First step of https://github.com/dart-lang/pub/issues/343.

Implemented `StrictDependenciesValidator`, which crawls all source files, finds all referenced `import` and `export` directives, and compares them against all declared `dependencies` and `dev_dependencies`.

IMO this should be an error, not a warning, but wanted input first to see if I've possibly missed legitimate use cases where people should be able to override and upload anyway. Should this also be added as a flag to `pub` to opt-in or just added by default? I didn't do anything but implement the validator yet.

~~Future work:~~

~~- [ ] Validate you haven't declared dependencies you don't use (?)~~
