### PR TITLE
only fetch .errors file for script load errors

### DIFF
--- a/lib/src/dartdevc/dartdevc.dart
+++ b/lib/src/dartdevc/dartdevc.dart
@@ -184,14 +184,16 @@ for (let moduleName of Object.getOwnPropertyNames(modulePaths)) {
 (function() {
   var oldOnError = requirejs.onError;
   requirejs.onError = function(e) {
-    var xhr = new XMLHttpRequest();
-    xhr.onreadystatechange = function() {
-      if (this.readyState == 4 && this.status == 200) {
-        console.error(this.responseText);
-      }
-    };
-    xhr.open("GET", e.originalError.srcElement.src + ".errors", true);
-    xhr.send();
+    if (e.originalError && e.originalError.srcElement) {
+      var xhr = new XMLHttpRequest();
+      xhr.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+          console.error(this.responseText);
+        }
+      };
+      xhr.open("GET", e.originalError.srcElement.src + ".errors", true);
+      xhr.send();
+    }
     // Also handle errors the normal way.
     if (oldOnError) oldOnError(e);
   };


### PR DESCRIPTION
`e.originalError` doesn't always exist (for timeout errors for instance), now we will only try to fetch the `.errors` file (and log the errors to the console) if `e.originalError.srcElement` exists.