### PR TITLE
Represent Pubspec.dependencies as a map

### DIFF
--- a/lib/src/barback/dependency_computer.dart
+++ b/lib/src/barback/dependency_computer.dart
@@ -194,7 +194,7 @@ class DependencyComputer {
               packageName == _graph.entrypoint.root.name
           ? package.immediateDependencies
           : package.dependencies;
-      for (var dep in dependencies) {
+      for (var dep in dependencies.values) {
         try {
           traversePackage(dep.name);
         } on CycleException catch (error) {
@@ -355,7 +355,7 @@ class _PackageDependencyComputer {
         return _applicableTransformers
             .map((config) => config.id)
             .toSet()
-            .union(unionAll(dependencies.map((dep) {
+            .union(unionAll(dependencies.values.map((dep) {
           try {
             return _dependencyComputer._transformersNeededByPackage(dep.name);
           } on CycleException catch (error) {

--- a/lib/src/cached_package.dart
+++ b/lib/src/cached_package.dart
@@ -82,9 +82,9 @@ class _CachedPubspec implements Pubspec {
   YamlMap get fields => _inner.fields;
   String get name => _inner.name;
   Version get version => _inner.version;
-  List<PackageRange> get dependencies => _inner.dependencies;
-  List<PackageRange> get devDependencies => _inner.devDependencies;
-  List<PackageRange> get dependencyOverrides => _inner.dependencyOverrides;
+  Map<String, PackageRange> get dependencies => _inner.dependencies;
+  Map<String, PackageRange> get devDependencies => _inner.devDependencies;
+  Map<String, PackageRange> get dependencyOverrides => _inner.dependencyOverrides;
   Map<String, Feature> get features => _inner.features;
   VersionConstraint get dartSdkConstraint => _inner.dartSdkConstraint;
   VersionConstraint get originalDartSdkConstraint =>

--- a/lib/src/cached_package.dart
+++ b/lib/src/cached_package.dart
@@ -84,7 +84,8 @@ class _CachedPubspec implements Pubspec {
   Version get version => _inner.version;
   Map<String, PackageRange> get dependencies => _inner.dependencies;
   Map<String, PackageRange> get devDependencies => _inner.devDependencies;
-  Map<String, PackageRange> get dependencyOverrides => _inner.dependencyOverrides;
+  Map<String, PackageRange> get dependencyOverrides =>
+      _inner.dependencyOverrides;
   Map<String, Feature> get features => _inner.features;
   VersionConstraint get dartSdkConstraint => _inner.dartSdkConstraint;
   VersionConstraint get originalDartSdkConstraint =>

--- a/lib/src/command/build.dart
+++ b/lib/src/command/build.dart
@@ -223,8 +223,8 @@ class BuildCommand extends BarbackCommand {
   /// directories next to each entrypoint in [entrypoints].
   Future _copyBrowserJsFiles(Iterable<AssetId> entrypoints, AssetSet assets) {
     // Must depend on the browser package.
-    if (!entrypoint.root.immediateDependencies
-        .any((dep) => dep.name == 'browser' && dep.source is HostedSource)) {
+    var browser = entrypoint.root.immediateDependencies['browser'];
+    if (browser == null || browser.source is! HostedSource) {
       return new Future.value();
     }
 

--- a/lib/src/command/deps.dart
+++ b/lib/src/command/deps.dart
@@ -90,14 +90,12 @@ class DepsCommand extends PubCommand {
   /// line.
   void _outputCompact() {
     var root = entrypoint.root;
-    _outputCompactPackages(
-        "dependencies", root.dependencies.keys);
+    _outputCompactPackages("dependencies", root.dependencies.keys);
     if (_includeDev) {
-      _outputCompactPackages(
-          "dev dependencies", root.devDependencies.keys);
+      _outputCompactPackages("dev dependencies", root.devDependencies.keys);
     }
-    _outputCompactPackages("dependency overrides",
-        root.dependencyOverrides.keys);
+    _outputCompactPackages(
+        "dependency overrides", root.dependencyOverrides.keys);
 
     var transitive = _getTransitiveDependencies();
     _outputCompactPackages("transitive dependencies", transitive);
@@ -130,14 +128,11 @@ class DepsCommand extends PubCommand {
   /// shown.
   void _outputList() {
     var root = entrypoint.root;
-    _outputListSection(
-        "dependencies", root.dependencies.keys);
+    _outputListSection("dependencies", root.dependencies.keys);
     if (_includeDev) {
-      _outputListSection(
-          "dev dependencies", root.devDependencies.keys);
+      _outputListSection("dev dependencies", root.devDependencies.keys);
     }
-    _outputListSection("dependency overrides",
-        root.dependencyOverrides.keys);
+    _outputListSection("dependency overrides", root.dependencyOverrides.keys);
 
     var transitive = _getTransitiveDependencies();
     if (transitive.isEmpty) return;
@@ -178,7 +173,8 @@ class DepsCommand extends PubCommand {
 
     // Start with the root dependencies.
     var packageTree = <String, Map>{};
-    var immediateDependencies = entrypoint.root.immediateDependencies.keys.toSet();
+    var immediateDependencies =
+        entrypoint.root.immediateDependencies.keys.toSet();
     if (!_includeDev) {
       immediateDependencies.removeAll(entrypoint.root.devDependencies.keys);
     }
@@ -233,8 +229,7 @@ class DepsCommand extends PubCommand {
     var nonDevDependencies = entrypoint.root.dependencies.keys.toList()
       ..addAll(entrypoint.root.dependencyOverrides.keys);
     return nonDevDependencies
-        .expand(
-            (name) => entrypoint.packageGraph.transitiveDependencies(name))
+        .expand((name) => entrypoint.packageGraph.transitiveDependencies(name))
         .map((package) => package.name)
         .toSet();
   }
@@ -259,7 +254,8 @@ class DepsCommand extends PubCommand {
       ..add(entrypoint.root)
       ..addAll((_includeDev
               ? entrypoint.root.immediateDependencies
-              : entrypoint.root.dependencies).keys
+              : entrypoint.root.dependencies)
+          .keys
           .map((name) => entrypoint.packageGraph.packages[name]));
 
     for (var package in packages) {

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -373,8 +373,7 @@ class Entrypoint {
   Future precompileExecutables({Iterable<String> changed}) async {
     _deleteExecutableSnapshots(changed: changed);
 
-    var executables = mapMap(
-        root.immediateDependencies,
+    var executables = mapMap(root.immediateDependencies,
         value: (name, _) => _executablesForPackage(name));
 
     for (var package in executables.keys.toList()) {

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:barback/barback.dart';
+import 'package:collection/collection.dart';
 import 'package:package_config/packages_file.dart' as packages_file;
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
@@ -372,10 +373,9 @@ class Entrypoint {
   Future precompileExecutables({Iterable<String> changed}) async {
     _deleteExecutableSnapshots(changed: changed);
 
-    var executables = new Map<String, List<AssetId>>.fromIterable(
+    var executables = mapMap(
         root.immediateDependencies,
-        key: (dep) => dep.name,
-        value: (dep) => _executablesForPackage(dep.name));
+        value: (name, _) => _executablesForPackage(name));
 
     for (var package in executables.keys.toList()) {
       if (executables[package].isEmpty) executables.remove(package);
@@ -609,12 +609,12 @@ class Entrypoint {
   /// or that don't match what's in there, this will throw a [DataError]
   /// describing the issue.
   void _assertLockFileUpToDate() {
-    if (!root.immediateDependencies.every(_isDependencyUpToDate)) {
+    if (!root.immediateDependencies.values.every(_isDependencyUpToDate)) {
       dataError('The pubspec.yaml file has changed since the pubspec.lock '
           'file was generated, please run "pub get" again.');
     }
 
-    var overrides = root.dependencyOverrides.map((dep) => dep.name).toSet();
+    var overrides = new MapKeySet(root.dependencyOverrides);
 
     // Check that uncached dependencies' pubspecs are also still satisfied,
     // since they're mutable and may have changed since the last get.
@@ -623,7 +623,7 @@ class Entrypoint {
       if (source is CachedSource) continue;
 
       try {
-        if (cache.load(id).dependencies.every((dep) =>
+        if (cache.load(id).dependencies.values.every((dep) =>
             overrides.contains(dep.name) || _isDependencyUpToDate(dep))) {
           continue;
         }

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -39,8 +39,7 @@ Future<int> runExecutable(Entrypoint entrypoint, String package,
   // Make sure the package is an immediate dependency of the entrypoint or the
   // entrypoint itself.
   if (entrypoint.root.name != package &&
-      !entrypoint.root.immediateDependencies
-          .any((dep) => dep.name == package)) {
+      !entrypoint.root.immediateDependencies.containsKey(package)) {
     if (entrypoint.packageGraph.packages.containsKey(package)) {
       dataError('Package "$package" is not an immediate dependency.\n'
           'Cannot run executables in transitive dependencies.');

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -55,15 +55,18 @@ class Package {
   Map<String, PackageRange> get devDependencies => pubspec.devDependencies;
 
   /// The dependency overrides this package specifies in its pubspec.
-  Map<String, PackageRange> get dependencyOverrides => pubspec.dependencyOverrides;
+  Map<String, PackageRange> get dependencyOverrides =>
+      pubspec.dependencyOverrides;
 
   /// All immediate dependencies this package specifies.
   ///
   /// This includes regular, dev dependencies, and overrides.
   Map<String, PackageRange> get immediateDependencies {
-    return {}..addAll(dependencies)..addAll(devDependencies)
-    // Make sure to add these last so they replace normal dependencies.
-    ..addAll(dependencyOverrides);
+    // Make sure to add overrides last so they replace normal dependencies.
+    return {}
+      ..addAll(dependencies)
+      ..addAll(devDependencies)
+      ..addAll(dependencyOverrides);
   }
 
   /// Returns a list of asset ids for all Dart executables in this package's bin

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -49,31 +49,21 @@ class Package {
   final Pubspec pubspec;
 
   /// The immediate dependencies this package specifies in its pubspec.
-  List<PackageRange> get dependencies => pubspec.dependencies;
+  Map<String, PackageRange> get dependencies => pubspec.dependencies;
 
   /// The immediate dev dependencies this package specifies in its pubspec.
-  List<PackageRange> get devDependencies => pubspec.devDependencies;
+  Map<String, PackageRange> get devDependencies => pubspec.devDependencies;
 
   /// The dependency overrides this package specifies in its pubspec.
-  List<PackageRange> get dependencyOverrides => pubspec.dependencyOverrides;
+  Map<String, PackageRange> get dependencyOverrides => pubspec.dependencyOverrides;
 
   /// All immediate dependencies this package specifies.
   ///
   /// This includes regular, dev dependencies, and overrides.
-  List<PackageRange> get immediateDependencies {
-    var deps = <String, PackageRange>{};
-
-    addToMap(dep) {
-      deps[dep.name] = dep;
-    }
-
-    dependencies.forEach(addToMap);
-    devDependencies.forEach(addToMap);
-
+  Map<String, PackageRange> get immediateDependencies {
+    return {}..addAll(dependencies)..addAll(devDependencies)
     // Make sure to add these last so they replace normal dependencies.
-    dependencyOverrides.forEach(addToMap);
-
-    return deps.values.toList();
+    ..addAll(dependencyOverrides);
   }
 
   /// Returns a list of asset ids for all Dart executables in this package's bin

--- a/lib/src/package_graph.dart
+++ b/lib/src/package_graph.dart
@@ -82,8 +82,7 @@ class PackageGraph {
     if (_transitiveDependencies == null) {
       var closure = transitiveClosure(
           mapMap<String, Package, String, Iterable<String>>(packages,
-              value: (_, package) =>
-                  package.dependencies.keys));
+              value: (_, package) => package.dependencies.keys));
       _transitiveDependencies =
           mapMap<String, Set<String>, String, Set<Package>>(closure,
               value: (depender, names) {

--- a/lib/src/package_graph.dart
+++ b/lib/src/package_graph.dart
@@ -83,7 +83,7 @@ class PackageGraph {
       var closure = transitiveClosure(
           mapMap<String, Package, String, Iterable<String>>(packages,
               value: (_, package) =>
-                  package.dependencies.map((dep) => dep.name)));
+                  package.dependencies.keys));
       _transitiveDependencies =
           mapMap<String, Set<String>, String, Set<Package>>(closure,
               value: (depender, names) {

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -597,11 +597,16 @@ class Pubspec {
       Map fields,
       SourceRegistry sources})
       : _version = version,
-        _dependencies = dependencies == null ? null : new Map.fromIterable(dependencies, key: (range) => range.name),
-        _devDependencies =
-            devDependencies == null ? null : new Map.fromIterable(devDependencies, key: (range) => range.name),
-        _dependencyOverrides =
-            dependencyOverrides == null ? null : new Map.fromIterable(dependencyOverrides, key: (range) => range.name),
+        _dependencies = dependencies == null
+            ? null
+            : new Map.fromIterable(dependencies, key: (range) => range.name),
+        _devDependencies = devDependencies == null
+            ? null
+            : new Map.fromIterable(devDependencies, key: (range) => range.name),
+        _dependencyOverrides = dependencyOverrides == null
+            ? null
+            : new Map.fromIterable(dependencyOverrides,
+                key: (range) => range.name),
         _dartSdkConstraint =
             dartSdkConstraint ?? includeDefaultSdkConstraint == true
                 ? _defaultUpperBoundSdkConstraint
@@ -788,7 +793,8 @@ class Pubspec {
             containingPath: pubspecPath);
       });
 
-      dependencies[name] = ref.withConstraint(versionConstraint).withFeatures(features);
+      dependencies[name] =
+          ref.withConstraint(versionConstraint).withFeatures(features);
     });
 
     return dependencies;

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -163,38 +163,38 @@ class Pubspec {
   Version _version;
 
   /// The additional packages this package depends on.
-  List<PackageRange> get dependencies {
+  Map<String, PackageRange> get dependencies {
     if (_dependencies != null) return _dependencies;
     _dependencies =
         _parseDependencies('dependencies', fields.nodes['dependencies']);
     return _dependencies;
   }
 
-  List<PackageRange> _dependencies;
+  Map<String, PackageRange> _dependencies;
 
   /// The packages this package depends on when it is the root package.
-  List<PackageRange> get devDependencies {
+  Map<String, PackageRange> get devDependencies {
     if (_devDependencies != null) return _devDependencies;
     _devDependencies = _parseDependencies(
         'dev_dependencies', fields.nodes['dev_dependencies']);
     return _devDependencies;
   }
 
-  List<PackageRange> _devDependencies;
+  Map<String, PackageRange> _devDependencies;
 
   /// The dependency constraints that this package overrides when it is the
   /// root package.
   ///
   /// Dependencies here will replace any dependency on a package with the same
   /// name anywhere in the dependency graph.
-  List<PackageRange> get dependencyOverrides {
+  Map<String, PackageRange> get dependencyOverrides {
     if (_dependencyOverrides != null) return _dependencyOverrides;
     _dependencyOverrides = _parseDependencies(
         'dependency_overrides', fields.nodes['dependency_overrides']);
     return _dependencyOverrides;
   }
 
-  List<PackageRange> _dependencyOverrides;
+  Map<String, PackageRange> _dependencyOverrides;
 
   Map<String, Feature> get features {
     if (_features != null) return _features;
@@ -235,7 +235,7 @@ class Pubspec {
 
           var sdkConstraints = _parseEnvironment(specNode);
 
-          return new Feature(nameNode.value, dependencies,
+          return new Feature(nameNode.value, dependencies.values,
               requires: requires,
               dartSdkConstraint: sdkConstraints.first,
               flutterSdkConstraint: sdkConstraints.last,
@@ -597,11 +597,11 @@ class Pubspec {
       Map fields,
       SourceRegistry sources})
       : _version = version,
-        _dependencies = dependencies == null ? null : dependencies.toList(),
+        _dependencies = dependencies == null ? null : new Map.fromIterable(dependencies, key: (range) => range.name),
         _devDependencies =
-            devDependencies == null ? null : devDependencies.toList(),
+            devDependencies == null ? null : new Map.fromIterable(devDependencies, key: (range) => range.name),
         _dependencyOverrides =
-            dependencyOverrides == null ? null : dependencyOverrides.toList(),
+            dependencyOverrides == null ? null : new Map.fromIterable(dependencyOverrides, key: (range) => range.name),
         _dartSdkConstraint =
             dartSdkConstraint ?? includeDefaultSdkConstraint == true
                 ? _defaultUpperBoundSdkConstraint
@@ -618,8 +618,8 @@ class Pubspec {
       : _sources = null,
         _name = null,
         _version = Version.none,
-        _dependencies = <PackageRange>[],
-        _devDependencies = <PackageRange>[],
+        _dependencies = {},
+        _devDependencies = {},
         _dartSdkConstraint = VersionConstraint.any,
         _flutterSdkConstraint = null,
         _includeDefaultSdkConstraint = false,
@@ -704,9 +704,9 @@ class Pubspec {
   }
 
   /// Parses the dependency field named [field], and returns the corresponding
-  /// list of dependencies.
-  List<PackageRange> _parseDependencies(String field, YamlNode node) {
-    var dependencies = <PackageRange>[];
+  /// map of dependency names to dependencies.
+  Map<String, PackageRange> _parseDependencies(String field, YamlNode node) {
+    var dependencies = <String, PackageRange>{};
 
     // Allow an empty dependencies key.
     if (node == null || node.value == null) return dependencies;
@@ -788,8 +788,7 @@ class Pubspec {
             containingPath: pubspecPath);
       });
 
-      dependencies
-          .add(ref.withConstraint(versionConstraint).withFeatures(features));
+      dependencies[name] = ref.withConstraint(versionConstraint).withFeatures(features);
     });
 
     return dependencies;

--- a/lib/src/solver/backtracking_solver.dart
+++ b/lib/src/solver/backtracking_solver.dart
@@ -137,7 +137,7 @@ class BacktrackingSolver {
       _forceLatest.add(package);
     }
 
-    for (var override in root.dependencyOverrides) {
+    for (var override in root.dependencyOverrides.values) {
       _overrides[override.name] = override;
     }
   }
@@ -718,7 +718,7 @@ class BacktrackingSolver {
   Future<Set<PackageRange>> depsFor(PackageId id) async {
     var pubspec = await _getPubspec(id);
     var deps = <String, List<PackageRange>>{};
-    _addDependencies(deps, pubspec.dependencies);
+    _addDependencies(deps, pubspec.dependencies.values);
 
     for (var feature in _selection.enabledFeatures(id.name, pubspec.features)) {
       _addDependencies(deps, feature.dependencies);
@@ -726,7 +726,7 @@ class BacktrackingSolver {
 
     if (id.isRoot) {
       // Include dev dependencies of the root package.
-      _addDependencies(deps, pubspec.devDependencies);
+      _addDependencies(deps, pubspec.devDependencies.values);
 
       // Add all overrides. This ensures a dependency only present as an
       // override is still included.
@@ -837,7 +837,7 @@ class BacktrackingSolver {
   void _logParameters() {
     var buffer = new StringBuffer();
     buffer.writeln("Solving dependencies:");
-    for (var package in root.dependencies) {
+    for (var package in root.dependencies.values) {
       buffer.write("- $package");
       var locked = getLocked(package.name);
       if (_forceLatest.contains(package.name)) {

--- a/lib/src/solver/unselected_package_queue.dart
+++ b/lib/src/solver/unselected_package_queue.dart
@@ -132,7 +132,7 @@ class UnselectedPackageQueue {
     // that constraint. Since the root package's dependency constraints won't
     // change during solving, we can safely filter out packages that don't meet
     // it.
-    for (var rootDep in _solver.root.immediateDependencies) {
+    for (var rootDep in _solver.root.immediateDependencies.values) {
       if (rootDep.name != ref.name) continue;
       return versions
           .where((id) => rootDep.constraint.allows(id.version))

--- a/lib/src/solver/version_solver.dart
+++ b/lib/src/solver/version_solver.dart
@@ -84,8 +84,8 @@ class SolveResult {
     // Don't factor in overridden dependencies' SDK constraints, because we'll
     // accept those packages even if their constraints don't match.
     var nonOverrides = pubspecs.values
-        .where((pubspec) =>
-            !_root.dependencyOverrides.containsKey(pubspec.name))
+        .where(
+            (pubspec) => !_root.dependencyOverrides.containsKey(pubspec.name))
         .toList();
 
     var dartMerged = new VersionConstraint.intersection(
@@ -103,10 +103,8 @@ class SolveResult {
         dartSdkConstraint: dartMerged,
         flutterSdkConstraint: flutterMerged,
         mainDependencies: new MapKeySet(_root.dependencies),
-        devDependencies:
-            new MapKeySet(_root.devDependencies),
-        overriddenDependencies:
-            new MapKeySet(_root.dependencyOverrides));
+        devDependencies: new MapKeySet(_root.devDependencies),
+        overriddenDependencies: new MapKeySet(_root.dependencyOverrides));
   }
 
   final SourceRegistry _sources;

--- a/lib/src/solver/version_solver.dart
+++ b/lib/src/solver/version_solver.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import "dart:convert";
 
+import 'package:collection/collection.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:stack_trace/stack_trace.dart';
 
@@ -84,7 +85,7 @@ class SolveResult {
     // accept those packages even if their constraints don't match.
     var nonOverrides = pubspecs.values
         .where((pubspec) =>
-            !_root.dependencyOverrides.any((dep) => dep.name == pubspec.name))
+            !_root.dependencyOverrides.containsKey(pubspec.name))
         .toList();
 
     var dartMerged = new VersionConstraint.intersection(
@@ -101,11 +102,11 @@ class SolveResult {
     return new LockFile(packages,
         dartSdkConstraint: dartMerged,
         flutterSdkConstraint: flutterMerged,
-        mainDependencies: _root.dependencies.map((range) => range.name).toSet(),
+        mainDependencies: new MapKeySet(_root.dependencies),
         devDependencies:
-            _root.devDependencies.map((range) => range.name).toSet(),
+            new MapKeySet(_root.devDependencies),
         overriddenDependencies:
-            _root.dependencyOverrides.map((range) => range.name).toSet());
+            new MapKeySet(_root.dependencyOverrides));
   }
 
   final SourceRegistry _sources;

--- a/lib/src/validator/dependency.dart
+++ b/lib/src/validator/dependency.dart
@@ -36,7 +36,7 @@ class DependencyValidator extends Validator {
   DependencyValidator(Entrypoint entrypoint) : super(entrypoint);
 
   Future validate() async {
-    await _validateDependencies(entrypoint.root.pubspec.dependencies);
+    await _validateDependencies(entrypoint.root.pubspec.dependencies.values);
 
     for (var feature in entrypoint.root.pubspec.features.values) {
       // Allow off-by-default features, since older pubs will just ignore them
@@ -58,7 +58,7 @@ class DependencyValidator extends Validator {
   }
 
   /// Validates all dependencies in [dependencies].
-  Future _validateDependencies(List<PackageRange> dependencies) async {
+  Future _validateDependencies(Iterable<PackageRange> dependencies) async {
     for (var dependency in dependencies) {
       var constraint = dependency.constraint;
       if (dependency.name == "flutter") {

--- a/lib/src/validator/dependency_override.dart
+++ b/lib/src/validator/dependency_override.dart
@@ -15,8 +15,7 @@ class DependencyOverrideValidator extends Validator {
   DependencyOverrideValidator(Entrypoint entrypoint) : super(entrypoint);
 
   Future validate() {
-    var overridden =
-        new MapKeySet(entrypoint.root.dependencyOverrides);
+    var overridden = new MapKeySet(entrypoint.root.dependencyOverrides);
     var dev = new MapKeySet(entrypoint.root.devDependencies);
     if (overridden.difference(dev).isNotEmpty) {
       errors.add('Your pubspec.yaml must not override non-dev dependencies.\n'

--- a/lib/src/validator/dependency_override.dart
+++ b/lib/src/validator/dependency_override.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:collection/collection.dart';
+
 import '../entrypoint.dart';
 import '../validator.dart';
 
@@ -14,8 +16,8 @@ class DependencyOverrideValidator extends Validator {
 
   Future validate() {
     var overridden =
-        entrypoint.root.dependencyOverrides.map((dep) => dep.name).toSet();
-    var dev = entrypoint.root.devDependencies.map((dep) => dep.name).toSet();
+        new MapKeySet(entrypoint.root.dependencyOverrides);
+    var dev = new MapKeySet(entrypoint.root.devDependencies);
     if (overridden.difference(dev).isNotEmpty) {
       errors.add('Your pubspec.yaml must not override non-dev dependencies.\n'
           'This ensures you test your package against the same versions of '

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:analyzer/analyzer.dart';
 import 'package:path/path.dart' as p;
+import 'package:collection/collection.dart';
 import 'package:pub/src/dart.dart';
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/io.dart';
@@ -61,10 +62,10 @@ class StrictDependenciesValidator extends Validator {
   }
 
   Future validate() async {
-    var dependencies = entrypoint.root.dependencies.map((d) => d.name).toSet()
+    var dependencies = entrypoint.root.dependencies.keys.toSet()
       ..add(entrypoint.root.name);
     var devDependencies =
-        entrypoint.root.devDependencies.map((d) => d.name).toSet();
+        new MapKeySet(entrypoint.root.devDependencies);
     _validateLibBin(dependencies, devDependencies);
     _validateBenchmarkExampleTestTool(dependencies, devDependencies);
   }

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -64,8 +64,7 @@ class StrictDependenciesValidator extends Validator {
   Future validate() async {
     var dependencies = entrypoint.root.dependencies.keys.toSet()
       ..add(entrypoint.root.name);
-    var devDependencies =
-        new MapKeySet(entrypoint.root.devDependencies);
+    var devDependencies = new MapKeySet(entrypoint.root.devDependencies);
     _validateLibBin(dependencies, devDependencies);
     _validateBenchmarkExampleTestTool(dependencies, devDependencies);
   }

--- a/test/dependency_computer/utils.dart
+++ b/test/dependency_computer/utils.dart
@@ -89,7 +89,7 @@ PackageGraph _loadPackageGraph() {
     if (packages.containsKey(packageName)) return;
     packages[packageName] = new Package.load(
         packageName, packagePath(packageName), systemCache.sources);
-    for (var dep in packages[packageName].dependencies) {
+    for (var dep in packages[packageName].dependencies.values) {
       loadPackage(dep.name);
     }
   }

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -80,7 +80,7 @@ dependencies:
     version: ">=1.2.3 <3.4.5"
 ''', sources);
 
-      var foo = pubspec.dependencies[0];
+      var foo = pubspec.dependencies['foo'];
       expect(foo.name, equals('foo'));
       expect(foo.constraint.allows(new Version(1, 2, 3)), isTrue);
       expect(foo.constraint.allows(new Version(1, 2, 5)), isTrue);
@@ -103,7 +103,7 @@ dev_dependencies:
     version: ">=1.2.3 <3.4.5"
 ''', sources);
 
-      var foo = pubspec.devDependencies[0];
+      var foo = pubspec.devDependencies['foo'];
       expect(foo.name, equals('foo'));
       expect(foo.constraint.allows(new Version(1, 2, 3)), isTrue);
       expect(foo.constraint.allows(new Version(1, 2, 5)), isTrue);
@@ -126,7 +126,7 @@ dependency_overrides:
     version: ">=1.2.3 <3.4.5"
 ''', sources);
 
-      var foo = pubspec.dependencyOverrides[0];
+      var foo = pubspec.dependencyOverrides['foo'];
       expect(foo.name, equals('foo'));
       expect(foo.constraint.allows(new Version(1, 2, 3)), isTrue);
       expect(foo.constraint.allows(new Version(1, 2, 5)), isTrue);
@@ -148,7 +148,7 @@ dependencies:
     unknown: blah
 ''', sources);
 
-      var foo = pubspec.dependencies[0];
+      var foo = pubspec.dependencies['foo'];
       expect(foo.name, equals('foo'));
       expect(foo.source, equals(sources['unknown']));
     });
@@ -160,7 +160,7 @@ dependencies:
     version: 1.2.3
 ''', sources);
 
-      var foo = pubspec.dependencies[0];
+      var foo = pubspec.dependencies['foo'];
       expect(foo.name, equals('foo'));
       expect(foo.source, equals(sources['hosted']));
     });

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -2602,7 +2602,7 @@ Future expectResolves(
   var resultPubspec = new Pubspec.fromMap({"dependencies": result}, registry);
 
   var ids = new Map.from(lockFile.packages);
-  for (var dep in resultPubspec.dependencies) {
+  for (var dep in resultPubspec.dependencies.values) {
     expect(ids, contains(dep.name));
     var id = ids.remove(dep.name);
 


### PR DESCRIPTION
This cleans up some existing code, but more importantly it makes some
algorithms for the new version solver more efficient.