### PR TITLE
Shield against global gitconfig in tests

### DIFF
--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -89,10 +89,8 @@ Descriptor gitPackageRevisionCacheDir(String name, [int modifier]) {
 /// Describes a directory for a Git package. This directory is of the form
 /// found in the repo cache of the global package cache.
 Descriptor gitPackageRepoCacheDir(String name) {
-  return pattern(
-      new RegExp("$name${r'-[a-f0-9]+'}"),
-      (dirName) => dir(
-          dirName, [dir('hooks'), dir('info'), dir('objects'), dir('refs')]));
+  return pattern(new RegExp("$name${r'-[a-f0-9]+'}"),
+      (dirName) => dir(dirName, [dir('objects'), dir('refs')]));
 }
 
 /// Describes the `packages/` directory containing all the given [packages],

--- a/test/descriptor/git.dart
+++ b/test/descriptor/git.dart
@@ -19,13 +19,14 @@ class GitRepoDescriptor extends DirectoryDescriptor {
         return super.create(parent).then((_) {
           return _runGitCommands(parent, [
             ['init'],
+            ['config', 'core.excludesfile', ''],
             ['add', '.'],
             ['commit', '-m', 'initial commit', '--allow-empty']
           ]);
         });
       }, 'creating Git repo:\n${describe()}');
 
-  /// Writes this descriptor to the filesystem, than commits any changes from
+  /// Writes this descriptor to the filesystem, then commits any changes from
   /// the previous structure to the Git repo.
   ///
   /// [parent] defaults to [defaultRoot].


### PR DESCRIPTION
Fixes #1535

The tests execute `git` in a number of places which is impacted by the
users global git config and can cause failure.

- Remove `info` and `hooks` from the list of required directories under
  `.git`. These are controlled by the `init.templatedir` config and are
  only the defaults but may not exist.
- For git repos created during the test configure `core.excludesfile` as
  empty since we rely on having full control over ignored files when we
  create `.gitignore` ourself.