### PR TITLE
Stop using deprecated DelegatingList.typed

### DIFF
--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -878,7 +878,7 @@ class Pubspec {
         _error('Must be a string.', element.span);
       }
     }
-    return DelegatingList.typed(list);
+    return list.cast<String>();
   }
 
   /// Verifies that [node] is a list and returns it.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,5 +43,5 @@ dev_dependencies:
   test_process: "^1.0.0"
 
 environment:
-  sdk: ">=2.0.0-dev.17.0 <2.0.0"
+  sdk: ">=2.0.0-dev.22.0 <2.0.0"
 


### PR DESCRIPTION
Bump minimum SDK to one that includes List.cast