### PR TITLE
Log HTTP response info at WARNING level for status codes >= 400

### DIFF
--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -194,7 +194,11 @@ class _PubHttpClient extends http.BaseClient {
     response.headers
         .forEach((name, value) => responseLog.writeln(_logField(name, value)));
 
-    log.fine(responseLog.toString().trim());
+    if (response.statusCode < 400) {
+      log.fine(responseLog.toString().trim());
+    } else {
+      log.warning(responseLog.toString().trim());
+    }
   }
 
   /// Returns a log-formatted string for the HTTP field or header with the given

--- a/test/get/hosted/get_test.dart
+++ b/test/get/hosted/get_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
@@ -53,5 +54,21 @@ main() {
 
     d.cacheDir({"foo": "1.2.3"}, port: server.port).validate();
     d.appPackagesFile({"foo": "1.2.3"}).validate();
+  });
+
+  group('HTTP response info is printed', () {
+    integration('silently on success', () {
+      servePackages((builder) => builder.serve("foo", "1.2.3"));
+
+      d.appDir({"foo": "1.2.3"}).create();
+
+      schedulePub(args: ["get"], silent: contains("HTTP response 200"));
+    });
+
+    integration('as a warning on error', () {
+      d.appDir({"foo": "1.2.3"}).create();
+
+      schedulePub(args: ["get"], error: contains("HTTP response 404"));
+    });
   });
 }


### PR DESCRIPTION
Addresses https://github.com/flutter/flutter/issues/9237
Easier than https://github.com/flutter/flutter/pull/9238