### PR TITLE
Improve/unify error handling, plumb through compilation errors to the browser console

### DIFF
--- a/lib/src/command/build.dart
+++ b/lib/src/command/build.dart
@@ -72,8 +72,8 @@ class BuildCommand extends BarbackCommand {
       var hasError = false;
 
       // Unified error handler for barback and dartdevc.
-      logError(error) {
-        log.error(log.red("Build error:\n$error"));
+      logError(error, {bool logToStdError = true}) {
+        if (logToStdError) log.error(log.red("Build error:\n$error"));
         hasError = true;
 
         if (log.json.enabled) {
@@ -110,8 +110,9 @@ class BuildCommand extends BarbackCommand {
       // rest once a build is complete.
       if (environment.dartDevcEnvironment != null) {
         await log.progress("Building dartdevc modules", () async {
-          assets.addAll(await environment.dartDevcEnvironment
-              .doFullBuild(assets, logError: logError));
+          assets.addAll(await environment.dartDevcEnvironment.doFullBuild(
+              assets,
+              logError: (e) => logError(e, logToStdError: false)));
         });
         await environment.dartDevcEnvironment.cleanUp();
       }

--- a/lib/src/dartdevc/dartdevc.dart
+++ b/lib/src/dartdevc/dartdevc.dart
@@ -123,10 +123,7 @@ Map<AssetId, Future<Asset>> bootstrapDartDevcEntrypoint(
     // Map from module name to module path.
     // Modules outside of the `packages` directory have different module path
     // and module names.
-    var modulePaths = {
-      appModulePath: appModulePath,
-      'dart_sdk': 'dart_sdk'
-    };
+    var modulePaths = {appModulePath: appModulePath, 'dart_sdk': 'dart_sdk'};
     var transitiveDeps = await moduleReader.readTransitiveDeps(module);
     for (var dep in transitiveDeps) {
       if (dep.dir != 'lib') {
@@ -190,7 +187,7 @@ for (let moduleName of Object.getOwnPropertyNames(modulePaths)) {
     var xhr = new XMLHttpRequest();
     xhr.onreadystatechange = function() {
       if (this.readyState == 4 && this.status == 200) {
-        console.log(this.responseText);
+        console.error(this.responseText);
       }
     };
     xhr.open("GET", e.originalError.srcElement.src + ".errors", true);

--- a/lib/src/dartdevc/dartdevc.dart
+++ b/lib/src/dartdevc/dartdevc.dart
@@ -179,7 +179,7 @@ for (let moduleName of Object.getOwnPropertyNames(modulePaths)) {
     }
 
     bootstrapContent.write('''
-// Whenever we fail to load a js module, try and request the corresponding
+// Whenever we fail to load a JS module, try to request the corresponding
 // `.errors` file, and log it to the console.
 (function() {
   var oldOnError = requirejs.onError;

--- a/lib/src/dartdevc/dartdevc_environment.dart
+++ b/lib/src/dartdevc/dartdevc_environment.dart
@@ -15,6 +15,7 @@ import '../io.dart';
 import '../log.dart' as log;
 import '../package_graph.dart';
 import 'dartdevc.dart';
+import 'errors.dart';
 import 'module.dart';
 import 'module_computer.dart';
 import 'module_reader.dart';
@@ -82,8 +83,7 @@ class DartDevcEnvironment {
         appDirs.add(p.url.dirname(asset.id.path));
         // Build the entrypoint JS files, and collect the set of transitive
         // modules that are required (will be built later).
-        var futureAssets =
-            _buildAsset(asset.id.addExtension('.js'), logError: logError);
+        var futureAssets = _buildAsset(asset.id.addExtension('.js'));
         var assets = await Future.wait(futureAssets.values);
         jsAssets.addAll(assets.where((asset) => asset != null));
         var module = await _moduleReader.moduleFor(asset.id);
@@ -94,10 +94,9 @@ class DartDevcEnvironment {
       // Build all required modules for the apps that were discovered.
       var allFutureAssets = <Future<Asset>>[];
       for (var module in modulesToBuild) {
-        allFutureAssets
-            .addAll(_buildAsset(module.jsId, logError: logError).values);
+        allFutureAssets.addAll(_buildAsset(module.jsId).values);
       }
-      // Copy all JS resoureces for each of the app dirs that were discovered.
+      // Copy all JS resources for each of the app dirs that were discovered.
       for (var dir in appDirs) {
         for (var name in _sdkResources.keys) {
           allFutureAssets.add(_buildJsResource(new AssetId(
@@ -142,24 +141,17 @@ class DartDevcEnvironment {
   /// Handles building all assets that we know how to build.
   ///
   /// Completes with an [AssetNotFoundException] if the asset couldn't be built.
-  Map<AssetId, Future<Asset>> _buildAsset(AssetId id,
-      {logError(String message)}) {
+  Map<AssetId, Future<Asset>> _buildAsset(AssetId id) {
     if (_assetCache.containsKey(id)) return {id: _assetCache[id]};
-    logError ??= (String message) => log.error(log.red(message));
     Map<AssetId, Future<Asset>> assets;
     if (id.path.endsWith(unlinkedSummaryExtension)) {
-      assets = {
-        id: createUnlinkedSummary(id, _moduleReader, _scratchSpace, logError)
-      };
+      assets = {id: createUnlinkedSummary(id, _moduleReader, _scratchSpace)};
     } else if (id.path.endsWith(linkedSummaryExtension)) {
-      assets = {
-        id: createLinkedSummary(id, _moduleReader, _scratchSpace, logError)
-      };
+      assets = {id: createLinkedSummary(id, _moduleReader, _scratchSpace)};
     } else if (_isEntrypointId(id)) {
       var dartId = _entrypointDartId(id);
       if (dartId != null) {
-        assets = bootstrapDartDevcEntrypoint(
-            dartId, _mode, _moduleReader, _barback.getAssetById);
+        assets = bootstrapDartDevcEntrypoint(dartId, _mode, _moduleReader);
       }
     } else if (_hasJsResource(id)) {
       assets = {id: _buildJsResource(id)};
@@ -168,21 +160,24 @@ class DartDevcEnvironment {
       assets = {id: new Future.error(new AssetNotFoundException(id))};
     } else if (id.path.endsWith('.js') || id.path.endsWith('.js.map')) {
       var jsId = id.extension == '.map' ? id.changeExtension('') : id;
-      assets = createDartdevcModule(jsId, _moduleReader, _scratchSpace,
-          _environmentConstants, _mode, logError);
+      assets = createDartdevcModule(
+          jsId, _moduleReader, _scratchSpace, _environmentConstants, _mode);
       // Pre-emptively start building all transitive JS deps under the
       // assumption they will be needed in the near future.
       () async {
         try {
           var module = await _moduleReader.moduleFor(jsId);
-          if (module == null) return;
           var deps = await _moduleReader.readTransitiveDeps(module);
           await Future
               .wait(deps.map((moduleId) => getAssetById(moduleId.jsId)));
-        } on AssetNotFoundException catch (_) {}
+        } catch (_) {
+          // Errors will be returned later when requests are made.
+        }
       }();
     } else if (id.path.endsWith(moduleConfigName)) {
       assets = {id: _buildModuleConfig(id)};
+    } else if (id.extension == '.errors') {
+      assets = {id: _cachedAsset(id)};
     }
     assets ??= <AssetId, Future<Asset>>{};
 
@@ -207,6 +202,15 @@ class DartDevcEnvironment {
     var modules = await computeModules(moduleMode, moduleAssets);
     var encoded = JSON.encode(modules);
     return new Asset.fromString(id, encoded);
+  }
+
+  /// Returns a cached asset for [id] if one exists, otherwise throws an
+  /// [AssetNotFoundException].
+  Future<Asset> _cachedAsset(AssetId id) async {
+    if (_assetCache.containsKey(id)) {
+      return _assetCache[id];
+    }
+    throw new AssetNotFoundException(id);
   }
 
   /// Whether [_sdkResources] has an asset matching [id].
@@ -287,7 +291,18 @@ class _AssetCache {
   void operator []=(AssetId id, Future<Asset> asset) {
     var packageCache = _assets.putIfAbsent(
         id.package, () => <String, Future<Result<Asset>>>{});
-    packageCache[id.path] = Result.capture(asset);
+    packageCache[id.path] = Result.capture(asset.catchError((e, s) {
+      // Log the error eagerly, and only once.
+      log.error(null, log.red(e), s);
+      // Create an asset that contains the errors, the app may use this to get
+      // information about any failed request.
+      var errorAssetId = id.addExtension('.errors');
+      this[errorAssetId] =
+          new Future.value(new Asset.fromString(errorAssetId, '$e'));
+      // Convert the error into an `AssetNotFoundException` which the server
+      // knows how to handle.
+      throw new AssetNotFoundException(id);
+    }, test: (e) => e is! AssetNotFoundException));
   }
 
   bool containsKey(AssetId id) => _getResult(id) != null;

--- a/lib/src/dartdevc/dartdevc_environment.dart
+++ b/lib/src/dartdevc/dartdevc_environment.dart
@@ -15,7 +15,6 @@ import '../io.dart';
 import '../log.dart' as log;
 import '../package_graph.dart';
 import 'dartdevc.dart';
-import 'errors.dart';
 import 'module.dart';
 import 'module_computer.dart';
 import 'module_reader.dart';

--- a/lib/src/dartdevc/errors.dart
+++ b/lib/src/dartdevc/errors.dart
@@ -1,0 +1,45 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:barback/barback.dart';
+
+import 'module.dart';
+
+/// An [Exception] that is thrown when the analyzer fails to create a summary.
+class AnalyzerSummaryException implements Exception {
+  /// The module that couldn't be compiled.
+  final AssetId assetId;
+
+  /// The error response from the dartdevc worker.
+  final String error;
+
+  AnalyzerSummaryException(this.assetId, this.error);
+
+  String toString() => 'Error creating summary for module: $assetId\n\n'
+      '$error';
+}
+
+/// An [Exception] that is thrown when dartdevc compilation fails.
+class DartDevcCompilationException implements Exception {
+  /// The js module that couldn't be compiled.
+  final AssetId assetId;
+
+  /// The error response from the dartdevc worker.
+  final String error;
+
+  DartDevcCompilationException(this.assetId, this.error);
+
+  String toString() => 'Error compiling dartdevc module: $assetId\n\n'
+      '$error';
+}
+
+/// An [Exception] that is thrown when a module is not found for an [AssetId].
+class MissingModuleException implements Exception {
+  /// The asset that a module could not be found for.
+  final AssetId assetId;
+
+  MissingModuleException(this.assetId);
+
+  String toString() => 'Unable to find module for $assetId';
+}

--- a/lib/src/dartdevc/errors.dart
+++ b/lib/src/dartdevc/errors.dart
@@ -4,32 +4,33 @@
 
 import 'package:barback/barback.dart';
 
-/// An [Exception] that is thrown when the analyzer fails to create a summary.
-class AnalyzerSummaryException implements Exception {
-  /// The module that couldn't be compiled.
-  final AssetId assetId;
+/// An [Exception] that is thrown when a worker returns an error.
+abstract class _WorkerException implements Exception {
+  final AssetId failedAsset;
 
-  /// The error response from the dartdevc worker.
   final String error;
 
-  AnalyzerSummaryException(this.assetId, this.error);
+  /// A message to prepend to [toString] output.
+  String get message;
 
-  String toString() => 'Error creating summary for module: $assetId\n\n'
-      '$error';
+  _WorkerException(this.failedAsset, this.error);
+
+  String toString() => '$message:$failedAsset\n\n$error';
+}
+
+/// An [Exception] that is thrown when the analyzer fails to create a summary.
+class AnalyzerSummaryException extends _WorkerException {
+  final String message = 'Error creating summary for module';
+
+  AnalyzerSummaryException(AssetId summaryId, String error)
+      : super(summaryId, error);
 }
 
 /// An [Exception] that is thrown when dartdevc compilation fails.
-class DartDevcCompilationException implements Exception {
-  /// The js module that couldn't be compiled.
-  final AssetId assetId;
+class DartDevcCompilationException extends _WorkerException {
+  final String message = 'Error compiling dartdevc module';
 
-  /// The error response from the dartdevc worker.
-  final String error;
-
-  DartDevcCompilationException(this.assetId, this.error);
-
-  String toString() => 'Error compiling dartdevc module: $assetId\n\n'
-      '$error';
+  DartDevcCompilationException(AssetId jsId, String error) : super(jsId, error);
 }
 
 /// An [Exception] that is thrown when a module is not found for an [AssetId].

--- a/lib/src/dartdevc/errors.dart
+++ b/lib/src/dartdevc/errors.dart
@@ -4,8 +4,6 @@
 
 import 'package:barback/barback.dart';
 
-import 'module.dart';
-
 /// An [Exception] that is thrown when the analyzer fails to create a summary.
 class AnalyzerSummaryException implements Exception {
   /// The module that couldn't be compiled.

--- a/lib/src/log.dart
+++ b/lib/src/log.dart
@@ -201,8 +201,9 @@ class Entry {
 /// If [error] is passed, it's appended to [message]. If [trace] is passed, it's
 /// printed at log level fine.
 void error(message, [error, StackTrace trace]) {
+  message ??= '';
   if (error != null) {
-    message = "$message: $error";
+    message = message.isEmpty ? "$error" : "$message: $error";
     if (error is Error && trace == null) trace = error.stackTrace;
   }
   write(Level.ERROR, message);


### PR DESCRIPTION
Added some new Exception types which are thrown instead of AssetNotFoundExceptions, and added uniform handling for them which creates a new asset at `originalId.addExtension('.errors')`.

This new asset is requested by the app when it fails to load a module and it prints the contents to the console so you can get compilation errors in your browser.

Partially resolves https://github.com/dart-lang/pub/issues/1618, I think we could still do something better with these errors but this is a good first step.