### PR TITLE
Use less special-casing for the root package

### DIFF
--- a/lib/src/package_name.dart
+++ b/lib/src/package_name.dart
@@ -97,6 +97,9 @@ class PackageRef extends PackageName {
   PackageRef(String name, Source source, description)
       : super._(name, source, description);
 
+  /// Creates a reference to the given root package.
+  PackageRef.root(Package package) : super._(package.name, null, package.name);
+
   /// Creates a reference to a magic package (see [isMagic]).
   PackageRef.magic(String name) : super._magic(name);
 
@@ -200,6 +203,12 @@ class PackageRange extends PackageName {
       : constraint = Version.none,
         features = const {},
         super._magic(name);
+
+  /// Creates a range that selects the root package.
+  PackageRange.root(Package package)
+      : constraint = package.version,
+        features = const {},
+        super._(package.name, null, package.name);
 
   /// Returns a description of [features], or the empty string if [features] is
   /// empty.


### PR DESCRIPTION
We now use the same logic to select a version and add
incompatibilities for the root package that we do for every other
package. This makes it easier to write logic that treats the root
package the same way as other packages.