### PR TITLE
add an e2e_test for dartdevc

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,6 @@
+presets:
+  e2e:
+    paths: [test/e2e]
+    platforms:
+      - chrome
+    pub_serve: 8080

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,3 +43,7 @@ dev_dependencies:
 
 environment:
   sdk: ">=1.24.0-dev.2.0 <2.0.0"
+
+transformers:
+- test/pub_serve:
+    $include: test/e2e/**/*_test.dart

--- a/test/e2e/pub_run_test/hello.dart
+++ b/test/e2e/pub_run_test/hello.dart
@@ -1,0 +1,5 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+String get hello => 'Hello';

--- a/test/e2e/pub_run_test/pub_run_test_test.dart
+++ b/test/e2e/pub_run_test/pub_run_test_test.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+@TestOn('browser')
+import 'package:test/test.dart';
+
+import 'hello.dart';
+
+main() {
+  test('hello world', () {
+    expect(hello, equals('Hello'));
+  });
+}


### PR DESCRIPTION
To run this test you need to run `pub serve --compiler=dartdevc` and then `pub run test -P e2e`.

I couldn't come up with anything better right now in terms of validating the full end to end workflow for dartdevc. A simple web test like this validates that applications can actually run (with relative and package  imports), which has a lot of value.

The main issue with this test imo is it isn't very discoverable, we could add some sort of high level test.sh script or more ideally integrate with travis and make sure it runs there. However I was having issues getting travis running (lots of errors regarding tar it seemed like).