### PR TITLE
log red on server errors when publishing, or green on success

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -103,7 +103,7 @@ class LishCommand extends PubCommand {
         // TODO(nweiz): the response may have XML-formatted information about
         // the error. Try to parse that out once we have an easily-accessible
         // XML parser.
-        fail('Failed to upload the package.');
+        fail(log.red('Failed to upload the package.'));
       } else if (urisEqual(Uri.parse(url.origin), Uri.parse(server.origin))) {
         handleJsonError(error.response);
       } else {

--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -240,7 +240,7 @@ void handleJsonSuccess(http.Response response) {
       parsed['success']['message'] is! String) {
     invalidServerResponse(response);
   }
-  log.message(parsed['success']['message']);
+  log.message(log.green(parsed['success']['message']));
 }
 
 /// Handles an unsuccessful JSON-formatted response from pub.dartlang.org.
@@ -255,7 +255,7 @@ void handleJsonError(http.Response response) {
       errorMap['error']['message'] is! String) {
     invalidServerResponse(response);
   }
-  fail(errorMap['error']['message']);
+  fail(log.red(errorMap['error']['message']));
 }
 
 /// Parses a response body, assuming it's JSON-formatted.
@@ -275,7 +275,7 @@ Map parseJsonResponse(http.Response response) {
 
 /// Throws an error describing an invalid response from the server.
 void invalidServerResponse(http.Response response) =>
-    fail('Invalid server response:\n${response.body}');
+    fail(log.red('Invalid server response:\n${response.body}'));
 
 /// Exception thrown when an HTTP operation fails.
 class PubHttpException implements Exception {


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/1706

Validated manually that this works, but I don't think its worth figuring out how to write a real test. In the test runner its not hooked into a console so the log colors don't do anything.

cc @kevmoo 