### PR TITLE
Allow including script tags pointing to subdirs with dartdevc

### DIFF
--- a/lib/src/dartdevc/dartdevc.dart
+++ b/lib/src/dartdevc/dartdevc.dart
@@ -238,25 +238,28 @@ require(["$appModulePath", "dart_sdk"], function(app, dart_sdk) {
     var bootstrapModuleName = p.withoutExtension(
         p.relative(bootstrapId.path, from: p.dirname(dartEntrypointId.path)));
     var entrypointJsContent = new StringBuffer('''
-var el;
+(function() {
+  $_currentDirectoryScript
+  var el;
 ''');
     if (isDebug) {
       entrypointJsContent.write('''
-el = document.createElement("script");
-el.defer = true;
-el.async = false;
-el.src = "dart_stack_trace_mapper.js";
-document.head.appendChild(el);
+  el = document.createElement("script");
+  el.defer = true;
+  el.async = false;
+  el.src = "dart_stack_trace_mapper.js";
+  document.head.appendChild(el);
 ''');
     }
 
     entrypointJsContent.write('''
-el = document.createElement("script");
-el.defer = true;
-el.async = false;
-el.src = "require.js";
-el.setAttribute("data-main", "$bootstrapModuleName");
-document.head.appendChild(el);
+  el = document.createElement("script");
+  el.defer = true;
+  el.async = false;
+  el.src = "require.js";
+  el.setAttribute("data-main", _currentDirectory + "$bootstrapModuleName");
+  document.head.appendChild(el);
+})();
 ''');
     outputCompleters[jsEntrypointId].complete(
         new Asset.fromString(jsEntrypointId, entrypointJsContent.toString()));


### PR DESCRIPTION
Fixes https://github.com/dart-lang/sdk/issues/30246

Note that there is no sane way I know of to actually write an e2e test for this because package:test requires the html file to have the same name as the dart file but with the .html extension.... :(