### PR TITLE
Fix a bug that only showed up in checked mode

### DIFF
--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -16,7 +16,8 @@ class Compiler {
 
   static final all = [dart2JS, dartDevc, none];
 
-  static Iterable<String> get names => all.map((compiler) => compiler.name);
+  static List<String> get names =>
+      all.map((compiler) => compiler.name).toList();
 
   final String name;
 


### PR DESCRIPTION
We were passing an Iterable in place of a List, but an implicit cast
was hiding it from analysis and it worked in practice in unchecked
mode.