### PR TITLE
only support listing the lib dir for cached packages

### DIFF
--- a/lib/src/cached_package.dart
+++ b/lib/src/cached_package.dart
@@ -54,16 +54,13 @@ class CachedPackage extends Package {
   /// is within a cached directory, but not otherwise.
   List<String> listFiles(
       {String beneath, recursive: true, bool useGitIgnore: false}) {
-    if (beneath == null) {
-      return super.listFiles(recursive: recursive, useGitIgnore: useGitIgnore);
+    if (beneath == null || !_pathInCache(beneath)) {
+      throw new UnsupportedError(
+          'Cached packages can only list their `lib` dir.');
     }
 
-    if (_pathInCache(beneath)) {
-      return listDir(p.join(_cacheDir, beneath),
-          includeDirs: false, recursive: recursive);
-    }
-    return super.listFiles(
-        beneath: beneath, recursive: recursive, useGitIgnore: useGitIgnore);
+    return listDir(p.join(_cacheDir, beneath),
+        includeDirs: false, recursive: recursive);
   }
 
   /// Returns whether [relativePath], a path relative to the package's root,


### PR DESCRIPTION
`CachedPackage` previously would fall back on serving from the original hosted package cache if you request files outside of lib, but that gives the untransformed sources which I don't think is ever correct to do.

This makes it an error to request anything outside of `lib` from a `CachedPackage`. As far as I know this should be fine (and the existing tests do pass), since the only package you should request files outside of lib from is the root package, and that package is never cached since it is always a path dependency?

Let me know if you think there is a use case this would break, merging this isn't super urgent so I will wait for @nex3 to comment.