### PR TITLE
Move shared code into shared libraries, clean up args.

### DIFF
--- a/lib/src/barback/dartdevc/dartdevc.dart
+++ b/lib/src/barback/dartdevc/dartdevc.dart
@@ -1,0 +1,225 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:barback/barback.dart';
+import 'package:bazel_worker/bazel_worker.dart';
+import 'package:cli_util/cli_util.dart' as cli_util;
+import 'package:path/path.dart' as p;
+
+import '../../io.dart';
+import 'module.dart';
+import 'module_reader.dart';
+import 'scratch_space.dart';
+import 'summaries.dart';
+import 'workers.dart';
+
+/// Bootstraps the js module for the entrypoint dart file [dartEntrypointId]
+/// with two additional JS files:
+///
+/// * A `$dartEntrypointId.js` file which is the main entrypoint for the app. It
+///   injects a script tag whose src is `require.js` and whose `data-main`
+///   attribute points at a `$dartEntrypointId.bootstrap.js` file.
+/// * A `$dartEntrypointId.bootstrap.js` file which invokes the top level `main`
+///   function from the entrypoint module, after performing some necessary SDK
+///   setup.
+///
+/// In debug mode an empty sourcemap will be output for the entrypoint js file
+/// to satisfy the test package runner (there is no original dart file to map it
+/// back to though).
+///
+/// Synchronously returns a `Map<AssetId, Future<Asset>>` so that you can know
+/// immediately what assets will be output.
+Map<AssetId, Future<Asset>> bootstrapDartDevcEntrypoint(
+    AssetId dartEntrypointId, BarbackMode mode, ModuleReader moduleReader) {
+  var bootstrapId = dartEntrypointId.addExtension('.bootstrap.js');
+  var jsEntrypointId = dartEntrypointId.addExtension('.js');
+  var jsMapEntrypointId = jsEntrypointId.addExtension('.js.map');
+
+  var outputCompleters = <AssetId, Completer<Asset>>{
+    bootstrapId: new Completer<Asset>(),
+    jsEntrypointId: new Completer<Asset>(),
+  };
+  if (mode == BarbackMode.DEBUG) {
+    outputCompleters[jsMapEntrypointId] = new Completer<Asset>();
+  }
+
+  () async {
+    var module = await moduleReader.moduleFor(dartEntrypointId);
+
+    // The path to the entrypoint js module as it should appear in the call to
+    // `require` in the bootstrap file.
+    var moduleDir = topLevelDir(dartEntrypointId.path);
+    var appModulePath = p.relative(p.join(moduleDir, module.id.name),
+        from: p.dirname(dartEntrypointId.path));
+
+    // The name of the entrypoint dart library within the entrypoint js module.
+    //
+    // This is used to invoke `main()` from within the bootstrap script.
+    //
+    // TODO(jakemac53): Sane module name creation, this only works in the most
+    // basic of cases.
+    //
+    // See https://github.com/dart-lang/sdk/issues/27262 for the root issue which
+    // will allow us to not rely on the naming schemes that dartdevc uses
+    // internally, but instead specify our own.
+    var appModuleScope = p.url
+        .split(p.withoutExtension(
+            p.relative(dartEntrypointId.path, from: moduleDir)))
+        .join("__")
+        .replaceAll('.', '\$46');
+    var bootstrapContent = '''
+require(["$appModulePath", "dart_sdk"], function(app, dart_sdk) {
+  dart_sdk._isolate_helper.startRootIsolate(() => {}, []);
+  app.$appModuleScope.main();
+});
+''';
+    outputCompleters[bootstrapId]
+        .complete(new Asset.fromString(bootstrapId, bootstrapContent));
+
+    var bootstrapModuleName = p.withoutExtension(
+        p.relative(bootstrapId.path, from: p.dirname(dartEntrypointId.path)));
+    var entrypointJsContent = '''
+var el = document.createElement("script");
+el.defer = true;
+el.async = false;
+el.src = "require.js";
+el.setAttribute("data-main", "$bootstrapModuleName");
+document.head.appendChild(el);
+''';
+    outputCompleters[jsEntrypointId]
+        .complete(new Asset.fromString(jsEntrypointId, entrypointJsContent));
+
+    if (mode == BarbackMode.DEBUG) {
+      outputCompleters[jsMapEntrypointId].complete(new Asset.fromString(
+          jsMapEntrypointId,
+          '{"version":3,"sourceRoot":"","sources":[],"names":[],"mappings":"",'
+          '"file":""}'));
+    }
+  }();
+
+  var outputFutures = <AssetId, Future<Asset>>{};
+  outputCompleters.forEach((k, v) => outputFutures[k] = v.future);
+  return outputFutures;
+}
+
+/// Compiles [module] using the `dartdevc` binary from the SDK to a relative
+/// path under the package that looks like `$outputDir/${module.id.name}.js`.
+///
+/// Synchronously returns a `Map<AssetId, Future<Asset>>` so that you can know
+/// immediately what assets will be output.
+Map<AssetId, Future<Asset>> createDartdevcModule(
+    Module module,
+    ScratchSpace scratchSpace,
+    Set<AssetId> linkedSummaryIds,
+    Map<String, String> environmentConstants,
+    BarbackMode mode,
+    logError(String message)) {
+  var outputCompleters = <AssetId, Completer<Asset>>{
+    module.id.jsId: new Completer<Asset>(),
+    module.id.jsSourceMapId: new Completer<Asset>(),
+  };
+
+  () async {
+    var jsOutputFile = scratchSpace.fileFor(module.id.jsId);
+    var sdk_summary = p.url.join(sdkDir.path, 'lib/_internal/ddc_sdk.sum');
+    var request = new WorkRequest();
+    request.arguments.addAll([
+      '--dart-sdk-summary=$sdk_summary',
+      // TODO(jakemac53): Remove when no longer needed,
+      // https://github.com/dart-lang/pub/issues/1583.
+      '--unsafe-angular2-whitelist',
+      '--modules=amd',
+      '--dart-sdk=${sdkDir.path}',
+      '--module-root=${scratchSpace.tempDir.path}',
+      '--library-root=${p.dirname(jsOutputFile.path)}',
+      '--summary-extension=${linkedSummaryExtension.substring(1)}',
+      '--no-summarize',
+      '-o',
+      jsOutputFile.path,
+    ]);
+
+    if (mode == BarbackMode.RELEASE) {
+      request.arguments.add('--no-source-map');
+    }
+
+    // Add environment constants.
+    environmentConstants.forEach((key, value) {
+      request.arguments.add('-D$key=$value');
+    });
+
+    // Add all the linked summaries as summary inputs.
+    for (var id in linkedSummaryIds) {
+      request.arguments.addAll(['-s', scratchSpace.fileFor(id).path]);
+    }
+
+    // Add URL mappings for all the package: files to tell DartDevc where to find
+    // them.
+    for (var id in module.assetIds) {
+      var uri = canonicalUriFor(id);
+      if (uri.startsWith('package:')) {
+        request.arguments
+            .add('--url-mapping=$uri,${scratchSpace.fileFor(id).path}');
+      }
+    }
+    // And finally add all the urls to compile, using the package: path for files
+    // under lib and the full absolute path for other files.
+    request.arguments.addAll(module.assetIds.map((id) {
+      var uri = canonicalUriFor(id);
+      if (uri.startsWith('package:')) {
+        return uri;
+      }
+      return scratchSpace.fileFor(id).path;
+    }));
+
+    var response = await dartdevcDriver.doWork(request);
+
+    // TODO(jakemac53): Fix the ddc worker mode so it always sends back a bad
+    // status code if something failed. Today we just make sure there is an output
+    // js file to verify it was successful.
+    if (response.exitCode != EXIT_CODE_OK || !jsOutputFile.existsSync()) {
+      logError(
+          'Error compiling dartdevc module: ${module.id}.\n${response.output}');
+    } else {
+      outputCompleters[module.id.jsId].complete(
+          new Asset.fromBytes(module.id.jsId, jsOutputFile.readAsBytesSync()));
+      if (mode == BarbackMode.DEBUG) {
+        var sourceMapFile = scratchSpace.fileFor(module.id.jsSourceMapId);
+        outputCompleters[module.id.jsSourceMapId].complete(new Asset.fromBytes(
+            module.id.jsSourceMapId, sourceMapFile.readAsBytesSync()));
+      }
+    }
+  }();
+
+  var outputFutures = <AssetId, Future<Asset>>{};
+  outputCompleters.forEach((k, v) => outputFutures[k] = v.future);
+  return outputFutures;
+}
+
+/// Copies the `dart_sdk.js` and `require.js` AMD files from the SDK into
+/// [outputDir].
+///
+/// Returns a `Map<AssetId, Asset>` of the created assets.
+Map<AssetId, Asset> copyDartDevcResources(String package, String outputDir) {
+  var sdk = cli_util.getSdkDir();
+  var outputs = <AssetId, Asset>{};
+
+  // Copy the dart_sdk.js file for AMD into the output folder.
+  var sdkJsOutputId =
+      new AssetId(package, p.url.join(outputDir, 'dart_sdk.js'));
+  var sdkAmdJsPath = p.url.join(sdk.path, 'lib/dev_compiler/amd/dart_sdk.js');
+  outputs[sdkJsOutputId] =
+      new Asset.fromFile(sdkJsOutputId, new File(sdkAmdJsPath));
+
+  // Copy the require.js file for AMD into the output folder.
+  var requireJsPath = p.url.join(sdk.path, 'lib/dev_compiler/amd/require.js');
+  var requireJsOutputId =
+      new AssetId(package, p.url.join(outputDir, 'require.js'));
+  outputs[requireJsOutputId] =
+      new Asset.fromFile(requireJsOutputId, new File(requireJsPath));
+
+  return outputs;
+}

--- a/lib/src/barback/dartdevc/dartdevc.dart
+++ b/lib/src/barback/dartdevc/dartdevc.dart
@@ -17,7 +17,7 @@ import 'scratch_space.dart';
 import 'summaries.dart';
 import 'workers.dart';
 
-/// Bootstraps the js module for the entrypoint dart file [dartEntrypointId]
+/// Bootstraps the JS module for the entrypoint dart file [dartEntrypointId]
 /// with two additional JS files:
 ///
 /// * A `$dartEntrypointId.js` file which is the main entrypoint for the app. It
@@ -27,7 +27,7 @@ import 'workers.dart';
 ///   function from the entrypoint module, after performing some necessary SDK
 ///   setup.
 ///
-/// In debug mode an empty sourcemap will be output for the entrypoint js file
+/// In debug mode an empty sourcemap will be output for the entrypoint JS file
 /// to satisfy the test package runner (there is no original dart file to map it
 /// back to though).
 ///
@@ -40,8 +40,8 @@ Map<AssetId, Future<Asset>> bootstrapDartDevcEntrypoint(
   var jsMapEntrypointId = jsEntrypointId.addExtension('.map');
 
   var outputCompleters = <AssetId, Completer<Asset>>{
-    bootstrapId: new Completer<Asset>(),
-    jsEntrypointId: new Completer<Asset>(),
+    bootstrapId: new Completer(),
+    jsEntrypointId: new Completer(),
   };
   if (mode == BarbackMode.DEBUG) {
     outputCompleters[jsMapEntrypointId] = new Completer<Asset>();
@@ -50,13 +50,13 @@ Map<AssetId, Future<Asset>> bootstrapDartDevcEntrypoint(
   () async {
     var module = await moduleReader.moduleFor(dartEntrypointId);
 
-    // The path to the entrypoint js module as it should appear in the call to
+    // The path to the entrypoint JS module as it should appear in the call to
     // `require` in the bootstrap file.
     var moduleDir = topLevelDir(dartEntrypointId.path);
-    var appModulePath = p.relative(p.join(moduleDir, module.id.name),
-        from: p.dirname(dartEntrypointId.path));
+    var appModulePath = p.url.relative(p.url.join(moduleDir, module.id.name),
+        from: p.url.dirname(dartEntrypointId.path));
 
-    // The name of the entrypoint dart library within the entrypoint js module.
+    // The name of the entrypoint dart library within the entrypoint JS module.
     //
     // This is used to invoke `main()` from within the bootstrap script.
     //
@@ -67,8 +67,8 @@ Map<AssetId, Future<Asset>> bootstrapDartDevcEntrypoint(
     // will allow us to not rely on the naming schemes that dartdevc uses
     // internally, but instead specify our own.
     var appModuleScope = p.url
-        .split(p.withoutExtension(
-            p.relative(dartEntrypointId.path, from: moduleDir)))
+        .split(p.url.withoutExtension(
+            p.url.relative(dartEntrypointId.path, from: moduleDir)))
         .join("__")
         .replaceAll('.', '\$46');
     var bootstrapContent = '''
@@ -119,10 +119,10 @@ Map<AssetId, Future<Asset>> createDartdevcModule(
     BarbackMode mode,
     logError(String message)) {
   var outputCompleters = <AssetId, Completer<Asset>>{
-    module.id.jsId: new Completer<Asset>(),
+    module.id.jsId: new Completer(),
   };
   if (mode == BarbackMode.DEBUG) {
-    outputCompleters[module.id.jsSourceMapId] = new Completer<Asset>();
+    outputCompleters[module.id.jsSourceMapId] = new Completer();
   }
 
   () async {
@@ -181,7 +181,7 @@ Map<AssetId, Future<Asset>> createDartdevcModule(
 
     // TODO(jakemac53): Fix the ddc worker mode so it always sends back a bad
     // status code if something failed. Today we just make sure there is an output
-    // js file to verify it was successful.
+    // JS file to verify it was successful.
     if (response.exitCode != EXIT_CODE_OK || !jsOutputFile.existsSync()) {
       var message =
           'Error compiling dartdevc module: ${module.id}.\n${response.output}';

--- a/lib/src/barback/dartdevc/dartdevc_bootstrap_transformer.dart
+++ b/lib/src/barback/dartdevc/dartdevc_bootstrap_transformer.dart
@@ -6,10 +6,10 @@ import 'dart:async';
 
 import 'package:analyzer/analyzer.dart';
 import 'package:barback/barback.dart';
-import 'package:path/path.dart' as p;
 
 import '../../dart.dart';
 import '../../io.dart';
+import 'dartdevc.dart';
 import 'module_reader.dart';
 
 class DartDevcBootstrapTransformer extends Transformer {
@@ -31,71 +31,9 @@ class DartDevcBootstrapTransformer extends Transformer {
     var parsed =
         parseCompilationUnit(await transform.primaryInput.readAsString());
     if (!isEntrypoint(parsed)) return;
-    await _bootstrapEntrypoint(transform.primaryInput.id, mode, transform);
-  }
-}
-
-/// Bootstraps the js module for the entrypoint dart file [dartEntrypointId]
-/// with two additional JS files:
-///
-/// * A `$dartEntrypointId.js` file which is the main entrypoint for the app. It
-///   injects a script tag whose src is `require.js` and whose `data-main`
-///   attribute points at a `$dartEntrypointId.bootstrap.js` file.
-/// * A `$dartEntrypointId.bootstrap.js` file which invokes the top level `main`
-///   function from the entrypoint module, after performing some necessary SDK
-///   setup.
-Future _bootstrapEntrypoint(
-    AssetId dartEntrypointId, BarbackMode mode, Transform transform) async {
-  var moduleReader = new ModuleReader(transform.readInputAsString);
-  var module = await moduleReader.moduleFor(dartEntrypointId);
-
-  // The path to the entrypoint js module as it should appear in the call to
-  // `require` in the bootstrap file.
-  var moduleDir = topLevelDir(dartEntrypointId.path);
-  var appModulePath = p.relative(p.join(moduleDir, module.id.name),
-      from: p.dirname(dartEntrypointId.path));
-
-  // The name of the entrypoint dart library within the entrypoint js module.
-  //
-  // This is used to invoke `main()` from within the bootstrap script.
-  //
-  // TODO(jakemac53): Sane module name creation, this only works in the most
-  // basic of cases.
-  //
-  // See https://github.com/dart-lang/sdk/issues/27262 for the root issue which
-  // will allow us to not rely on the naming schemes that dartdevc uses
-  // internally, but instead specify our own.
-  var appModuleScope = p.url
-      .split(p
-          .withoutExtension(p.relative(dartEntrypointId.path, from: moduleDir)))
-      .join("__")
-      .replaceAll('.', '\$46');
-  var bootstrapContent = '''
-require(["$appModulePath", "dart_sdk"], function(app, dart_sdk) {
-  dart_sdk._isolate_helper.startRootIsolate(() => {}, []);
-  app.$appModuleScope.main();
-});
-''';
-  var bootstrapId = dartEntrypointId.addExtension('.bootstrap.js');
-  transform.addOutput(new Asset.fromString(bootstrapId, bootstrapContent));
-
-  var bootstrapModuleName = p.withoutExtension(
-      p.relative(bootstrapId.path, from: p.dirname(dartEntrypointId.path)));
-  var entrypointJsContent = '''
-var el = document.createElement("script");
-el.defer = true;
-el.async = false;
-el.src = "require.js";
-el.setAttribute("data-main", "$bootstrapModuleName");
-document.head.appendChild(el);
-''';
-  transform.addOutput(new Asset.fromString(
-      dartEntrypointId.addExtension('.js'), entrypointJsContent));
-
-  if (mode == BarbackMode.DEBUG) {
-    transform.addOutput(new Asset.fromString(
-        dartEntrypointId.addExtension('.js.map'),
-        '{"version":3,"sourceRoot":"","sources":[],"names":[],"mappings":"",'
-        '"file":""}'));
+    var outputs = await bootstrapDartDevcEntrypoint(transform.primaryInput.id,
+        mode, new ModuleReader(transform.readInputAsString));
+    await Future.wait(outputs.values
+        .map((futureAsset) async => transform.addOutput(await futureAsset)));
   }
 }

--- a/lib/src/barback/dartdevc/dartdevc_resource_transformer.dart
+++ b/lib/src/barback/dartdevc/dartdevc_resource_transformer.dart
@@ -3,15 +3,14 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:analyzer/analyzer.dart';
 import 'package:barback/barback.dart';
-import 'package:cli_util/cli_util.dart' as cli_util;
 import 'package:path/path.dart' as p;
 
 import '../../dart.dart';
 import '../../io.dart';
+import 'dartdevc.dart';
 
 /// Copies the `dart_sdk.js` and `require.js` AMD files from the SDK into each
 /// entrypoint dir.
@@ -39,21 +38,8 @@ class DartDevcResourceTransformer extends AggregateTransformer
     }
     if (!hasEntrypoint) return;
 
-    var sdk = cli_util.getSdkDir();
-
-    // Copy the dart_sdk.js file for AMD into the output folder.
-    var sdkJsOutputId = new AssetId(
-        transform.package, p.url.join(transform.key, 'dart_sdk.js'));
-    var sdkAmdJsPath = p.url.join(sdk.path, 'lib/dev_compiler/amd/dart_sdk.js');
-    transform
-        .addOutput(new Asset.fromFile(sdkJsOutputId, new File(sdkAmdJsPath)));
-
-    // Copy the require.js file for AMD into the output folder.
-    var requireJsOutputId =
-        new AssetId(transform.package, p.url.join(transform.key, 'require.js'));
-    var requireJsPath = p.url.join(sdk.path, 'lib/dev_compiler/amd/require.js');
-    transform.addOutput(
-        new Asset.fromFile(requireJsOutputId, new File(requireJsPath)));
+    var outputs = copyDartDevcResources(transform.package, transform.key);
+    outputs.values.forEach(transform.addOutput);
   }
 
   @override

--- a/lib/src/barback/dartdevc/module.dart
+++ b/lib/src/barback/dartdevc/module.dart
@@ -5,8 +5,7 @@
 import 'package:barback/barback.dart';
 import 'package:path/path.dart' as p;
 
-import 'linked_summary_transformer.dart';
-import 'unlinked_summary_transformer.dart';
+import 'summaries.dart';
 
 /// Serializable object that describes a single `module`.
 ///
@@ -73,6 +72,8 @@ class ModuleId {
       _moduleAssetWithExtension(linkedSummaryExtension);
 
   AssetId get jsId => _moduleAssetWithExtension('.js');
+
+  AssetId get jsSourceMapId => jsId.addExtension('.map');
 
   const ModuleId(this.package, this.name, this.dir);
 

--- a/lib/src/barback/dartdevc/summaries.dart
+++ b/lib/src/barback/dartdevc/summaries.dart
@@ -1,0 +1,115 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:barback/barback.dart';
+import 'package:bazel_worker/bazel_worker.dart';
+
+import 'module.dart';
+import 'scratch_space.dart';
+import 'workers.dart';
+
+final String linkedSummaryExtension = '.linked.sum';
+final String unlinkedSummaryExtension = '.unlinked.sum';
+
+/// Creates a linked summary for [module].
+///
+/// [unlinkedSummaryIds] should contain unlinked summaries for all transitive
+/// deps of [module], and [scratchSpace] must have those files available as well
+/// as the original Dart sources for this module.
+///
+/// Synchronously returns a `Map<AssetId, Future<Asset>>` so that you can know
+/// immediately what assets will be output.
+Map<AssetId, Future<Asset>> createLinkedSummaryForModule(
+    Module module,
+    Set<AssetId> unlinkedSummaryIds,
+    ScratchSpace scratchSpace,
+    logError(String message)) {
+  var outputCompleters = <AssetId, Completer<Asset>>{
+    module.id.linkedSummaryId: new Completer<Asset>(),
+  };
+
+  () async {
+    var summaryOutputFile = scratchSpace.fileFor(module.id.linkedSummaryId);
+    var request = new WorkRequest();
+    // TODO(jakemac53): Diet parsing results in erroneous errors in later steps,
+    // but ideally we would do that (pass '--build-summary-only-diet').
+    request.arguments.addAll([
+      '--build-summary-only',
+      '--build-summary-output=${summaryOutputFile.path}',
+      '--strong',
+    ]);
+    // Add all the unlinked summaries as build summary inputs.
+    request.arguments.addAll(unlinkedSummaryIds.map((id) =>
+        '--build-summary-unlinked-input=${scratchSpace.fileFor(id).path}'));
+    // Add all the files to include in the linked summary bundle.
+    request.arguments.addAll(module.assetIds.map((id) {
+      var uri = canonicalUriFor(id);
+      if (!uri.startsWith('package:')) {
+        uri = 'file://$uri';
+      }
+      return '$uri|${scratchSpace.fileFor(id).path}';
+    }));
+    var response = await analyzerDriver.doWork(request);
+    if (response.exitCode == EXIT_CODE_ERROR) {
+      logError('Error creating linked summaries for module: ${module.id}.\n'
+          '${response.output}');
+    } else {
+      outputCompleters[module.id.linkedSummaryId].complete(new Asset.fromBytes(
+          module.id.linkedSummaryId, summaryOutputFile.readAsBytesSync()));
+    }
+  }();
+
+  var outputFutures = <AssetId, Future<Asset>>{};
+  outputCompleters.forEach((k, v) => outputFutures[k] = v.future);
+  return outputFutures;
+}
+
+/// Creates an unlinked summary for [module].
+///
+/// [scratchSpace] must have the Dart sources for this module available.
+///
+/// Synchronously returns a `Map<AssetId, Future<Asset>>` so that you can know
+/// immediately what assets will be output.
+Map<AssetId, Future<Asset>> createUnlinkedSummaryForModule(
+    Module module, ScratchSpace scratchSpace, logError(String message)) {
+  var outputCompleters = <AssetId, Completer<Asset>>{
+    module.id.unlinkedSummaryId: new Completer<Asset>(),
+  };
+
+  () async {
+    var summaryOutputFile = scratchSpace.fileFor(module.id.unlinkedSummaryId);
+    var request = new WorkRequest();
+    // TODO(jakemac53): Diet parsing results in erroneous errors later on today,
+    // but ideally we would do that (pass '--build-summary-only-diet').
+    request.arguments.addAll([
+      '--build-summary-only',
+      '--build-summary-only-unlinked',
+      '--build-summary-output=${summaryOutputFile.path}',
+      '--strong',
+    ]);
+    // Add all the files to include in the unlinked summary bundle.
+    request.arguments.addAll(module.assetIds.map((id) {
+      var uri = canonicalUriFor(id);
+      if (!uri.startsWith('package:')) {
+        uri = 'file://$uri';
+      }
+      return '$uri|${scratchSpace.fileFor(id).path}';
+    }));
+    var response = await analyzerDriver.doWork(request);
+    if (response.exitCode == EXIT_CODE_ERROR) {
+      logError('Error creating unlinked summaries for module: ${module.id}.\n'
+          '${response.output}');
+    } else {
+      outputCompleters[module.id.unlinkedSummaryId].complete(
+          new Asset.fromBytes(module.id.unlinkedSummaryId,
+              summaryOutputFile.readAsBytesSync()));
+    }
+  }();
+
+  var outputFutures = <AssetId, Future<Asset>>{};
+  outputCompleters.forEach((k, v) => outputFutures[k] = v.future);
+  return outputFutures;
+}

--- a/lib/src/barback/dartdevc/summaries.dart
+++ b/lib/src/barback/dartdevc/summaries.dart
@@ -54,8 +54,13 @@ Map<AssetId, Future<Asset>> createLinkedSummaryForModule(
     }));
     var response = await analyzerDriver.doWork(request);
     if (response.exitCode == EXIT_CODE_ERROR) {
-      logError('Error creating linked summaries for module: ${module.id}.\n'
-          '${response.output}');
+      var message =
+          'Error creating linked summaries for module: ${module.id}.\n'
+          '${response.output}';
+      logError(message);
+      outputCompleters.values.forEach((completer) {
+        completer.completeError(message);
+      });
     } else {
       outputCompleters[module.id.linkedSummaryId].complete(new Asset.fromBytes(
           module.id.linkedSummaryId, summaryOutputFile.readAsBytesSync()));
@@ -100,8 +105,13 @@ Map<AssetId, Future<Asset>> createUnlinkedSummaryForModule(
     }));
     var response = await analyzerDriver.doWork(request);
     if (response.exitCode == EXIT_CODE_ERROR) {
-      logError('Error creating unlinked summaries for module: ${module.id}.\n'
-          '${response.output}');
+      var message =
+          'Error creating unlinked summaries for module: ${module.id}.\n'
+          '${response.output}';
+      logError(message);
+      outputCompleters.values.forEach((completer) {
+        completer.completeError(message);
+      });
     } else {
       outputCompleters[module.id.unlinkedSummaryId].complete(
           new Asset.fromBytes(module.id.unlinkedSummaryId,

--- a/test/barback/dartdevc/linked_summary_transformer_test.dart
+++ b/test/barback/dartdevc/linked_summary_transformer_test.dart
@@ -5,7 +5,7 @@
 import 'package:analyzer/src/summary/idl.dart';
 import 'package:scheduled_test/scheduled_test.dart';
 
-import 'package:pub/src/barback/dartdevc/linked_summary_transformer.dart';
+import 'package:pub/src/barback/dartdevc/summaries.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/barback/dartdevc/linked_summary_transformer_test.dart
+++ b/test/barback/dartdevc/linked_summary_transformer_test.dart
@@ -20,7 +20,7 @@ main() {
         d.file(
             "foo.dart",
             """
-  void foo() {};
+  void foo() {}
   """)
       ]),
     ]).create();

--- a/test/barback/dartdevc/module_config_transformer_test.dart
+++ b/test/barback/dartdevc/module_config_transformer_test.dart
@@ -21,7 +21,7 @@ main() {
         d.file(
             "foo.dart",
             """
-  void foo() {};
+  void foo() {}
   """)
       ]),
     ]).create();

--- a/test/barback/dartdevc/unlinked_summary_transformer_test.dart
+++ b/test/barback/dartdevc/unlinked_summary_transformer_test.dart
@@ -5,7 +5,7 @@
 import 'package:analyzer/src/summary/idl.dart';
 import 'package:scheduled_test/scheduled_test.dart';
 
-import 'package:pub/src/barback/dartdevc/unlinked_summary_transformer.dart';
+import 'package:pub/src/barback/dartdevc/summaries.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/barback/dartdevc/unlinked_summary_transformer_test.dart
+++ b/test/barback/dartdevc/unlinked_summary_transformer_test.dart
@@ -21,7 +21,7 @@ main() {
         d.file(
             "foo.dart",
             """
-  void foo() {};
+  void foo() {}
   """)
       ]),
     ]).create();


### PR DESCRIPTION
For the most part this is just moving code around, with some minor cleanup.

The apis no longer take a `Transform` for any of these methods so they are more general, and they all return either a `Map<AssetId, Future<Asset>>` or `Map<AssetId, Asset>` synchronously.