### PR TITLE
Add a default SDK constraint

### DIFF
--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -456,7 +456,8 @@ dependencies:
     group("environment", () {
       test("allows an omitted environment", () {
         var pubspec = new Pubspec.parse('', sources);
-        expect(pubspec.dartSdkConstraint, equals(VersionConstraint.any));
+        expect(pubspec.dartSdkConstraint,
+            equals(new VersionConstraint.parse("<2.0.0-dev.infinity")));
         expect(pubspec.flutterSdkConstraint, isNull);
       });
 

--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -436,7 +436,7 @@ main() {
           d.libPubspec("integration_pkg", "1.0.0", deps: {"foo": "^1.2.3"})
         ]).create();
 
-        expectDependencyValidationError('  sdk: ">=1.8.0 <2.0.0"');
+        expectDependencyValidationError('  sdk: ">=1.8.0 <2.0.0-dev.infinity"');
       });
 
       test("with a too-broad SDK constraint", () async {
@@ -461,7 +461,8 @@ main() {
 
         expect(
             validatePackage(dependency),
-            completion(pairOf(anyElement(contains('  sdk: ">=1.25.0 <2.0.0"')),
+            completion(pairOf(
+                anyElement(contains('  sdk: ">=1.25.0 <2.0.0-dev.infinity"')),
                 anyElement(contains('  foo: any')))));
       });
 

--- a/test/validator/sdk_constraint_test.dart
+++ b/test/validator/sdk_constraint_test.dart
@@ -68,9 +68,7 @@ main() {
               pairOf(anyElement(contains('">=1.19.0 <1.50.0"')), isEmpty)));
     });
 
-    test(
-        "has a Flutter SDK constraint with no SDK "
-        "constraint", () async {
+    test("has a Flutter SDK constraint with no SDK constraint", () async {
       await d.dir(appPath, [
         d.pubspec({
           "name": "test_pkg",
@@ -80,8 +78,9 @@ main() {
       ]).create();
       expect(
           validatePackage(sdkConstraint),
-          completion(
-              pairOf(anyElement(contains('">=1.19.0 <2.0.0"')), isEmpty)));
+          completion(pairOf(
+              anyElement(contains('">=1.19.0 <2.0.0-dev.infinity"')),
+              isEmpty)));
     });
   });
 }

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -892,6 +892,26 @@ void dartSdkConstraint() {
     await d.appDir({'foo': 'any'}).create();
     await expectResolves(result: {'foo': '2.0.0', 'bar': '2.0.0'}, tries: 3);
   });
+
+  test('allows 2.0.0-dev by default', () async {
+    await d.dir(appPath, [
+      await d.pubspec({'name': 'myapp'})
+    ]).create();
+
+    await expectResolves(
+        environment: {'_PUB_TEST_SDK_VERSION': '2.0.0-dev.99'}, result: {});
+  });
+
+  test('disallows 2.0.0 by default', () async {
+    await d.dir(appPath, [
+      await d.pubspec({'name': 'myapp'})
+    ]).create();
+
+    await expectResolves(
+        environment: {'_PUB_TEST_SDK_VERSION': '2.0.0'},
+        error: 'Package myapp requires SDK version <2.0.0-dev.infinity but the '
+            'current SDK is 2.0.0.');
+  });
 }
 
 void flutterSdkConstraint() {


### PR DESCRIPTION
Packages that don't declare an SDK constraint will now be considered
compatible with SDK versions matching <2.0.0-dev.infinity.

Closes #1657