### PR TITLE
add web compiler option to pubspec.yaml, change --compiler to --web-compiler

### DIFF
--- a/lib/src/cached_package.dart
+++ b/lib/src/cached_package.dart
@@ -89,7 +89,7 @@ class _CachedPubspec implements Pubspec {
   bool get isPrivate => _inner.isPrivate;
   bool get isEmpty => _inner.isEmpty;
   List<PubspecException> get allErrors => _inner.allErrors;
-  Map<String, String> get jsCompiler => _inner.jsCompiler;
+  Map<String, String> get webCompiler => _inner.webCompiler;
 
   List<Set<TransformerConfig>> get transformers => const [];
 

--- a/lib/src/cached_package.dart
+++ b/lib/src/cached_package.dart
@@ -89,6 +89,7 @@ class _CachedPubspec implements Pubspec {
   bool get isPrivate => _inner.isPrivate;
   bool get isEmpty => _inner.isEmpty;
   List<PubspecException> get allErrors => _inner.allErrors;
+  Map<String, String> get jsCompiler => _inner.jsCompiler;
 
   List<Set<TransformerConfig>> get transformers => const [];
 

--- a/lib/src/cached_package.dart
+++ b/lib/src/cached_package.dart
@@ -7,6 +7,7 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
 import 'barback/transformer_config.dart';
+import 'compiler.dart';
 import 'io.dart';
 import 'package.dart';
 import 'pubspec.dart';
@@ -89,7 +90,7 @@ class _CachedPubspec implements Pubspec {
   bool get isPrivate => _inner.isPrivate;
   bool get isEmpty => _inner.isEmpty;
   List<PubspecException> get allErrors => _inner.allErrors;
-  Map<String, String> get webCompiler => _inner.webCompiler;
+  Map<String, Compiler> get webCompiler => _inner.webCompiler;
 
   List<Set<TransformerConfig>> get transformers => const [];
 

--- a/lib/src/command/barback.dart
+++ b/lib/src/command/barback.dart
@@ -35,20 +35,20 @@ abstract class BarbackCommand extends PubCommand {
             "The --dart2js flag can't be used with the --web-compiler arg. "
             "Prefer using the --web-compiler arg as --[no]-dart2js is "
             "deprecated.");
+      } else {
+        log.warning("The --dart2js flag is deprecated, please use "
+            "--web-compiler=dart2js option instead.");
       }
-      if (argResults['dart2js']) {
+      if (argResults["dart2js"]) {
         return Compiler.dart2JS;
       } else {
         return Compiler.none;
       }
-    } else if (argResults.options.contains("web-compiler") &&
-        argResults.wasParsed("web-compiler")) {
+    } else if (argResults.options.contains("web-compiler")) {
       return Compiler.byName(argResults["web-compiler"]);
     } else {
-      var compilerName = entrypoint.root.pubspec.webCompiler[mode.name];
-      return compilerName != null
-          ? Compiler.byName(compilerName)
-          : Compiler.dart2JS;
+      var compiler = entrypoint.root.pubspec.webCompiler[mode.name];
+      return compiler ?? Compiler.dart2JS;
     }
   }
 

--- a/lib/src/command/barback.dart
+++ b/lib/src/command/barback.dart
@@ -27,23 +27,25 @@ abstract class BarbackCommand extends PubCommand {
 
   /// The current compiler mode.
   Compiler get compiler {
-    if (argResults.options.contains('dart2js') &&
-        argResults.wasParsed('dart2js')) {
-      if (argResults.options.contains("compiler") &&
-          argResults.wasParsed("compiler")) {
-        usageException(
-            "The --dart2js flag can't be used with the --compiler arg. "
-            "Prefer using the --compiler arg as --[no]-dart2js is deprecated.");
+    if (argResults.options.contains("dart2js") &&
+        argResults.wasParsed("dart2js")) {
+      if (argResults.options.contains("js") && argResults.wasParsed("js")) {
+        usageException("The --dart2js flag can't be used with the --js arg. "
+            "Prefer using the --js arg as --[no]-dart2js is deprecated.");
       }
       if (argResults['dart2js']) {
         return Compiler.dart2JS;
       } else {
         return Compiler.none;
       }
-    } else if (argResults.options.contains("compiler")) {
-      return Compiler.byName(argResults["compiler"]);
+    } else if (argResults.options.contains("js") &&
+        argResults.wasParsed("js")) {
+      return Compiler.byName(argResults["js"]);
     } else {
-      return Compiler.dart2JS;
+      var compilerName = entrypoint.root.pubspec.jsCompiler[mode.name];
+      return compilerName != null
+          ? Compiler.byName(compilerName)
+          : Compiler.dart2JS;
     }
   }
 
@@ -68,7 +70,7 @@ abstract class BarbackCommand extends PubCommand {
         defaultsTo: false,
         negatable: false);
 
-    argParser.addOption("compiler",
+    argParser.addOption("js",
         allowed: Compiler.names,
         defaultsTo: 'dart2js',
         help: 'The JavaScript compiler to use to build the app.');

--- a/lib/src/command/barback.dart
+++ b/lib/src/command/barback.dart
@@ -29,20 +29,23 @@ abstract class BarbackCommand extends PubCommand {
   Compiler get compiler {
     if (argResults.options.contains("dart2js") &&
         argResults.wasParsed("dart2js")) {
-      if (argResults.options.contains("js") && argResults.wasParsed("js")) {
-        usageException("The --dart2js flag can't be used with the --js arg. "
-            "Prefer using the --js arg as --[no]-dart2js is deprecated.");
+      if (argResults.options.contains("web-compiler") &&
+          argResults.wasParsed("web-compiler")) {
+        usageException(
+            "The --dart2js flag can't be used with the --web-compiler arg. "
+            "Prefer using the --web-compiler arg as --[no]-dart2js is "
+            "deprecated.");
       }
       if (argResults['dart2js']) {
         return Compiler.dart2JS;
       } else {
         return Compiler.none;
       }
-    } else if (argResults.options.contains("js") &&
-        argResults.wasParsed("js")) {
-      return Compiler.byName(argResults["js"]);
+    } else if (argResults.options.contains("web-compiler") &&
+        argResults.wasParsed("web-compiler")) {
+      return Compiler.byName(argResults["web-compiler"]);
     } else {
-      var compilerName = entrypoint.root.pubspec.jsCompiler[mode.name];
+      var compilerName = entrypoint.root.pubspec.webCompiler[mode.name];
       return compilerName != null
           ? Compiler.byName(compilerName)
           : Compiler.dart2JS;
@@ -70,7 +73,7 @@ abstract class BarbackCommand extends PubCommand {
         defaultsTo: false,
         negatable: false);
 
-    argParser.addOption("js",
+    argParser.addOption("web-compiler",
         allowed: Compiler.names,
         help: 'The JavaScript compiler to use to build the app.');
   }

--- a/lib/src/command/barback.dart
+++ b/lib/src/command/barback.dart
@@ -72,7 +72,6 @@ abstract class BarbackCommand extends PubCommand {
 
     argParser.addOption("js",
         allowed: Compiler.names,
-        defaultsTo: 'dart2js',
         help: 'The JavaScript compiler to use to build the app.');
   }
 

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -357,14 +357,14 @@ class Pubspec {
 
   /// The settings for which web compiler to use in which mode.
   ///
-  /// It is a map of strings to string. Each key is the name of a mode, and
-  /// the value is the name of the web compiler to use in that mode.
+  /// It is a map of [String] to [Compiler]. Each key is the name of a mode, and
+  /// the value is the web compiler to use in that mode.
   ///
   /// Valid compiler values are all of [Compiler.names].
-  Map<String, String> get webCompiler {
+  Map<String, Compiler> get webCompiler {
     if (_webCompiler != null) return _webCompiler;
 
-    _webCompiler = {};
+    _webCompiler = <String, Compiler>{};
     var webYaml = fields.nodes['web'];
     if (webYaml == null) return _webCompiler;
 
@@ -385,26 +385,18 @@ class Pubspec {
         _error('"compiler" keys must be strings.', key.span);
       }
 
-      final keyPattern = new RegExp(r"^[a-zA-Z0-9_-]+$");
-      if (!keyPattern.hasMatch(key.value)) {
-        _error(
-            '"compiler" keys may only contain letters, '
-            'numbers, hyphens and underscores.',
-            key.span);
-      }
-
       if (!Compiler.names.contains(value.value)) {
         _error(
             '"compiler" values must be one of ${Compiler.names}.', value.span);
       }
 
-      _webCompiler[key.value] = value.value;
+      _webCompiler[key.value] = Compiler.byName(value.value);
     });
 
     return _webCompiler;
   }
 
-  Map<String, String> _webCompiler;
+  Map<String, Compiler> _webCompiler;
 
   /// Whether the package is private and cannot be published.
   ///

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -366,7 +366,7 @@ class Pubspec {
 
     _webCompiler = <String, Compiler>{};
     var webYaml = fields.nodes['web'];
-    if (webYaml == null) return _webCompiler;
+    if (webYaml?.value == null) return _webCompiler;
 
     if (webYaml is! Map) {
       _error('"web" field must be a map.', webYaml.span);

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -355,49 +355,56 @@ class Pubspec {
 
   Map<String, String> _executables;
 
-  /// The options for which JS compiler to use in which mode.
+  /// The settings for which web compiler to use in which mode.
   ///
   /// It is a map of strings to string. Each key is the name of a mode, and
-  /// the value is the name of the JS compiler to use in that mode.
+  /// the value is the name of the web compiler to use in that mode.
   ///
   /// Valid compiler values are all of [Compiler.names].
-  Map<String, String> get jsCompiler {
-    if (_jsCompiler != null) return _jsCompiler;
+  Map<String, String> get webCompiler {
+    if (_webCompiler != null) return _webCompiler;
 
-    _jsCompiler = {};
-    var yaml = fields['js_compiler'];
-    if (yaml == null) return {};
+    _webCompiler = {};
+    var webYaml = fields.nodes['web'];
+    if (webYaml == null) return _webCompiler;
 
-    if (yaml is! Map) {
-      _error('"js_compiler" field must be a map.',
-          fields.nodes['js_compiler'].span);
+    if (webYaml is! Map) {
+      _error('"web" field must be a map.', webYaml.span);
     }
 
-    yaml.nodes.forEach((key, value) {
+    var compilerYaml = (webYaml as YamlMap)['compiler'];
+    if (compilerYaml == null) return _webCompiler;
+
+    if (compilerYaml is! Map) {
+      _error('"compiler" field must be a map.',
+          (webYaml as YamlMap).nodes['compiler'].span);
+    }
+
+    compilerYaml.nodes.forEach((key, value) {
       if (key.value is! String) {
-        _error('"js_compiler" keys must be strings.', key.span);
+        _error('"compiler" keys must be strings.', key.span);
       }
 
       final keyPattern = new RegExp(r"^[a-zA-Z0-9_-]+$");
       if (!keyPattern.hasMatch(key.value)) {
         _error(
-            '"js_compiler" keys may only contain letters, '
+            '"compiler" keys may only contain letters, '
             'numbers, hyphens and underscores.',
             key.span);
       }
 
       if (!Compiler.names.contains(value.value)) {
-        _error('"js_compiler" values must be one of ${Compiler.names}.',
-            value.span);
+        _error(
+            '"compiler" values must be one of ${Compiler.names}.', value.span);
       }
 
-      _jsCompiler[key.value] = value.value;
+      _webCompiler[key.value] = value.value;
     });
 
-    return _jsCompiler;
+    return _webCompiler;
   }
 
-  Map<String, String> _jsCompiler;
+  Map<String, String> _webCompiler;
 
   /// Whether the package is private and cannot be published.
   ///

--- a/test/compiler/compiler_selection_test.dart
+++ b/test/compiler/compiler_selection_test.dart
@@ -14,7 +14,8 @@ import '../serve/utils.dart';
 import 'utils.dart';
 
 main() {
-  integrationWithCompiler("js flag switches compilers", (compiler) {
+  integrationWithCompiler("--web-compiler option switches compilers",
+      (compiler) {
     d.dir(appPath, [
       d.appPubspec(),
       d.dir("lib", [
@@ -63,7 +64,7 @@ main() {
     endPubServe();
   }, compilers: Compiler.all);
 
-  integration("invalid js flag gives an error", () {
+  integration("invalid --web-compiler option gives an error", () {
     d.dir(appPath, [
       d.appPubspec(),
     ]).create();
@@ -96,7 +97,7 @@ main() {
     }
   });
 
-  integrationWithCompiler("js_compiler can be set in the pubspec", (compiler) {
+  integrationWithCompiler("web compiler can be set in the pubspec", (compiler) {
     d.dir(appPath, [
       d.pubspec({
         'name': 'myapp',

--- a/test/compiler/compiler_selection_test.dart
+++ b/test/compiler/compiler_selection_test.dart
@@ -69,30 +69,30 @@ main() {
     ]).create();
 
     pubGet();
-    var process = startPubServe(args: ['--js', 'invalid']);
+    var process = startPubServe(args: ['--web-compiler', 'invalid']);
     process.shouldExit(USAGE);
-    process.stderr.expect(
-        consumeThrough('"invalid" is not an allowed value for option "js".'));
+    process.stderr.expect(consumeThrough(
+        '"invalid" is not an allowed value for option "web-compiler".'));
   });
 
-  integration("--dart2js with --js is invalid", () {
+  integration("--dart2js with --web-compiler is invalid", () {
     d.dir(appPath, [
       d.appPubspec(),
     ]).create();
 
     pubGet();
     var argCombos = [
-      ['--dart2js', '--js=dartdevc'],
-      ['--no-dart2js', '--js=dartdevc'],
-      ['--dart2js', '--js=dart2js'],
-      ['--no-dart2js', '--js=dart2js'],
+      ['--dart2js', '--web-compiler=dartdevc'],
+      ['--no-dart2js', '--web-compiler=dartdevc'],
+      ['--dart2js', '--web-compiler=dart2js'],
+      ['--no-dart2js', '--web-compiler=dart2js'],
     ];
     for (var args in argCombos) {
       var process = startPubServe(args: args);
       process.shouldExit(USAGE);
       process.stderr.expect(consumeThrough(
-          "The --dart2js flag can't be used with the --js arg. Prefer "
-          "using the --js arg as --[no]-dart2js is deprecated."));
+          "The --dart2js flag can't be used with the --web-compiler arg. Prefer "
+          "using the --web-compiler arg as --[no]-dart2js is deprecated."));
     }
   });
 
@@ -100,7 +100,9 @@ main() {
     d.dir(appPath, [
       d.pubspec({
         'name': 'myapp',
-        'js_compiler': {'debug': compiler.name}
+        'web': {
+          'compiler': {'debug': compiler.name}
+        },
       }),
       d.dir('web', [
         d.file(
@@ -126,12 +128,14 @@ main() {
     endPubServe();
   });
 
-  integrationWithCompiler("--js flag overrides pubspec js_compiler config",
+  integrationWithCompiler("--web-compiler flag overrides pubspec config",
       (compiler) {
     d.dir(appPath, [
       d.pubspec({
         'name': 'myapp',
-        'js_compiler': {'debug': Compiler.none.name}
+        'web': {
+          'compiler': {'debug': Compiler.none.name}
+        },
       }),
       d.dir('web', [
         d.file(

--- a/test/compiler/compiles_entrypoints_in_root_package_test.dart
+++ b/test/compiler/compiles_entrypoints_in_root_package_test.dart
@@ -42,7 +42,7 @@ main() {
       "benchmark",
       "foo",
       "web",
-      "--js=${compiler.name}"
+      "--web-compiler=${compiler.name}"
     ], output: new RegExp(r'Built [\d]+ files to "build".'));
 
     d.dir(appPath, [

--- a/test/compiler/compiles_entrypoints_in_root_package_test.dart
+++ b/test/compiler/compiles_entrypoints_in_root_package_test.dart
@@ -42,7 +42,7 @@ main() {
       "benchmark",
       "foo",
       "web",
-      "--compiler=${compiler.name}"
+      "--js=${compiler.name}"
     ], output: new RegExp(r'Built [\d]+ files to "build".'));
 
     d.dir(appPath, [

--- a/test/compiler/environment_constant_test.dart
+++ b/test/compiler/environment_constant_test.dart
@@ -30,7 +30,7 @@ main() {
         "build",
         "--define",
         "name=fblthp",
-        "--compiler=${compiler.name}"
+        "--js=${compiler.name}"
       ], output: new RegExp(r'Built [\d]+ file[s]? to "build".'));
 
       var expectedFile;

--- a/test/compiler/environment_constant_test.dart
+++ b/test/compiler/environment_constant_test.dart
@@ -30,7 +30,7 @@ main() {
         "build",
         "--define",
         "name=fblthp",
-        "--js=${compiler.name}"
+        "--web-compiler=${compiler.name}"
       ], output: new RegExp(r'Built [\d]+ file[s]? to "build".'));
 
       var expectedFile;

--- a/test/compiler/ignores_entrypoints_in_lib_test.dart
+++ b/test/compiler/ignores_entrypoints_in_lib_test.dart
@@ -25,7 +25,7 @@ main() {
   integrationWithCompiler("build ignores Dart entrypoints in lib", (compiler) {
     pubGet();
     schedulePub(
-        args: ["build", "--all", "--compiler=${compiler.name}"],
+        args: ["build", "--all", "--js=${compiler.name}"],
         output: new RegExp(r'Built [\d]+ files? to "build".'));
 
     d.dir(appPath, [

--- a/test/compiler/ignores_entrypoints_in_lib_test.dart
+++ b/test/compiler/ignores_entrypoints_in_lib_test.dart
@@ -25,7 +25,7 @@ main() {
   integrationWithCompiler("build ignores Dart entrypoints in lib", (compiler) {
     pubGet();
     schedulePub(
-        args: ["build", "--all", "--js=${compiler.name}"],
+        args: ["build", "--all", "--web-compiler=${compiler.name}"],
         output: new RegExp(r'Built [\d]+ files? to "build".'));
 
     d.dir(appPath, [

--- a/test/compiler/ignores_non_entrypoint_dart_files_test.dart
+++ b/test/compiler/ignores_non_entrypoint_dart_files_test.dart
@@ -26,7 +26,7 @@ main() {
       (compiler) {
     pubGet();
     schedulePub(
-        args: ["build", "--compiler=${compiler.name}"],
+        args: ["build", "--js=${compiler.name}"],
         output: new RegExp(r'Built [\d]+ files? to "build".'));
 
     d.dir(appPath, [

--- a/test/compiler/ignores_non_entrypoint_dart_files_test.dart
+++ b/test/compiler/ignores_non_entrypoint_dart_files_test.dart
@@ -26,7 +26,7 @@ main() {
       (compiler) {
     pubGet();
     schedulePub(
-        args: ["build", "--js=${compiler.name}"],
+        args: ["build", "--web-compiler=${compiler.name}"],
         output: new RegExp(r'Built [\d]+ files? to "build".'));
 
     d.dir(appPath, [

--- a/test/compiler/includes_source_maps_in_debug_test.dart
+++ b/test/compiler/includes_source_maps_in_debug_test.dart
@@ -26,7 +26,7 @@ main() {
 
     pubGet();
     schedulePub(
-        args: ["build", "--mode", "debug", "--js=${compiler.name}"],
+        args: ["build", "--mode", "debug", "--web-compiler=${compiler.name}"],
         output: new RegExp(r'Built \d+ files to "build".'),
         exitCode: 0);
 

--- a/test/compiler/includes_source_maps_in_debug_test.dart
+++ b/test/compiler/includes_source_maps_in_debug_test.dart
@@ -26,7 +26,7 @@ main() {
 
     pubGet();
     schedulePub(
-        args: ["build", "--mode", "debug", "--compiler=${compiler.name}"],
+        args: ["build", "--mode", "debug", "--js=${compiler.name}"],
         output: new RegExp(r'Built \d+ files to "build".'),
         exitCode: 0);
 

--- a/test/compiler/omits_source_map_in_release_test.dart
+++ b/test/compiler/omits_source_map_in_release_test.dart
@@ -25,7 +25,7 @@ main() {
 
     pubGet();
     schedulePub(
-        args: ["build", "--js=${compiler.name}"],
+        args: ["build", "--web-compiler=${compiler.name}"],
         output: new RegExp(r'Built \d+ files? to "build".'),
         exitCode: 0);
 

--- a/test/compiler/omits_source_map_in_release_test.dart
+++ b/test/compiler/omits_source_map_in_release_test.dart
@@ -25,7 +25,7 @@ main() {
 
     pubGet();
     schedulePub(
-        args: ["build", "--compiler=${compiler.name}"],
+        args: ["build", "--js=${compiler.name}"],
         output: new RegExp(r'Built \d+ files? to "build".'),
         exitCode: 0);
 

--- a/test/compiler/reports_dart_parse_errors_test.dart
+++ b/test/compiler/reports_dart_parse_errors_test.dart
@@ -30,7 +30,7 @@ main() {
   });
 
   integrationWithCompiler("Pub build reports Dart parse errors", (compiler) {
-    var pub = startPub(args: ["build", "--compiler", compiler.name]);
+    var pub = startPub(args: ["build", "--js", compiler.name]);
     _expectErrors(pub, compiler);
 
     pub.shouldExit(exit_codes.DATA);
@@ -42,7 +42,7 @@ main() {
   });
 
   integrationWithCompiler("Pub serve reports Dart parse errors", (compiler) {
-    var pub = pubServe(args: ["--compiler", compiler.name]);
+    var pub = pubServe(args: ["--js", compiler.name]);
 
     switch (compiler) {
       case Compiler.dartDevc:

--- a/test/compiler/reports_dart_parse_errors_test.dart
+++ b/test/compiler/reports_dart_parse_errors_test.dart
@@ -30,7 +30,7 @@ main() {
   });
 
   integrationWithCompiler("Pub build reports Dart parse errors", (compiler) {
-    var pub = startPub(args: ["build", "--js", compiler.name]);
+    var pub = startPub(args: ["build", "--web-compiler", compiler.name]);
     _expectErrors(pub, compiler);
 
     pub.shouldExit(exit_codes.DATA);
@@ -42,7 +42,7 @@ main() {
   });
 
   integrationWithCompiler("Pub serve reports Dart parse errors", (compiler) {
-    var pub = pubServe(args: ["--js", compiler.name]);
+    var pub = pubServe(args: ["--web-compiler", compiler.name]);
 
     switch (compiler) {
       case Compiler.dartDevc:

--- a/test/compiler/source_maps_are_self_contained_test.dart
+++ b/test/compiler/source_maps_are_self_contained_test.dart
@@ -55,7 +55,7 @@ main() {
 
     pubGet();
     schedulePub(
-        args: ["build", "--mode", "debug", "--js", compiler.name],
+        args: ["build", "--mode", "debug", "--web-compiler", compiler.name],
         output: new RegExp(r'Built \d+ files to "build".'),
         exitCode: 0);
 

--- a/test/compiler/source_maps_are_self_contained_test.dart
+++ b/test/compiler/source_maps_are_self_contained_test.dart
@@ -55,7 +55,7 @@ main() {
 
     pubGet();
     schedulePub(
-        args: ["build", "--mode", "debug", "--compiler", compiler.name],
+        args: ["build", "--mode", "debug", "--js", compiler.name],
         output: new RegExp(r'Built \d+ files to "build".'),
         exitCode: 0);
 

--- a/test/compiler/supports_configuration_with_build_test.dart
+++ b/test/compiler/supports_configuration_with_build_test.dart
@@ -71,7 +71,7 @@ main() {
     pubGet();
 
     schedulePub(
-        args: ["build", "--js", compiler.name],
+        args: ["build", "--web-compiler", compiler.name],
         output: new RegExp(r'Built \d+ files? to "build".'),
         exitCode: 0);
 

--- a/test/compiler/supports_configuration_with_build_test.dart
+++ b/test/compiler/supports_configuration_with_build_test.dart
@@ -71,7 +71,7 @@ main() {
     pubGet();
 
     schedulePub(
-        args: ["build", "--compiler", compiler.name],
+        args: ["build", "--js", compiler.name],
         output: new RegExp(r'Built \d+ files? to "build".'),
         exitCode: 0);
 

--- a/test/compiler/utils.dart
+++ b/test/compiler/utils.dart
@@ -15,6 +15,6 @@ void integrationWithCompiler(String name, void testFn(Compiler compiler),
     {List<Compiler> compilers}) {
   compilers ??= [Compiler.dart2JS, Compiler.dartDevc];
   for (var compiler in compilers) {
-    integration('--compiler=${compiler.name} $name', () => testFn(compiler));
+    integration('--js=${compiler.name} $name', () => testFn(compiler));
   }
 }

--- a/test/compiler/utils.dart
+++ b/test/compiler/utils.dart
@@ -15,6 +15,6 @@ void integrationWithCompiler(String name, void testFn(Compiler compiler),
     {List<Compiler> compilers}) {
   compilers ??= [Compiler.dart2JS, Compiler.dartDevc];
   for (var compiler in compilers) {
-    integration('--js=${compiler.name} $name', () => testFn(compiler));
+    integration('--web-compiler=${compiler.name} $name', () => testFn(compiler));
   }
 }

--- a/test/dartdevc/build_test.dart
+++ b/test/dartdevc/build_test.dart
@@ -9,7 +9,7 @@ import '../descriptor.dart' as d;
 import '../test_pub.dart';
 
 main() {
-  integration("pub build --compiler=dartdevc creates all required sources", () {
+  integration("pub build --js=dartdevc creates all required sources", () {
     d.dir("foo", [
       d.libPubspec("foo", "1.0.0"),
       d.dir("lib", [
@@ -58,7 +58,7 @@ void main() => other.main();
 
     pubGet();
     schedulePub(
-        args: ["build", "web", "--compiler=${Compiler.dartDevc.name}"],
+        args: ["build", "web", "--js=${Compiler.dartDevc.name}"],
         output: new RegExp(r'Built [\d]+ files to "build".'));
 
     d.dir(appPath, [

--- a/test/dartdevc/build_test.dart
+++ b/test/dartdevc/build_test.dart
@@ -9,7 +9,7 @@ import '../descriptor.dart' as d;
 import '../test_pub.dart';
 
 main() {
-  integration("pub build --js=dartdevc creates all required sources", () {
+  integration("pub build --web-compiler=dartdevc creates all required sources", () {
     d.dir("foo", [
       d.libPubspec("foo", "1.0.0"),
       d.dir("lib", [
@@ -58,7 +58,7 @@ void main() => other.main();
 
     pubGet();
     schedulePub(
-        args: ["build", "web", "--js=${Compiler.dartDevc.name}"],
+        args: ["build", "web", "--web-compiler=${Compiler.dartDevc.name}"],
         output: new RegExp(r'Built [\d]+ files to "build".'));
 
     d.dir(appPath, [

--- a/test/dartdevc/dartdevc_test.dart
+++ b/test/dartdevc/dartdevc_test.dart
@@ -48,7 +48,7 @@ void main() {
     ]).create();
 
     pubGet();
-    pubServe(args: ['--js', 'dartdevc']);
+    pubServe(args: ['--web-compiler', 'dartdevc']);
     // Just confirm some basic things are present indicating that the module
     // was compiled. The goal here is not to test dartdevc itself.
     requestShouldSucceed('web__main.js', contains('main'));
@@ -79,7 +79,7 @@ void main() {
     ]).create();
 
     pubGet();
-    pubServe(args: ['--js', 'dartdevc']);
+    pubServe(args: ['--web-compiler', 'dartdevc']);
     requestShouldSucceed('dart_sdk.js', null);
     requestShouldSucceed('require.js', null);
     requestShouldSucceed('dart_stack_trace_mapper.js', null);

--- a/test/dartdevc/dartdevc_test.dart
+++ b/test/dartdevc/dartdevc_test.dart
@@ -48,7 +48,7 @@ void main() {
     ]).create();
 
     pubGet();
-    pubServe(args: ['--compiler', 'dartdevc']);
+    pubServe(args: ['--js', 'dartdevc']);
     // Just confirm some basic things are present indicating that the module
     // was compiled. The goal here is not to test dartdevc itself.
     requestShouldSucceed('web__main.js', contains('main'));
@@ -79,7 +79,7 @@ void main() {
     ]).create();
 
     pubGet();
-    pubServe(args: ['--compiler', 'dartdevc']);
+    pubServe(args: ['--js', 'dartdevc']);
     requestShouldSucceed('dart_sdk.js', null);
     requestShouldSucceed('require.js', null);
     requestShouldSucceed('dart_stack_trace_mapper.js', null);

--- a/test/dartdevc/module_config_test.dart
+++ b/test/dartdevc/module_config_test.dart
@@ -51,7 +51,7 @@ main() {}
     ]).create();
 
     pubGet();
-    pubServe(args: ['--compiler', 'dartdevc']);
+    pubServe(args: ['--js', 'dartdevc']);
 
     moduleRequestShouldSucceed(moduleConfigName, [
       makeModule(

--- a/test/dartdevc/module_config_test.dart
+++ b/test/dartdevc/module_config_test.dart
@@ -51,7 +51,7 @@ main() {}
     ]).create();
 
     pubGet();
-    pubServe(args: ['--js', 'dartdevc']);
+    pubServe(args: ['--web-compiler', 'dartdevc']);
 
     moduleRequestShouldSucceed(moduleConfigName, [
       makeModule(

--- a/test/dartdevc/summaries_test.dart
+++ b/test/dartdevc/summaries_test.dart
@@ -50,7 +50,7 @@ void main() {}
     ]).create();
 
     pubGet();
-    pubServe(args: ['--js', 'dartdevc']);
+    pubServe(args: ['--web-compiler', 'dartdevc']);
 
     linkedSummaryRequestShouldSucceed('web__main$linkedSummaryExtension', [
       endsWith('web/main.dart'),
@@ -119,7 +119,7 @@ void main() {}
     ]).create();
 
     pubGet();
-    pubServe(args: ['--js', 'dartdevc']);
+    pubServe(args: ['--web-compiler', 'dartdevc']);
 
     unlinkedSummaryRequestShouldSucceed(
         'web__main$unlinkedSummaryExtension', [endsWith('web/main.dart')]);

--- a/test/dartdevc/summaries_test.dart
+++ b/test/dartdevc/summaries_test.dart
@@ -50,7 +50,7 @@ void main() {}
     ]).create();
 
     pubGet();
-    pubServe(args: ['--compiler', 'dartdevc']);
+    pubServe(args: ['--js', 'dartdevc']);
 
     linkedSummaryRequestShouldSucceed('web__main$linkedSummaryExtension', [
       endsWith('web/main.dart'),
@@ -119,7 +119,7 @@ void main() {}
     ]).create();
 
     pubGet();
-    pubServe(args: ['--compiler', 'dartdevc']);
+    pubServe(args: ['--js', 'dartdevc']);
 
     unlinkedSummaryRequestShouldSucceed(
         'web__main$unlinkedSummaryExtension', [endsWith('web/main.dart')]);

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -606,6 +606,16 @@ executables:
           expect(pubspec.webCompiler, isEmpty);
         });
 
+        test("defaults to an empty map if web is null", () {
+          var pubspec = new Pubspec.parse('web:', sources);
+          expect(pubspec.webCompiler, isEmpty);
+        });
+
+        test("defaults to an empty map if compiler is null", () {
+          var pubspec = new Pubspec.parse('web: {compiler:}', sources);
+          expect(pubspec.webCompiler, isEmpty);
+        });
+
         test("allows simple names for keys and valid compilers in values", () {
           var pubspec = new Pubspec.parse(
               '''
@@ -622,7 +632,6 @@ web:
         });
 
         test("throws if not a map", () {
-          expectPubspecException('web:', (pubspec) => pubspec.webCompiler);
           expectPubspecException(
               'web: {compiler: dartdevc}', (pubspec) => pubspec.webCompiler);
           expectPubspecException(

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pub/src/compiler.dart';
 import 'package:pub/src/package.dart';
 import 'package:pub/src/pubspec.dart';
 import 'package:pub/src/source.dart';
@@ -615,12 +616,13 @@ web:
     release: dart2js
 ''',
               sources);
-          expect(pubspec.webCompiler['abcDEF-123_'], equals('none'));
-          expect(pubspec.webCompiler['debug'], equals('dartdevc'));
-          expect(pubspec.webCompiler['release'], equals('dart2js'));
+          expect(pubspec.webCompiler['abcDEF-123_'], equals(Compiler.none));
+          expect(pubspec.webCompiler['debug'], equals(Compiler.dartDevc));
+          expect(pubspec.webCompiler['release'], equals(Compiler.dart2JS));
         });
 
         test("throws if not a map", () {
+          expectPubspecException('web:', (pubspec) => pubspec.webCompiler);
           expectPubspecException(
               'web: {compiler: dartdevc}', (pubspec) => pubspec.webCompiler);
           expectPubspecException(
@@ -629,11 +631,6 @@ web:
 
         test("throws if key is not a string", () {
           expectPubspecException('web: {compiler: {123: dartdevc}}',
-              (pubspec) => pubspec.webCompiler);
-        });
-
-        test("throws if a key isn't a simple name", () {
-          expectPubspecException('web: {compiler: {funny/name: dartdevc}}',
               (pubspec) => pubspec.webCompiler);
         });
 

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -592,5 +592,53 @@ executables:
         expect(pubspec.executables['command'], equals('command'));
       });
     });
+
+    group("js_compiler", () {
+      test("defaults to an empty map if omitted", () {
+        var pubspec = new Pubspec.parse('', sources);
+        expect(pubspec.jsCompiler, isEmpty);
+      });
+
+      test("allows simple names for keys and valid compilers in values", () {
+        var pubspec = new Pubspec.parse(
+            '''
+js_compiler:
+  abcDEF-123_: none
+  debug: dartdevc
+  release: dart2js
+''',
+            sources);
+        expect(pubspec.jsCompiler['abcDEF-123_'], equals('none'));
+        expect(pubspec.jsCompiler['debug'], equals('dartdevc'));
+        expect(pubspec.jsCompiler['release'], equals('dart2js'));
+      });
+
+      test("throws if not a map", () {
+        expectPubspecException(
+            'js_compiler: dartdevc', (pubspec) => pubspec.jsCompiler);
+        expectPubspecException(
+            'js_compiler: [dartdevc]', (pubspec) => pubspec.jsCompiler);
+      });
+
+      test("throws if key is not a string", () {
+        expectPubspecException(
+            'js_compiler: {123: dartdevc}', (pubspec) => pubspec.jsCompiler);
+      });
+
+      test("throws if a key isn't a simple name", () {
+        expectPubspecException('js_compiler: {funny/name: dartdevc}',
+            (pubspec) => pubspec.jsCompiler);
+      });
+
+      test("throws if a value is not a supported compiler", () {
+        expectPubspecException(
+            'js_compiler: {debug: frog}', (pubspec) => pubspec.jsCompiler);
+      });
+
+      test("throws if the value is null", () {
+        expectPubspecException(
+            'js_compiler:\n  debug:', (pubspec) => pubspec.jsCompiler);
+      });
+    });
   });
 }

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -593,51 +593,59 @@ executables:
       });
     });
 
-    group("js_compiler", () {
-      test("defaults to an empty map if omitted", () {
-        var pubspec = new Pubspec.parse('', sources);
-        expect(pubspec.jsCompiler, isEmpty);
+    group("web", () {
+      test("can be empty", () {
+        var pubspec = new Pubspec.parse('web: {}', sources);
+        expect(pubspec.webCompiler, isEmpty);
       });
 
-      test("allows simple names for keys and valid compilers in values", () {
-        var pubspec = new Pubspec.parse(
-            '''
-js_compiler:
-  abcDEF-123_: none
-  debug: dartdevc
-  release: dart2js
+      group("compiler", () {
+        test("defaults to an empty map if omitted", () {
+          var pubspec = new Pubspec.parse('', sources);
+          expect(pubspec.webCompiler, isEmpty);
+        });
+
+        test("allows simple names for keys and valid compilers in values", () {
+          var pubspec = new Pubspec.parse(
+              '''
+web:
+  compiler:
+    abcDEF-123_: none
+    debug: dartdevc
+    release: dart2js
 ''',
-            sources);
-        expect(pubspec.jsCompiler['abcDEF-123_'], equals('none'));
-        expect(pubspec.jsCompiler['debug'], equals('dartdevc'));
-        expect(pubspec.jsCompiler['release'], equals('dart2js'));
-      });
+              sources);
+          expect(pubspec.webCompiler['abcDEF-123_'], equals('none'));
+          expect(pubspec.webCompiler['debug'], equals('dartdevc'));
+          expect(pubspec.webCompiler['release'], equals('dart2js'));
+        });
 
-      test("throws if not a map", () {
-        expectPubspecException(
-            'js_compiler: dartdevc', (pubspec) => pubspec.jsCompiler);
-        expectPubspecException(
-            'js_compiler: [dartdevc]', (pubspec) => pubspec.jsCompiler);
-      });
+        test("throws if not a map", () {
+          expectPubspecException(
+              'web: {compiler: dartdevc}', (pubspec) => pubspec.webCompiler);
+          expectPubspecException(
+              'web: {compiler: [dartdevc]}', (pubspec) => pubspec.webCompiler);
+        });
 
-      test("throws if key is not a string", () {
-        expectPubspecException(
-            'js_compiler: {123: dartdevc}', (pubspec) => pubspec.jsCompiler);
-      });
+        test("throws if key is not a string", () {
+          expectPubspecException('web: {compiler: {123: dartdevc}}',
+              (pubspec) => pubspec.webCompiler);
+        });
 
-      test("throws if a key isn't a simple name", () {
-        expectPubspecException('js_compiler: {funny/name: dartdevc}',
-            (pubspec) => pubspec.jsCompiler);
-      });
+        test("throws if a key isn't a simple name", () {
+          expectPubspecException('web: {compiler: {funny/name: dartdevc}}',
+              (pubspec) => pubspec.webCompiler);
+        });
 
-      test("throws if a value is not a supported compiler", () {
-        expectPubspecException(
-            'js_compiler: {debug: frog}', (pubspec) => pubspec.jsCompiler);
-      });
+        test("throws if a value is not a supported compiler", () {
+          expectPubspecException('web: {compiler: {debug: frog}}',
+              (pubspec) => pubspec.webCompiler);
+        });
 
-      test("throws if the value is null", () {
-        expectPubspecException(
-            'js_compiler:\n  debug:', (pubspec) => pubspec.jsCompiler);
+        test("throws if the value is null", () {
+          expectPubspecException(
+              'web: {compiler: {debug: }}', (pubspec) => pubspec.webCompiler);
+        });
       });
     });
   });

--- a/test/serve/utils.dart
+++ b/test/serve/utils.dart
@@ -157,7 +157,7 @@ ScheduledProcess startPubServe(
     "--log-admin-url",
   ];
   if (compiler != null) {
-    pubArgs.add("--compiler=${compiler.name}");
+    pubArgs.add("--js=${compiler.name}");
   }
 
   if (args != null) pubArgs.addAll(args);

--- a/test/serve/utils.dart
+++ b/test/serve/utils.dart
@@ -157,7 +157,7 @@ ScheduledProcess startPubServe(
     "--log-admin-url",
   ];
   if (compiler != null) {
-    pubArgs.add("--js=${compiler.name}");
+    pubArgs.add("--web-compiler=${compiler.name}");
   }
 
   if (args != null) pubArgs.addAll(args);


### PR DESCRIPTION
With the top level key in the pubspec being called `js-compiler`, it no longer makes sense for the command line arg to be just `compiler` (same argument holds about future compilers conflicting). Since `js-compiler` is really long I talked with @munificent and we landed on just `--js`.

Let me know if there are objections to changing the flag from `--compiler` to `--js`. If we could come up with a single character shorthand for `--js-compiler` that might be preferable, but I don't know of one that really makes sense.

cc @kevmoo @munificent @jwren @devoncarew 

EDIT: See comment below about naming changes