### PR TITLE
Add default upper bound Dart SDK constraint override from 2.0.0 -> 2.0.0-dev.infinity

### DIFF
--- a/lib/src/cached_package.dart
+++ b/lib/src/cached_package.dart
@@ -87,6 +87,9 @@ class _CachedPubspec implements Pubspec {
   List<PackageRange> get dependencyOverrides => _inner.dependencyOverrides;
   Map<String, Feature> get features => _inner.features;
   VersionConstraint get dartSdkConstraint => _inner.dartSdkConstraint;
+  VersionConstraint get originalDartSdkConstraint =>
+      _inner.originalDartSdkConstraint;
+  bool get dartSdkWasOverridden => _inner.dartSdkWasOverridden;
   VersionConstraint get flutterSdkConstraint => _inner.flutterSdkConstraint;
   String get publishTo => _inner.publishTo;
   Map<String, String> get executables => _inner.executables;

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -22,6 +22,7 @@ import 'log.dart' as log;
 import 'package.dart';
 import 'package_name.dart';
 import 'package_graph.dart';
+import 'pubspec.dart';
 import 'sdk.dart' as sdk;
 import 'solver/version_solver.dart';
 import 'source/cached.dart';
@@ -193,6 +194,23 @@ class Entrypoint {
       bool packagesDir: false}) async {
     var result = await resolveVersions(type, cache, root,
         lockFile: lockFile, useLatest: useLatest);
+
+    // Log once about all overridden packages.
+    if (warnAboutPreReleaseTwoDotZeroSdkOverrides && result.pubspecs != null) {
+      var overriddenPackages = result.pubspecs.values
+          .where((pubspec) => pubspec.dartSdkWasOverridden)
+          .map((pubspec) => pubspec.name)
+          .join(', ');
+      if (overriddenPackages.isNotEmpty) {
+        log.message(log.yellow(
+            'Overriding Dart SDK constraint from <2.0.0 to <2.0.0-dev.infinity'
+            ' for the following packages:\n\n$overriddenPackages\n\n'
+            'To disable this you can set the PUB_ALLOW_PRERELEASE_SDK system '
+            'environment variable to `false`, or you can silence this message '
+            'by setting it to `quiet`.'));
+      }
+    }
+
     if (!result.succeeded) throw result.error;
 
     result.showReport(type);

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -197,14 +197,16 @@ class Entrypoint {
 
     // Log once about all overridden packages.
     if (warnAboutPreReleaseTwoDotZeroSdkOverrides && result.pubspecs != null) {
-      var overriddenPackages = result.pubspecs.values
-          .where((pubspec) => pubspec.dartSdkWasOverridden)
-          .map((pubspec) => pubspec.name)
+      var overriddenPackages = (result.pubspecs.values
+              .where((pubspec) => pubspec.dartSdkWasOverridden)
+              .map((pubspec) => pubspec.name)
+              .toList()
+                ..sort())
           .join(', ');
       if (overriddenPackages.isNotEmpty) {
         log.message(log.yellow(
             'Overriding Dart SDK constraint from <2.0.0 to <2.0.0-dev.infinity'
-            ' for the following packages:\n\n$overriddenPackages\n\n'
+            ' for the following packages:\n\n${overriddenPackages}\n\n'
             'To disable this you can set the PUB_ALLOW_PRERELEASE_SDK system '
             'environment variable to `false`, or you can silence this message '
             'by setting it to `quiet`.'));

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -14,6 +14,7 @@ import 'compiler.dart';
 import 'exceptions.dart';
 import 'feature.dart';
 import 'io.dart';
+import 'log.dart';
 import 'package_name.dart';
 import 'source_registry.dart';
 import 'utils.dart';
@@ -29,13 +30,53 @@ final _packageName = new RegExp(
 /// The default SDK upper bound constraint for packages that don't declare one.
 ///
 /// This provides a sane default for packages that don't have an upper bound.
-final _defaultUpperBoundSdkConstraint = new VersionConstraint.parse("<2.0.0");
+final VersionRange _defaultUpperBoundSdkConstraint =
+    new VersionConstraint.parse("<2.0.0");
+
+/// The upper bound contraint that matches the dev sdk.
+final _preReleaseTwoDotZeroSdkVersion = new Version.parse("2.0.0-dev.infinity");
+
+/// Whether or not to allow the pre-release sdk for packages that have an
+/// upper bound Dart SDK constraint of <2.0.0.
+///
+/// If enabled then a Dart SDK upper bound of <2.0.0 is always converted to
+/// <2.0.0-dev.infinity.
+///
+/// This has a default value of `true` but can be overridden with the
+/// PUB_ALLOW_PRERELEASE_SDK system environment variable.
+final bool allowPreReleaseTwoDotZeroSdk = () {
+  var userSetting =
+      Platform.environment["PUB_ALLOW_PRERELEASE_SDK"]?.toLowerCase() ?? 'true';
+  switch (userSetting) {
+    case "true":
+      return true;
+      break;
+    case "quiet":
+      warnAboutPreReleaseTwoDotZeroSdkOverrides = false;
+      return true;
+      break;
+    case "false":
+      return false;
+      break;
+    default:
+      warning(yellow('''
+The environment variable PUB_ALLOW_PRERELEASE_SDK is set as `$userSetting`.
+The expected value is either `true`, `quiet` (true but no logging), or `false`.
+Using a default value of `true`.
+'''));
+      return true;
+  }
+}();
+
+/// Whether or not to warn about pre-release sdk overrides.
+bool warnAboutPreReleaseTwoDotZeroSdkOverrides = true;
 
 /// Whether or not `features` are enabled.
 ///
 /// This can be overridden manually or by setting the ENABLE_PUB_FEATURES
 /// environment variable to "true".
-bool featuresEnabled = Platform.environment["ENABLE_PUB_FEATURES"] != "true";
+bool featuresEnabled =
+    Platform.environment["ENABLE_PUB_FEATURES"]?.toLowerCase() != "true";
 
 /// The parsed contents of a pubspec file.
 ///
@@ -68,7 +109,12 @@ class Pubspec {
 
   /// Whether or not to apply the [_defaultUpperBoundsSdkConstraint] to this
   /// pubspec.
-  bool _includeDefaultSdkConstraint;
+  final bool _includeDefaultSdkConstraint;
+
+  /// Whether or not the sdk version was overridden from <2.0.0 to
+  /// <2.0.0-dev.infinity.
+  bool get dartSdkWasOverridden => _dartSdkWasOverridden;
+  bool _dartSdkWasOverridden = false;
 
   /// The package's name.
   String get name {
@@ -300,12 +346,24 @@ class Pubspec {
 
   /// The constraint on the Dart SDK, with [_defaultUpperBoundSdkConstraint] if
   /// none is specified.
+  ///
+  /// This also includes the pre-release override if
+  /// [allowPreReleaseTwoDotZeroSdk] is `true`.
   VersionConstraint get dartSdkConstraint {
     _ensureEnvironment();
     return _dartSdkConstraint;
   }
 
   VersionConstraint _dartSdkConstraint;
+
+  /// The original Dart SDK constraint, if [dartSdkWasOverridden] is `true`,
+  /// otherwise this will be identical to [dartSdkConstraint].
+  VersionConstraint get originalDartSdkConstraint {
+    _ensureEnvironment();
+    return _originalDartSdkConstraint ?? dartSdkConstraint;
+  }
+
+  VersionConstraint _originalDartSdkConstraint;
 
   /// The constraint on the Flutter SDK, or `null` if none is specified.
   VersionConstraint get flutterSdkConstraint {
@@ -321,7 +379,23 @@ class Pubspec {
     if (_dartSdkConstraint != null) return;
 
     var pair = _parseEnvironment(fields);
-    _dartSdkConstraint = pair.first;
+    var parsedDartSdkConstraint = pair.first;
+
+    if (allowPreReleaseTwoDotZeroSdk &&
+        parsedDartSdkConstraint is VersionRange &&
+        parsedDartSdkConstraint.max == _defaultUpperBoundSdkConstraint.max &&
+        !parsedDartSdkConstraint.includeMax) {
+      _originalDartSdkConstraint = parsedDartSdkConstraint;
+      _dartSdkWasOverridden = true;
+      _dartSdkConstraint = new VersionRange(
+          min: parsedDartSdkConstraint.min,
+          includeMin: parsedDartSdkConstraint.includeMin,
+          max: _preReleaseTwoDotZeroSdkVersion,
+          includeMax: false);
+    } else {
+      _dartSdkConstraint = parsedDartSdkConstraint;
+    }
+
     _flutterSdkConstraint = pair.last;
   }
 

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -33,10 +33,10 @@ final _packageName = new RegExp(
 final VersionRange _defaultUpperBoundSdkConstraint =
     new VersionConstraint.parse("<2.0.0");
 
-/// The upper bound contraint that matches the dev sdk.
+/// The upper bound contraint that matches the dev SDK.
 final _preReleaseTwoDotZeroSdkVersion = new Version.parse("2.0.0-dev.infinity");
 
-/// Whether or not to allow the pre-release sdk for packages that have an
+/// Whether or not to allow the pre-release SDK for packages that have an
 /// upper bound Dart SDK constraint of <2.0.0.
 ///
 /// If enabled then a Dart SDK upper bound of <2.0.0 is always converted to
@@ -44,32 +44,27 @@ final _preReleaseTwoDotZeroSdkVersion = new Version.parse("2.0.0-dev.infinity");
 ///
 /// This has a default value of `true` but can be overridden with the
 /// PUB_ALLOW_PRERELEASE_SDK system environment variable.
-final bool allowPreReleaseTwoDotZeroSdk = () {
-  var userSetting =
+bool get allowPreReleaseTwoDotZeroSdk => allowPreReleaseSdkValue != 'false';
+
+/// The value of the PUB_ALLOW_PRERELEASE_SDK environment variable, defaulted
+/// to `true`.
+final String allowPreReleaseSdkValue = () {
+  var value =
       Platform.environment["PUB_ALLOW_PRERELEASE_SDK"]?.toLowerCase() ?? 'true';
-  switch (userSetting) {
-    case "true":
-      return true;
-      break;
-    case "quiet":
-      warnAboutPreReleaseTwoDotZeroSdkOverrides = false;
-      return true;
-      break;
-    case "false":
-      return false;
-      break;
-    default:
-      warning(yellow('''
-The environment variable PUB_ALLOW_PRERELEASE_SDK is set as `$userSetting`.
+  if (!['true', 'quiet', 'false'].contains(value)) {
+    warning(yellow('''
+The environment variable PUB_ALLOW_PRERELEASE_SDK is set as `$value`.
 The expected value is either `true`, `quiet` (true but no logging), or `false`.
 Using a default value of `true`.
 '''));
-      return true;
+    value = 'true';
   }
+  return value;
 }();
 
-/// Whether or not to warn about pre-release sdk overrides.
-bool warnAboutPreReleaseTwoDotZeroSdkOverrides = true;
+/// Whether or not to warn about pre-release SDK overrides.
+bool get warnAboutPreReleaseTwoDotZeroSdkOverrides =>
+    allowPreReleaseSdkValue != 'quiet';
 
 /// Whether or not `features` are enabled.
 ///
@@ -111,7 +106,7 @@ class Pubspec {
   /// pubspec.
   final bool _includeDefaultSdkConstraint;
 
-  /// Whether or not the sdk version was overridden from <2.0.0 to
+  /// Whether or not the SDK version was overridden from <2.0.0 to
   /// <2.0.0-dev.infinity.
   bool get dartSdkWasOverridden => _dartSdkWasOverridden;
   bool _dartSdkWasOverridden = false;

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -57,7 +57,7 @@ abstract class Validator {
   void validateSdkConstraint(Version firstSdkVersion, String message) {
     // If the SDK constraint disallowed all versions before [firstSdkVersion],
     // no error is necessary.
-    if (entrypoint.root.pubspec.dartSdkConstraint
+    if (entrypoint.root.pubspec.originalDartSdkConstraint
         .intersect(new VersionRange(max: firstSdkVersion))
         .isEmpty) {
       return;
@@ -78,8 +78,8 @@ abstract class Validator {
         includeMin: allowedSdks.includeMin,
         includeMax: allowedSdks.includeMax);
 
-    var newSdkConstraint =
-        entrypoint.root.pubspec.dartSdkConstraint.intersect(allowedSdks);
+    var newSdkConstraint = entrypoint.root.pubspec.originalDartSdkConstraint
+        .intersect(allowedSdks);
     if (newSdkConstraint.isEmpty) newSdkConstraint = allowedSdks;
 
     errors.add("$message\n"

--- a/lib/src/validator/sdk_constraint.dart
+++ b/lib/src/validator/sdk_constraint.dart
@@ -19,7 +19,7 @@ class SdkConstraintValidator extends Validator {
   SdkConstraintValidator(Entrypoint entrypoint) : super(entrypoint);
 
   Future validate() async {
-    var dartConstraint = entrypoint.root.pubspec.dartSdkConstraint;
+    var dartConstraint = entrypoint.root.pubspec.originalDartSdkConstraint;
     if (dartConstraint is VersionRange) {
       if (dartConstraint.toString().startsWith("^")) {
         errors.add(

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -444,9 +444,9 @@ dependencies:
 
     group("environment", () {
       test("allows an omitted environment", () {
-        var pubspec = new Pubspec.parse('', sources);
+        var pubspec = new Pubspec.parse('name: testing', sources);
         expect(pubspec.dartSdkConstraint,
-            equals(new VersionConstraint.parse("<2.0.0")));
+            equals(new VersionConstraint.parse("<2.0.0-dev.infinity")));
         expect(pubspec.flutterSdkConstraint, isNull);
       });
 
@@ -459,11 +459,12 @@ dependencies:
 
       test("defaults the upper constraint for the sdk", () {
         var pubspec = new Pubspec.parse('''
+  name: test
   environment:
     sdk: ">1.0.0"
   ''', sources);
         expect(pubspec.dartSdkConstraint,
-            equals(new VersionConstraint.parse(">1.0.0 <2.0.0")));
+            equals(new VersionConstraint.parse(">1.0.0 <2.0.0-dev.infinity")));
         expect(pubspec.flutterSdkConstraint, isNull);
       });
 

--- a/test/upgrade/report/describes_change_test.dart
+++ b/test/upgrade/report/describes_change_test.dart
@@ -56,6 +56,6 @@ Resolving dependencies\.\.\..*
 . source_changed 2\.0\.0 from path \.\.[/\\]source_changed \(was 1\.0\.0\)
 . unchanged 1\.0\.0
 . version_changed 2\.0\.0 \(was 1\.0\.0\)
-""", multiLine: true));
+""", multiLine: true), environment: {'PUB_ALLOW_PRERELEASE_SDK': 'false'});
   });
 }

--- a/test/upgrade/report/does_not_show_newer_versions_for_locked_packages_test.dart
+++ b/test/upgrade/report/does_not_show_newer_versions_for_locked_packages_test.dart
@@ -33,6 +33,6 @@ main() {
 Resolving dependencies\.\.\..*
   not_upgraded 1\.0\.0
 . upgraded 2\.0\.0 \(was 1\.0\.0\) \(3\.0\.0-dev available\)
-""", multiLine: true));
+""", multiLine: true), environment: {'PUB_ALLOW_PRERELEASE_SDK': 'false'});
   });
 }

--- a/test/upgrade/report/leading_character_shows_change_test.dart
+++ b/test/upgrade/report/leading_character_shows_change_test.dart
@@ -82,6 +82,6 @@ Resolving dependencies\.\.\..*
 > upgraded .*
 These packages are no longer being depended on:
 - removed .*
-""", multiLine: true));
+""", multiLine: true), environment: {'PUB_ALLOW_PRERELEASE_SDK': 'false'});
   });
 }

--- a/test/upgrade/report/shows_newer_available_versions_test.dart
+++ b/test/upgrade/report/shows_newer_available_versions_test.dart
@@ -46,6 +46,6 @@ Resolving dependencies\.\.\..*
 . no_newer 1\.0\.0
 . one_newer_stable 1\.0\.0 \(1\.0\.1 available\)
 . one_newer_unstable 1\.0\.0 \(1\.0\.1-unstable\.1 available\)
-""", multiLine: true));
+""", multiLine: true), environment: {'PUB_ALLOW_PRERELEASE_SDK': 'false'});
   });
 }

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -1062,14 +1062,14 @@ void dartSdkConstraint() {
       environment: {'_PUB_TEST_SDK_VERSION': '2.0.0-dev.99'},
       // Log output should mention the PUB_ALLOW_RELEASE_SDK environment
       // variable and mention the foo and bar packages specifically.
-      output: allOf(contains('PUB_ALLOW_PRERELEASE_SDK'),
-          anyOf(contains('foo, bar'), contains('bar, foo'))),
+      output: allOf(
+          contains('PUB_ALLOW_PRERELEASE_SDK'), anyOf(contains('bar, foo'))),
     );
   });
 
   test(
-      'pub doesn\'t log about pre-release sdk overrides if '
-      'PUB_ALLOW_PRERELEASE_SDK=quiet', () async {
+      "pub doesn't log about pre-release sdk overrides if "
+      "PUB_ALLOW_PRERELEASE_SDK=quiet", () async {
     await d.dir('foo', [
       await d.pubspec({'name': 'foo'})
     ]).create();


### PR DESCRIPTION
Also introduces the PUB_ALLOW_PRERELEASE_SDK environment variable which can override this behavior. Valid values are `true` (default), `false`, and `quiet` (true but no log message about the override).

Fixes https://github.com/dart-lang/pub/issues/1692