### PR TITLE
Don't ignore test/build/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .idea
 .pub/
 .settings/
-build/
+/build/
 packages
 /.packages
 pubspec.lock


### PR DESCRIPTION
The current ignore is too broach and matches some of the tests. A
leading slash makes the ignore only match a build directory at the root
of the repo