### PR TITLE
Allow multiple dependencies from one package onto another

### DIFF
--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -118,7 +118,6 @@ class Pubspec {
     if (_dependencies != null) return _dependencies;
     _dependencies =
         _parseDependencies('dependencies', fields.nodes['dependencies']);
-    _checkDependencyOverlap(_dependencies, _devDependencies);
     return _dependencies;
   }
 
@@ -129,7 +128,6 @@ class Pubspec {
     if (_devDependencies != null) return _devDependencies;
     _devDependencies = _parseDependencies(
         'dev_dependencies', fields.nodes['dev_dependencies']);
-    _checkDependencyOverlap(_dependencies, _devDependencies);
     return _devDependencies;
   }
 
@@ -731,33 +729,6 @@ class Pubspec {
     }
 
     return name;
-  }
-
-  /// Makes sure the same package doesn't appear as both a regular and dev
-  /// dependency.
-  void _checkDependencyOverlap(
-      List<PackageRange> dependencies, List<PackageRange> devDependencies) {
-    if (dependencies == null) return;
-    if (devDependencies == null) return;
-
-    var dependencyNames = dependencies.map((dep) => dep.name).toSet();
-    var collisions = dependencyNames
-        .intersection(devDependencies.map((dep) => dep.name).toSet());
-    if (collisions.isEmpty) return;
-
-    var span = fields["dependencies"]
-        .nodes
-        .keys
-        .firstWhere((key) => collisions.contains(key.value))
-        .span;
-
-    // TODO(nweiz): associate source range info with PackageRanges and use it
-    // here.
-    _error(
-        '${pluralize('Package', collisions.length)} '
-        '${toSentence(collisions.map((package) => '"$package"'))} cannot '
-        'appear in both "dependencies" and "dev_dependencies".',
-        span);
   }
 
   /// Runs [fn] and wraps any [FormatException] it throws in a

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -180,23 +180,6 @@ dependencies:
       expect(foo.source, equals(sources['hosted']));
     });
 
-    test("throws if a package is in dependencies and dev_dependencies", () {
-      expectPubspecException(
-          '''
-dependencies:
-  foo:
-    mock: ok
-dev_dependencies:
-  foo:
-    mock: ok
-''', (pubspec) {
-        // This check only triggers if both [dependencies] and [devDependencies]
-        // are accessed.
-        pubspec.dependencies;
-        pubspec.devDependencies;
-      });
-    });
-
     test("throws if it dependes on itself", () {
       expectPubspecException(
           '''

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -288,7 +288,9 @@ void devDependency() {
   group("with both a dev and regular dependency", () {
     test("succeeds when both are satisfied", () async {
       await servePackages((builder) {
+        builder.serve('foo', '1.0.0');
         builder.serve('foo', '2.0.0');
+        builder.serve('foo', '3.0.0');
       });
 
       await d.dir(appPath, [
@@ -2153,7 +2155,7 @@ void features() {
           "dependencies": {
             'bar': {
               'version': '1.0.0',
-              'features': {'stuff': true}
+              'features': {'stuff': false}
             },
           },
           "features": {

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -284,6 +284,130 @@ void devDependency() {
     await d.appDir({'foo': '1.0.0'}).create();
     await expectResolves(result: {'foo': '1.0.0'});
   });
+
+  group("with both a dev and regular dependency", () {
+    test("succeeds when both are satisfied", () async {
+      await servePackages((builder) {
+        builder.serve('foo', '2.0.0');
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'dependencies': {'foo': '>=1.0.0 <3.0.0'},
+          'dev_dependencies': {'foo': '>=2.0.0 <4.0.0'}
+        })
+      ]).create();
+
+      await expectResolves(result: {'foo': '2.0.0'});
+    });
+
+    test("fails when main dependency isn't satisfied", () async {
+      await servePackages((builder) {
+        builder.serve('foo', '3.0.0');
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'dependencies': {'foo': '>=1.0.0 <3.0.0'},
+          'dev_dependencies': {'foo': '>=2.0.0 <4.0.0'}
+        })
+      ]).create();
+
+      await expectResolves(
+          error: "Package foo has no versions that match >=2.0.0 <3.0.0 "
+              "derived from:\n"
+              "- myapp depends on version >=1.0.0 <3.0.0\n"
+              "- myapp depends on version >=2.0.0 <4.0.0");
+    });
+
+    test("fails when dev dependency isn't satisfied", () async {
+      await servePackages((builder) {
+        builder.serve('foo', '1.0.0');
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'dependencies': {'foo': '>=1.0.0 <3.0.0'},
+          'dev_dependencies': {'foo': '>=2.0.0 <4.0.0'}
+        })
+      ]).create();
+
+      await expectResolves(
+          error: "Package foo has no versions that match >=2.0.0 <3.0.0 "
+              "derived from:\n"
+              "- myapp depends on version >=1.0.0 <3.0.0\n"
+              "- myapp depends on version >=2.0.0 <4.0.0");
+    });
+
+    test("fails when dev and main constraints are incompatible", () async {
+      await servePackages((builder) {
+        builder.serve('foo', '1.0.0');
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'dependencies': {'foo': '>=1.0.0 <2.0.0'},
+          'dev_dependencies': {'foo': '>=2.0.0 <3.0.0'}
+        })
+      ]).create();
+
+      await expectResolves(
+          error:
+              "Package foo has no versions that match <empty> derived from:\n"
+              "- myapp depends on version >=1.0.0 <2.0.0\n"
+              "- myapp depends on version >=2.0.0 <3.0.0");
+    });
+
+    test("fails when dev and main sources are incompatible", () async {
+      await servePackages((builder) {
+        builder.serve('foo', '1.0.0');
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'dependencies': {'foo': '>=1.0.0 <2.0.0'},
+          'dev_dependencies': {
+            'foo': {'path': '../foo'}
+          }
+        })
+      ]).create();
+
+      await expectResolves(
+          error: "Incompatible dependencies on foo:\n"
+              "- myapp depends on it from source hosted\n"
+              "- myapp depends on it from source path");
+    });
+
+    test("fails when dev and main descriptions are incompatible", () async {
+      await servePackages((builder) {
+        builder.serve('foo', '1.0.0');
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'dependencies': {
+            'foo': {'path': 'foo'}
+          },
+          'dev_dependencies': {
+            'foo': {'path': '../foo'}
+          }
+        })
+      ]).create();
+
+      await expectResolves(
+          error: 'Incompatible dependencies on foo:\n'
+              '- myapp depends on it with description '
+              '{"path":"foo","relative":true}\n'
+              '- myapp depends on it with description '
+              '{"path":"../foo","relative":true}');
+    });
+  });
 }
 
 void unsolvable() {
@@ -1976,6 +2100,94 @@ void features() {
             error: "Package foo feature stuff requires Flutter SDK version "
                 "^2.0.0 but the current SDK is 1.2.3.");
       });
+    });
+  });
+
+  group("with overlapping dependencies", () {
+    test("can enable extra features", () async {
+      await servePackages((builder) {
+        builder.serve('foo', '1.0.0', pubspec: {
+          "dependencies": {'bar': '1.0.0'},
+          "features": {
+            "stuff": {
+              "default": false,
+              "dependencies": {
+                'bar': {
+                  'features': {'stuff': true}
+                }
+              }
+            }
+          }
+        });
+
+        builder.serve('bar', '1.0.0', pubspec: {
+          "features": {
+            "stuff": {
+              "default": false,
+              "dependencies": {'baz': '1.0.0'}
+            }
+          }
+        });
+
+        builder.serve('baz', '1.0.0');
+      });
+
+      await d.appDir({
+        'foo': {'version': '1.0.0'}
+      }).create();
+      await expectResolves(result: {'foo': '1.0.0', 'bar': '1.0.0'});
+
+      await d.appDir({
+        'foo': {
+          'version': '1.0.0',
+          'features': {'stuff': true}
+        }
+      }).create();
+      await expectResolves(
+          result: {'foo': '1.0.0', 'bar': '1.0.0', 'baz': '1.0.0'});
+    });
+
+    test("can't disable features", () async {
+      await servePackages((builder) {
+        builder.serve('foo', '1.0.0', pubspec: {
+          "dependencies": {
+            'bar': {
+              'version': '1.0.0',
+              'features': {'stuff': true}
+            },
+          },
+          "features": {
+            "stuff": {
+              "default": false,
+              "dependencies": {
+                'bar': {
+                  'features': {'stuff': true}
+                }
+              }
+            }
+          }
+        });
+
+        builder.serve('bar', '1.0.0', pubspec: {
+          "features": {
+            "stuff": {
+              "default": true,
+              "dependencies": {'baz': '1.0.0'}
+            }
+          }
+        });
+
+        builder.serve('baz', '1.0.0');
+      });
+
+      await d.appDir({
+        'foo': {
+          'version': '1.0.0',
+          'features': {'stuff': true}
+        }
+      }).create();
+      await expectResolves(
+          result: {'foo': '1.0.0', 'bar': '1.0.0', 'baz': '1.0.0'});
     });
   });
 }


### PR DESCRIPTION
Enabling multiple dependencies is necessary for some use-cases for
issue #1593 like having a package expose a feature that enables a
feature in a dependency, or having a package expose a "testing"
feature and also depend on test from its dev dependencies.

For consistency with features, this also removes the restriction that
a pubspec may not have a normal and dev dependency on the same
package.