### PR TITLE
Annotate fail with @alwaysThrows, Remove unreachable throws

### DIFF
--- a/lib/src/barback/transformer_isolate.dart
+++ b/lib/src/barback/transformer_isolate.dart
@@ -98,7 +98,6 @@ class TransformerIsolate {
       // failed was the one we were loading transformers from, throw an
       // application exception with a more user-friendly message.
       fail('Transformer library "$packageUri" not found.', error, stackTrace);
-      return null;
     }
   }
 

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -880,9 +880,6 @@ class Pubspec {
     if (node == null || node.value == null) return new YamlList();
     if (node is YamlList) return node;
     _error('Must be a list.', node.span);
-
-    // TODO(nweiz): Remove this when sdk#31384 is fixed.
-    throw "Unreachable";
   }
 
   /// Runs [fn] and wraps any [FormatException] it throws in a

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import "package:crypto/crypto.dart" as crypto;
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import "package:stack_trace/stack_trace.dart";
 
@@ -725,6 +726,7 @@ String yamlToString(data) {
 }
 
 /// Throw a [ApplicationException] with [message].
+@alwaysThrows
 void fail(String message, [innerError, StackTrace innerTrace]) {
   if (innerError != null) {
     throw new WrappedException(message, innerError, innerTrace);

--- a/test/descriptor_server.dart
+++ b/test/descriptor_server.dart
@@ -96,7 +96,6 @@ class DescriptorServer {
     _server.mount((request) {
       fail("The HTTP server received an unexpected request:\n"
           "${request.method} ${request.requestedUri}");
-      return new shelf.Response.forbidden(null);
     });
     addTearDown(() => _server.close());
   }


### PR DESCRIPTION
https://github.com/dart-lang/sdk/issues/31384 was fixed in
https://github.com/dart-lang/sdk/commit/0a6253312f

Available in Dart 2.0.0-dev.12.0