### PR TITLE
Fix another bug in SDK override logic

### DIFF
--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -391,7 +391,11 @@ class Pubspec {
     if (!allowPreReleaseSdk) return false;
     if (!sdk.version.isPreRelease) return false;
     if (sdkConstraint.includeMax) return false;
-    if (sdkConstraint.min != null && sdkConstraint.min.isPreRelease) {
+    if (sdkConstraint.min != null &&
+        sdkConstraint.min.isPreRelease &&
+        sdkConstraint.min.major == sdk.version.major &&
+        sdkConstraint.min.minor == sdk.version.minor &&
+        sdkConstraint.min.patch == sdk.version.patch) {
       return false;
     }
     if (sdkConstraint.max == null) return false;


### PR DESCRIPTION
We'd previously been disabling SDK overrides any time the minimum
constraint was a pre-release version, whether or not that version had
anything to do with the SDK. We not only disable the overrides when
the minimum constraint is a pre-release version *of the current SDK*.

Closes #1781
Closes #1780
See dart-lang/sdk#31926
See dart-lang/sdk#31940