### PR TITLE
Allow dart2js to compile with the CFE.

### DIFF
--- a/lib/src/barback/dart2js_transformer.dart
+++ b/lib/src/barback/dart2js_transformer.dart
@@ -161,7 +161,8 @@ class Dart2JSTransformer extends Transformer implements LazyTransformer {
         suppressPackageWarnings:
             _configBool('suppressPackageWarnings', defaultsTo: true),
         terse: _configBool('terse'),
-        includeSourceMapUrls: _generateSourceMaps);
+        includeSourceMapUrls: _generateSourceMaps,
+        platformBinaries: provider.libraryRoot.resolve('lib/_internal/').path);
   }
 
   /// Parses and returns the "commandLineOptions" configuration option.
@@ -395,7 +396,13 @@ class _BarbackCompilerProvider implements dart.CompilerProvider {
     return new Future.sync(() {
       // Find the corresponding asset in barback.
       var id = _sourceUrlToId(url);
-      if (id != null) return _transform.readInputAsString(id);
+      if (id != null) {
+        if (id.extension == '.dill') {
+          return _transform.readInput(id);
+        } else {
+          return _transform.readInputAsString(id);
+        }
+      }
 
       // Don't allow arbitrary file paths that point to things not in packages.
       // Doing so won't work in Dartium.

--- a/lib/src/barback/dart2js_transformer.dart
+++ b/lib/src/barback/dart2js_transformer.dart
@@ -281,7 +281,7 @@ class _BarbackCompilerProvider implements dart.CompilerProvider {
   }
 
   /// A [CompilerInputProvider] for dart2js.
-  Future<String> provideInput(Uri resourceUri) {
+  Future provideInput(Uri resourceUri) {
     // We only expect to get absolute "file:" URLs from dart2js.
     assert(resourceUri.isAbsolute);
     assert(resourceUri.scheme == "file");
@@ -392,13 +392,16 @@ class _BarbackCompilerProvider implements dart.CompilerProvider {
     }
   }
 
-  Future<String> _readResource(Uri url) {
-    return new Future.sync(() {
+  Future _readResource(Uri url) {
+    return new Future.sync(() async {
       // Find the corresponding asset in barback.
       var id = _sourceUrlToId(url);
       if (id != null) {
         if (id.extension == '.dill') {
-          return _transform.readInput(id);
+          var stream = _transform.readInput(id);
+          var bytes = <int>[];
+          await stream.forEach(bytes.addAll);
+          return bytes;
         } else {
           return _transform.readInputAsString(id);
         }

--- a/lib/src/barback/dart2js_transformer.dart
+++ b/lib/src/barback/dart2js_transformer.dart
@@ -282,7 +282,7 @@ class _BarbackCompilerProvider implements dart.CompilerProvider {
   }
 
   /// A [CompilerInputProvider] for dart2js.
-  Future/* <String | List<int>> */ provideInput(Uri resourceUri) {
+  Future /* <String | List<int>> */ provideInput(Uri resourceUri) {
     // We only expect to get absolute "file:" URLs from dart2js.
     assert(resourceUri.isAbsolute);
     assert(resourceUri.scheme == "file");

--- a/lib/src/barback/pub_package_provider.dart
+++ b/lib/src/barback/pub_package_provider.dart
@@ -148,10 +148,10 @@ class PubPackageProvider implements StaticPackageProvider {
           files = files.map((file) => file.replaceAll(trailingUnderscore, ""));
         }
 
-        bool isIncluded(extension) =>
-            extension == '.dart' || extension == '.dill';
-        return new Stream.fromIterable(
-            files.where((file) => isIncluded(p.extension(file))).map((file) {
+        return new Stream.fromIterable(files
+            .where((file) =>
+                p.extension(file) == '.dart' || p.extension(file) == '.dill')
+            .map((file) {
           var idPath = p.join("lib", "lib", p.relative(file, from: libPath));
           return new AssetId('\$sdk', p.toUri(idPath).toString());
         }));

--- a/lib/src/barback/pub_package_provider.dart
+++ b/lib/src/barback/pub_package_provider.dart
@@ -75,8 +75,9 @@ class PubPackageProvider implements StaticPackageProvider {
     }
 
     // "$sdk" is a pseudo-package that provides access to the Dart library
-    // sources in the SDK. The dart2js transformer uses this to locate the Dart
-    // sources for "dart:" libraries.
+    // sources and kernel .dill files in the SDK. The dart2js transformer uses
+    // this to locate the Dart sources for "dart:" libraries and the
+    // dart2js_platform.dill files.
     if (id.package == r'$sdk') {
       // The asset path contains two "lib" entries. The first represents pub's
       // concept that all public assets are in "lib". The second comes from the
@@ -147,8 +148,10 @@ class PubPackageProvider implements StaticPackageProvider {
           files = files.map((file) => file.replaceAll(trailingUnderscore, ""));
         }
 
+        bool isIncluded(extension) =>
+            extension == '.dart' || extension == '.dill';
         return new Stream.fromIterable(
-            files.where((file) => p.extension(file) == ".dart").map((file) {
+            files.where((file) => isIncluded(p.extension(file))).map((file) {
           var idPath = p.join("lib", "lib", p.relative(file, from: libPath));
           return new AssetId('\$sdk', p.toUri(idPath).toString());
         }));

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -68,7 +68,8 @@ Future compile(String entrypoint, CompilerProvider provider,
     bool suppressPackageWarnings: true,
     bool terse: false,
     bool includeSourceMapUrls: false,
-    bool toDart: false}) async {
+    bool toDart: false,
+    String platformBinaries}) async {
   // dart2js chokes on relative paths. Including "/./" can also confuse it, so
   // we normalize as well.
   entrypoint = p.normalize(p.absolute(entrypoint));
@@ -85,6 +86,9 @@ Future compile(String entrypoint, CompilerProvider provider,
   if (!suppressPackageWarnings) options.add('--show-package-warnings');
   if (terse) options.add('--terse');
   if (toDart) options.add('--output-type=dart');
+  if (platformBinaries != null) {
+    options.add('--platform-binaries=$platformBinaries');
+  }
 
   var sourceUrl = p.toUri(entrypoint);
   options.add("--out=$sourceUrl.js");


### PR DESCRIPTION
Dart2js needs an extra argument to locate the dart2js_platform.dill file. The provider for the compiler needs to read this file as a binary file.

This change is necessary before we can make dart2js use the CFE by default.

Two questions:
* do you need `compiler_unsupported` to get updated? Its current version doesn't have the `--platform-binaries` flag. I'm investigating what's the process to update that package, but it appears we are not running dart2js as part of pub tests (when I run `pub run test`, all tests pass.)
* do we need to indicate a minimal sdk version where this pub will work? (I assume that it might not be needed, because pub is always shipped with the sdk.


