### PR TITLE
Revert "Set the content type during publish to application/gzip (#1671)"

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:http/http.dart' as http;
-import 'package:http_parser/http_parser.dart' as http_parser;
 
 import '../ascii_tree.dart' as tree;
 import '../command.dart';
@@ -88,9 +87,7 @@ class LishCommand extends PubCommand {
           request.followRedirects = false;
           request.files.add(new http.MultipartFile.fromBytes(
               'file', packageBytes,
-              filename: 'package.tar.gz',
-              contentType: new http_parser.MediaType('application', 'gzip')));
-
+              filename: 'package.tar.gz'));
           var postResponse =
               await http.Response.fromStream(await client.send(request));
 


### PR DESCRIPTION
This reverts commit 3e4890f1e45e94ae7bad416cda7b5632bf67275a.

Does not fix https://github.com/dart-lang/pub/issues/1666
Tracking internally here http://b/63855519