### PR TITLE
add Module/ModuleId/ModuleReader classes

### DIFF
--- a/lib/src/barback/dartdevc/module.dart
+++ b/lib/src/barback/dartdevc/module.dart
@@ -1,0 +1,61 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:barback/barback.dart';
+
+/// Serializable object that describes a single `module`.
+///
+/// A `module` is a set of dart [AssetId]s contained in the module and a list of
+/// other [AssetId]s which are direct dependencies.
+///
+/// Note that all [assetIds] must be in the same package, but
+/// [directDependencies] may be from any package.
+///
+/// Use a [ModuleReader#readTransitiveDeps] to get the transitive dependencies
+/// of a module.
+class Module {
+  final ModuleId id;
+  final Set<AssetId> assetIds;
+  final Set<AssetId> directDependencies;
+
+  Module(this.id, this.assetIds, this.directDependencies);
+  Module.fromJson(List<List<dynamic>> json)
+      : id = new ModuleId.fromJson(json[0]),
+        assetIds = new Set<AssetId>.from(
+            json[1].map((id) => new AssetId.deserialize(id))),
+        directDependencies = new Set<AssetId>.from(
+            json[2].map((d) => new AssetId.deserialize(d)));
+
+  List<List<dynamic>> toJson() => [
+        id.toJson(),
+        assetIds.map((id) => id.serialize()).toList(),
+        directDependencies.map((d) => d.serialize()).toList(),
+      ];
+}
+
+/// Serializable identifier of a [Module].
+///
+/// A [Module] can only be a part of a single package, and must have a unique
+/// name within that package.
+class ModuleId {
+  final String package;
+  final String name;
+
+  const ModuleId(this.package, this.name);
+  ModuleId.fromJson(List<String> json)
+      : package = json[0],
+        name = json[1];
+
+  List<String> toJson() => <String>[package, name];
+
+  @override
+  String toString() => 'ModuleId: $package|$name';
+
+  @override
+  bool operator ==(other) =>
+      other is ModuleId && other.package == package && other.name == this.name;
+
+  @override
+  int get hashCode => '$package|$name'.hashCode;
+}

--- a/lib/src/barback/dartdevc/module.dart
+++ b/lib/src/barback/dartdevc/module.dart
@@ -20,6 +20,12 @@ class Module {
   final Set<AssetId> directDependencies;
 
   Module(this.id, this.assetIds, this.directDependencies);
+
+  /// Creates a [Module] from [json] which should be a [List] that was created
+  /// with [toJson].
+  ///
+  /// It should contain exactly 3 entries, representing the [id], [assetIds],
+  /// and [directDependencies] fields in that order.
   Module.fromJson(List<List<dynamic>> json)
       : id = new ModuleId.fromJson(json[0]),
         assetIds = new Set<AssetId>.from(
@@ -27,6 +33,11 @@ class Module {
         directDependencies = new Set<AssetId>.from(
             json[2].map((d) => new AssetId.deserialize(d)));
 
+  /// Serialize this [Module] to a nested [List] which can be encoded with
+  /// `JSON.encode` and then decoded later with `JSON.decode`.
+  ///
+  /// The resulting [List] will have 3 values, representing the [id],
+  /// [assetIds], and [directDependencies] fields in that order.
   List<List<dynamic>> toJson() => [
         id.toJson(),
         assetIds.map((id) => id.serialize()).toList(),
@@ -43,10 +54,21 @@ class ModuleId {
   final String name;
 
   const ModuleId(this.package, this.name);
+
+  /// Creates a [ModuleId] from [json] which should be a [List] that was created
+  /// with [toJson].
+  ///
+  /// It should contain exactly 2 entries, representing the [package] and [name]
+  /// fields in that order.
   ModuleId.fromJson(List<String> json)
       : package = json[0],
         name = json[1];
 
+  /// Serialize this [ModuleId] to a nested [List] which can be encoded with
+  /// `JSON.encode` and then decoded later with `JSON.decode`.
+  ///
+  /// The resulting [List] will have 2 values, representing the [package] and
+  /// [name] fields in that order.
   List<String> toJson() => <String>[package, name];
 
   @override
@@ -57,5 +79,5 @@ class ModuleId {
       other is ModuleId && other.package == package && other.name == this.name;
 
   @override
-  int get hashCode => '$package|$name'.hashCode;
+  int get hashCode => package.hashCode ^ name.hashCode;
 }

--- a/lib/src/barback/dartdevc/module_reader.dart
+++ b/lib/src/barback/dartdevc/module_reader.dart
@@ -1,0 +1,92 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:barback/barback.dart';
+import 'package:path/path.dart' as p;
+
+import 'module.dart';
+
+typedef FutureOr<String> ReadAsString(AssetId id);
+
+/// The name of the module config files.
+const moduleConfigName = '.moduleConfig';
+
+/// Reads and caches [Module]s, and allows you to get transitive dependencies.
+class ModuleReader {
+  final ReadAsString assetReader;
+
+  final _modulesByAssetId = <AssetId, Module>{};
+
+  final _modulesByModuleId = <ModuleId, Module>{};
+
+  final _moduleConfigFutures = <AssetId, Future<List<Module>>>{};
+
+  ModuleReader(this.assetReader);
+
+  /// Returns a [Future<Module>] containing [id].
+  ///
+  /// Module configs are expected to live under the same top level directory of
+  /// the package as [id].
+  Future<Module> moduleFor(AssetId id) async {
+    var parts = p.split(p.dirname(id.path));
+    if (parts.length == 0) {
+      throw new ArgumentError("Unexpected asset `$id` which isn't under a top "
+          "level directory of its package.");
+    }
+    var moduleConfigId =
+        new AssetId(id.package, p.join(parts.first, moduleConfigName));
+    await readModules(moduleConfigId);
+    return _modulesByAssetId[id];
+  }
+
+  /// Computes the transitive deps of [id] by reading all the modules for all
+  /// its dependencies recursively.
+  ///
+  /// Assumes that any dependencies modules are either already loaded or exist
+  /// in the default module config file for their package.
+  Future<Set<ModuleId>> readTransitiveDeps(Module module) async {
+    var allModuleDepIds = new Set<ModuleId>();
+    Future updateDeps(Iterable<AssetId> assetDepIds) async {
+      for (var assetDepId in assetDepIds) {
+        var assetDepModule = await moduleFor(assetDepId);
+        if (!allModuleDepIds.add(assetDepModule.id)) continue;
+        await updateDeps(assetDepModule.directDependencies);
+      }
+    }
+
+    await updateDeps(module.directDependencies);
+    return allModuleDepIds;
+  }
+
+  /// Loads all [Module]s in [moduleConfigId] if they are not already loaded.
+  ///
+  /// Populates [_modules] and [_modulesByAssetId] for each loaded [Module].
+  ///
+  /// Returns a [Future<List<Module>>] representing all modules contained in
+  /// [moduleConfigId].
+  Future<List<Module>> readModules(AssetId moduleConfigId) {
+    return _moduleConfigFutures.putIfAbsent(moduleConfigId, () async {
+      var modules = <Module>[];
+      var content = await assetReader(moduleConfigId);
+      var serializedModules = JSON.decode(content) as List<List<List<dynamic>>>;
+      for (var serializedModule in serializedModules) {
+        var module = new Module.fromJson(serializedModule);
+        modules.add(module);
+        _modulesByModuleId[module.id] = module;
+        for (var id in module.assetIds) {
+          if (_modulesByAssetId.containsKey(id)) {
+            throw new StateError('Assets can only exist in one module, but $id'
+                'was found in both ${_modulesByAssetId[id].id} and '
+                '${module.id}');
+          }
+          _modulesByAssetId[id] = module;
+        }
+      }
+      return modules;
+    });
+  }
+}

--- a/test/barback/dartdevc/module_test.dart
+++ b/test/barback/dartdevc/module_test.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'package:pub/src/barback/dartdevc/module.dart';
+
+import 'util.dart';
+
+void main() {
+  group('ModuleId', () {
+    test('can go to and from json', () {
+      var id = makeModuleId();
+      var newId = new ModuleId.fromJson(JSON.decode(JSON.encode(id)));
+      expect(newId, equals(id));
+      expect(newId.hashCode, equals(id.hashCode));
+    });
+  });
+
+  group('Module', () {
+    test('can go to and from json', () {
+      var module = makeModule();
+      var newModule = new Module.fromJson(JSON.decode(JSON.encode(module)));
+      expectModulesEqual(module, newModule);
+    });
+
+    test('can be serialized in a list', () {
+      var modules = makeModules();
+      var serialized = JSON.encode(modules);
+      var newModules =
+          JSON.decode(serialized).map((s) => new Module.fromJson(s)).toList();
+      expect(modules.length, equals(newModules.length));
+      for (int i = 0; i < modules.length; i++) {
+        expectModulesEqual(modules[i], newModules[i]);
+      }
+    });
+  });
+}

--- a/test/barback/dartdevc/util.dart
+++ b/test/barback/dartdevc/util.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:barback/barback.dart';
+import 'package:test/test.dart';
+
+import 'package:pub/src/barback/dartdevc/module.dart';
+
+// Keep incrementing ids so we don't accidentally create duplicates.
+int _next = 0;
+
+AssetId makeAssetId({String package, String topLevelDir}) {
+  _next++;
+  package ??= 'pkg_$_next';
+  topLevelDir ??= 'lib';
+  return new AssetId(package, '$topLevelDir/$_next.dart');
+}
+
+Set<AssetId> makeAssetIds({String package, String topLevelDir}) =>
+    new Set<AssetId>.from(new List.generate(
+        10, (_) => makeAssetId(package: package, topLevelDir: topLevelDir)));
+
+ModuleId makeModuleId({String package}) {
+  _next++;
+  package ??= 'pkg_$_next';
+  return new ModuleId(package, 'name_$_next');
+}
+
+Set<ModuleId> makeModuleIds({String package}) => new Set<ModuleId>.from(
+    new List.generate(10, (_) => makeModuleId(package: package)));
+
+Module makeModule(
+    {String package, Set<AssetId> directDependencies, String topLevelDir}) {
+  var id = makeModuleId(package: package);
+  var assetIds = makeAssetIds(package: id.package, topLevelDir: topLevelDir);
+  directDependencies ??= new Set<AssetId>();
+  return new Module(id, assetIds, directDependencies);
+}
+
+List<Module> makeModules({String package}) =>
+    new List.generate(10, (_) => makeModule(package: package));
+
+void expectModulesEqual(Module expected, Module actual) {
+  expect(expected.id, equals(actual.id));
+  expect(expected.assetIds, equals(actual.assetIds));
+  expect(expected.directDependencies, equals(actual.directDependencies));
+}


### PR DESCRIPTION
These provide the building blocks for storing information about modules that are created by a package.

The idea is that each top level folder under a package will have a single `.moduleConfig` file that describes all the modules under that folder. Modules will not be allowed to cross over top level folders or packages.