### PR TITLE
add back dart:io import to pubspec.dart

### DIFF
--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as path;

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -1,6 +1,7 @@
 // Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 
 import 'package:collection/collection.dart';


### PR DESCRIPTION
Looks like the features env variable revert removed a dart:io import which was relied upon by a susequent change. 