### PR TITLE
fix cache invalidation for module configuration in dartdevc

### DIFF
--- a/lib/src/dartdevc/dartdevc_environment.dart
+++ b/lib/src/dartdevc/dartdevc_environment.dart
@@ -132,6 +132,7 @@ class DartDevcEnvironment {
   /// Invalidates [package] and all packages that depend on [package].
   void invalidatePackage(String package) {
     _assetCache.invalidatePackage(package);
+    _moduleReader.invalidatePackage(package);
     _scratchSpace.deletePackageFiles(package,
         isRootPackage: package == _packageGraph.entrypoint.root.name);
   }

--- a/lib/src/dartdevc/module_reader.dart
+++ b/lib/src/dartdevc/module_reader.dart
@@ -121,7 +121,7 @@ class ModuleReader {
         _modulesByModuleId[module.id] = module;
         for (var id in module.assetIds) {
           if (_modulesByAssetId.containsKey(id)) {
-            throw new StateError('Assets can only exist in one module, but $id'
+            throw new StateError('Assets can only exist in one module, but $id '
                 'was found in both ${_modulesByAssetId[id].id} and '
                 '${module.id}');
           }
@@ -130,5 +130,20 @@ class ModuleReader {
       }
       return modules;
     });
+  }
+
+  /// Invalidates all [Module]s for [package].
+  void invalidatePackage(String package) {
+    // `map` must be of type <AssetId|ModuleId, dynamic>
+    removePackage(String package, Map map) {
+      var idsToRemove = map.keys.where((id) => id.package == package).toList();
+      for (var id in idsToRemove) {
+        map.remove(id);
+      }
+    }
+
+    removePackage(package, _moduleConfigFutures);
+    removePackage(package, _modulesByModuleId);
+    removePackage(package, _modulesByAssetId);
   }
 }

--- a/test/dartdevc/dartdevc_test.dart
+++ b/test/dartdevc/dartdevc_test.dart
@@ -1,7 +1,10 @@
 // Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'dart:async';
+import 'dart:io';
 
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
@@ -9,7 +12,9 @@ import '../serve/utils.dart';
 import '../test_pub.dart';
 
 main() {
-  test("can compile js files for modules under lib and web", () async {
+  test(
+      "can compile js files for modules under lib and web, and handle new "
+      "files and edits.", () async {
     await d.dir("foo", [
       d.libPubspec("foo", "1.0.0"),
       d.dir("lib", [
@@ -20,20 +25,19 @@ main() {
   """)
       ]),
     ]).create();
-
-    await d.dir(appPath, [
-      d.appPubspec({
-        "foo": {"path": "../foo"}
-      }),
-      d.dir("lib", [
-        d.file(
-            "hello.dart",
-            """
+    var appHelloFile = d.file(
+        "hello.dart",
+        """
 import 'package:foo/foo.dart';
 
 hello() => message;
-""")
-      ]),
+""");
+    var appLibDir = d.dir("lib", [appHelloFile]);
+    var appDir = d.dir(appPath, [
+      d.appPubspec({
+        "foo": {"path": "../foo"}
+      }),
+      appLibDir,
       d.dir("web", [
         d.file(
             "main.dart",
@@ -45,10 +49,12 @@ void main() {
 }
 """)
       ])
-    ]).create();
+    ]);
+    await appDir.create();
 
     await pubGet();
     await pubServe(args: ['--web-compiler', 'dartdevc']);
+
     // Just confirm some basic things are present indicating that the module
     // was compiled. The goal here is not to test dartdevc itself.
     await requestShouldSucceed('web__main.js', contains('main'));
@@ -62,6 +68,41 @@ void main() {
         'packages/foo/lib__foo.js.map', contains('lib__foo.js'));
     await requestShould404('invalid.js');
     await requestShould404('packages/foo/invalid.js');
+
+    // Add a new file.
+    var srcDir = d.dir('src', [
+      d.file(
+          "world.dart",
+          """
+world() => "world";
+""")
+    ]);
+    await srcDir.create(p.join(d.sandbox, appDir.name, appLibDir.name));
+    // TODO(jakemac53): Better solution here, we need to give pub a bit of time
+    // to recognize the file change. See below as well.
+    await new Future.delayed(new Duration(seconds: 1));
+    await requestShouldSucceed(
+        'packages/myapp/lib__src__world.js', contains('world'));
+    await requestShouldSucceed('packages/myapp/lib__src__world.js.map',
+        contains('lib__src__world.js'));
+
+    // Edit existing file.
+    var helloFile = new File(
+        p.join(d.sandbox, appDir.name, appLibDir.name, appHelloFile.name));
+    assert(helloFile.existsSync());
+    await helloFile.writeAsString("""
+import "package:foo/foo.dart";
+import "src/world.dart";
+
+hello() => print(hello() + " " + world());
+""");
+    await new Future.delayed(new Duration(seconds: 1));
+    await requestShouldSucceed('packages/myapp/lib__hello.js',
+        allOf(contains('hello'), contains('world')));
+    await requestShouldSucceed(
+        'packages/myapp/lib__hello.js.map', contains('lib__hello.js'));
+    await requestShould404('packages/myapp/lib__src__world.js');
+
     await endPubServe();
   });
 


### PR DESCRIPTION
Previously the actual module configuration didn't get updated which means reorganizing your package could give weird errors :(. Unfortunately the bug report didn't come through until just before the stable 1.24 release but I will see what it takes to get this in a +1 release as people are definitely likely to run into it.