### PR TITLE
Don't adjust SDK constraints whose min versions are prerelease

### DIFF
--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -391,6 +391,9 @@ class Pubspec {
     if (!allowPreReleaseSdk) return false;
     if (!sdk.version.isPreRelease) return false;
     if (sdkConstraint.includeMax) return false;
+    if (sdkConstraint.min != null && sdkConstraint.min.isPreRelease) {
+      return false;
+    }
     if (sdkConstraint.max == null) return false;
     if (sdkConstraint.max.isPreRelease) return false;
     return sdkConstraint.max.major == sdk.version.major &&

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -1135,111 +1135,114 @@ void dartSdkConstraint() {
             'current SDK is 2.0.0.');
   });
 
-  test("pre-release override requires major SDK versions to match", () async {
-    await d.dir(appPath, [
-      await d.pubspec({
-        'name': 'myapp',
-        'environment': {'sdk': '<2.2.3'}
-      })
-    ]).create();
+  group("pre-release override", () {
+    group("requires", () {
+      test("major SDK versions to match", () async {
+        await d.dir(appPath, [
+          await d.pubspec({
+            'name': 'myapp',
+            'environment': {'sdk': '<2.2.3'}
+          })
+        ]).create();
 
-    await expectResolves(
-        environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
-        output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
-  });
+        await expectResolves(
+            environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
+            output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
+      });
 
-  test("pre-release override requires minor SDK versions to match", () async {
-    await d.dir(appPath, [
-      await d.pubspec({
-        'name': 'myapp',
-        'environment': {'sdk': '<1.3.3'}
-      })
-    ]).create();
+      test("minor SDK versions to match", () async {
+        await d.dir(appPath, [
+          await d.pubspec({
+            'name': 'myapp',
+            'environment': {'sdk': '<1.3.3'}
+          })
+        ]).create();
 
-    await expectResolves(
-        environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
-        output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
-  });
+        await expectResolves(
+            environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
+            output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
+      });
 
-  test("pre-release override requires patch SDK versions to match", () async {
-    await d.dir(appPath, [
-      await d.pubspec({
-        'name': 'myapp',
-        'environment': {'sdk': '<1.2.4'}
-      })
-    ]).create();
+      test("patch SDK versions to match", () async {
+        await d.dir(appPath, [
+          await d.pubspec({
+            'name': 'myapp',
+            'environment': {'sdk': '<1.2.4'}
+          })
+        ]).create();
 
-    await expectResolves(
-        environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
-        output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
-  });
+        await expectResolves(
+            environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
+            output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
+      });
 
-  test("pre-release override requires exclusive max", () async {
-    await d.dir(appPath, [
-      await d.pubspec({
-        'name': 'myapp',
-        'environment': {'sdk': '<=1.2.3'}
-      })
-    ]).create();
+      test("exclusive max", () async {
+        await d.dir(appPath, [
+          await d.pubspec({
+            'name': 'myapp',
+            'environment': {'sdk': '<=1.2.3'}
+          })
+        ]).create();
 
-    await expectResolves(
-        environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
-        output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
-  });
+        await expectResolves(
+            environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
+            output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
+      });
 
-  test("pre-release override requires pre-release SDK", () async {
-    await d.dir(appPath, [
-      await d.pubspec({
-        'name': 'myapp',
-        'environment': {'sdk': '<1.2.3'}
-      })
-    ]).create();
+      test("pre-release SDK", () async {
+        await d.dir(appPath, [
+          await d.pubspec({
+            'name': 'myapp',
+            'environment': {'sdk': '<1.2.3'}
+          })
+        ]).create();
 
-    await expectResolves(
-        environment: {'_PUB_TEST_SDK_VERSION': '1.2.3'},
-        error: 'Package myapp requires SDK version <1.2.3 but the current '
-            'SDK is 1.2.3.');
-  });
+        await expectResolves(
+            environment: {'_PUB_TEST_SDK_VERSION': '1.2.3'},
+            error: 'Package myapp requires SDK version <1.2.3 but the current '
+                'SDK is 1.2.3.');
+      });
 
-  test("pre-release override requires no existing pre-release constraints",
-      () async {
-    await d.dir(appPath, [
-      await d.pubspec({
-        'name': 'myapp',
-        'environment': {'sdk': '<1.2.3-dev.2.0'}
-      })
-    ]).create();
+      test("no existing pre-release constraint", () async {
+        await d.dir(appPath, [
+          await d.pubspec({
+            'name': 'myapp',
+            'environment': {'sdk': '<1.2.3-dev.2.0'}
+          })
+        ]).create();
 
-    await expectResolves(
-        environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
-        output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
-  });
+        await expectResolves(
+            environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
+            output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
+      });
 
-  test("pre-release override requires no build release constraints", () async {
-    await d.dir(appPath, [
-      await d.pubspec({
-        'name': 'myapp',
-        'environment': {'sdk': '<1.2.3+1'}
-      })
-    ]).create();
+      test("no build release constraints", () async {
+        await d.dir(appPath, [
+          await d.pubspec({
+            'name': 'myapp',
+            'environment': {'sdk': '<1.2.3+1'}
+          })
+        ]).create();
 
-    await expectResolves(
-        environment: {'_PUB_TEST_SDK_VERSION': '1.2.3'},
-        output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
-  });
+        await expectResolves(
+            environment: {'_PUB_TEST_SDK_VERSION': '1.2.3'},
+            output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
+      });
+    });
 
-  test("pre-release override works generally", () async {
-    await d.dir(appPath, [
-      await d.pubspec({
-        'name': 'myapp',
-        'environment': {'sdk': '<1.2.3'}
-      })
-    ]).create();
+    test("works generally", () async {
+      await d.dir(appPath, [
+        await d.pubspec({
+          'name': 'myapp',
+          'environment': {'sdk': '<1.2.3'}
+        })
+      ]).create();
 
-    await expectResolves(
-        environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
-        output: allOf(contains('PUB_ALLOW_PRERELEASE_SDK'),
-            contains('<=1.2.3-dev.1.0'), contains('myapp')));
+      await expectResolves(
+          environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
+          output: allOf(contains('PUB_ALLOW_PRERELEASE_SDK'),
+              contains('<=1.2.3-dev.1.0'), contains('myapp')));
+    });
   });
 }
 

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -1203,7 +1203,7 @@ void dartSdkConstraint() {
                 'SDK is 1.2.3.');
       });
 
-      test("no existing pre-release constraint", () async {
+      test("no max pre-release constraint", () async {
         await d.dir(appPath, [
           await d.pubspec({
             'name': 'myapp',
@@ -1214,6 +1214,20 @@ void dartSdkConstraint() {
         await expectResolves(
             environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
             output: isNot(contains('PUB_ALLOW_PRERELEASE_SDK')));
+      });
+
+      test("no min pre-release constraint", () async {
+        await d.dir(appPath, [
+          await d.pubspec({
+            'name': 'myapp',
+            'environment': {'sdk': '>=1.2.3-dev.2.0 <2.0.0'}
+          })
+        ]).create();
+
+        await expectResolves(
+            environment: {'_PUB_TEST_SDK_VERSION': '1.2.3-dev.1.0'},
+            error: 'Package myapp requires SDK version >=1.2.3-dev.2.0 <2.0.0 '
+                'but the current SDK is 1.2.3-dev.1.0.');
       });
 
       test("no build release constraints", () async {


### PR DESCRIPTION
Previously, if the user was using 1.2.3-dev.1 and a package had an SDK
constraint ">=1.2.3-dev.2", we would try to create an invalid
">=1.2.3-dev.2 <1.2.3-dev.1" constraint.

Closes #1770