### PR TITLE
remove the require.js timeout for module loading

### DIFF
--- a/lib/src/dartdevc/dartdevc.dart
+++ b/lib/src/dartdevc/dartdevc.dart
@@ -201,7 +201,7 @@ for (let moduleName of Object.getOwnPropertyNames(modulePaths)) {
 }());
 
 require.config({
-    waitSeconds: 30,
+    waitSeconds: 0,
     paths: customModulePaths
 });
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/1644

We could make this configurable but I don't think there is much value in that.