### PR TITLE
Add support for depending on packages from the Fuchsia SDK

### DIFF
--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -8,6 +8,7 @@ import 'package:pub_semver/pub_semver.dart';
 
 import 'sdk/dart.dart';
 import 'sdk/flutter.dart';
+import 'sdk/fuchsia.dart';
 
 /// An SDK that can provide packages and on which pubspecs can express version
 /// constraints.
@@ -27,6 +28,9 @@ abstract class Sdk {
   /// The SDK's version number, or `null` if the SDK is unavailable.
   Version get version;
 
+  /// The version of pub that added support for this SDK.
+  Version get firstPubVersion;
+
   /// A message to indicate to the user how to make this SDK available.
   ///
   /// This is printed after a version solve where the SDK wasn't found. It may
@@ -45,7 +49,7 @@ abstract class Sdk {
 /// A map from SDK identifiers that appear in pubspecs to the implementations of
 /// those SDKs.
 final sdks = new UnmodifiableMapView<String, Sdk>(
-    {"dart": sdk, "flutter": new FlutterSdk()});
+    {"dart": sdk, "flutter": new FlutterSdk(), "fuchsia": new FuchsiaSdk()});
 
 /// The core Dart SDK.
 final sdk = new DartSdk();

--- a/lib/src/sdk/dart.dart
+++ b/lib/src/sdk/dart.dart
@@ -17,6 +17,7 @@ class DartSdk extends Sdk {
   String get name => "Dart";
   bool get isAvailable => true;
   String get installMessage => null;
+  Version get firstPubVersion => Version.none;
 
   /// The path to the root directory of the SDK.
   ///

--- a/lib/src/sdk/fuchsia.dart
+++ b/lib/src/sdk/fuchsia.dart
@@ -10,17 +10,19 @@ import 'package:pub_semver/pub_semver.dart';
 import '../io.dart';
 import '../sdk.dart';
 
-class FlutterSdk extends Sdk {
-  String get name => "Flutter";
+class FuchsiaSdk extends Sdk {
+  String get name => "Fuchsia";
   bool get isAvailable => _isAvailable;
-  Version get firstPubVersion => new Version.parse('1.19.0');
+  Version get firstPubVersion => new Version.parse('2.0.0-dev.48.0');
 
   static final bool _isAvailable =
-      Platform.environment.containsKey("FLUTTER_ROOT");
-  static final String _rootDirectory = Platform.environment["FLUTTER_ROOT"];
+      Platform.environment.containsKey("FUCHSIA_DART_SDK_ROOT");
+  static final String _rootDirectory =
+      Platform.environment["FUCHSIA_DART_SDK_ROOT"];
 
   String get installMessage =>
-      "Flutter users should run `flutter packages get` instead of `pub get`.";
+      "Please set the FUCHSIA_DART_SDK_ROOT environment variable to point to "
+      "the root of the Fuchsia SDK for Dart.";
 
   final Version version = () {
     if (!_isAvailable) return null;
@@ -32,15 +34,8 @@ class FlutterSdk extends Sdk {
   String packagePath(String name) {
     if (!isAvailable) return null;
 
-    // Flutter packages exist in both `$flutter/packages` and
-    // `$flutter/bin/cache/pkg`. This checks both locations in order. If [name]
-    // exists in neither place, it returns the `$flutter/packages` location
-    // which is more human-readable for error messages.
     var packagePath = p.join(_rootDirectory, 'packages', name);
     if (dirExists(packagePath)) return packagePath;
-
-    var cachePath = p.join(_rootDirectory, 'bin', 'cache', 'pkg', name);
-    if (dirExists(cachePath)) return cachePath;
 
     return null;
   }

--- a/lib/src/sdk/fuchsia.dart
+++ b/lib/src/sdk/fuchsia.dart
@@ -13,7 +13,7 @@ import '../sdk.dart';
 class FuchsiaSdk extends Sdk {
   String get name => "Fuchsia";
   bool get isAvailable => _isAvailable;
-  Version get firstPubVersion => new Version.parse('2.0.0-dev.48.0');
+  Version get firstPubVersion => new Version.parse('2.0.0-dev.51.0');
 
   static final bool _isAvailable =
       Platform.environment.containsKey("FUCHSIA_DART_SDK_ROOT");

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -209,10 +209,11 @@ String namedSequence(String name, Iterable iter, [String plural]) {
 /// Returns a sentence fragment listing the elements of [iter].
 ///
 /// This converts each element of [iter] to a string and separates them with
-/// commas and/or "and" where appropriate.
-String toSentence(Iterable iter) {
+/// commas and/or [conjunction] (`"and"` by default) where appropriate.
+String toSentence(Iterable iter, {String conjunction}) {
   if (iter.length == 1) return iter.first.toString();
-  return iter.take(iter.length - 1).join(", ") + " and ${iter.last}";
+  conjunction ??= 'and';
+  return iter.take(iter.length - 1).join(", ") + " $conjunction ${iter.last}";
 }
 
 /// Returns [name] if [number] is 1, or the plural of [name] otherwise.

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -69,14 +69,14 @@ abstract class Validator {
       // Unless the user is using a dev SDK themselves, suggest that they use a
       // non-dev SDK constraint, even if there were some dev versions that are
       // allowed.
-      firstSdkVersion = firstSdkVersion.nextMinor;
+      firstSdkVersion = firstSdkVersion.nextPatch;
     }
 
     var allowedSdks = new VersionRange(
         min: firstSdkVersion,
         includeMin: true,
         max: firstSdkVersion.isPreRelease
-            ? firstSdkVersion.nextMinor
+            ? firstSdkVersion.nextPatch
             : firstSdkVersion.nextBreaking);
 
     var newSdkConstraint = entrypoint.root.pubspec.originalDartSdkConstraint

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -9,6 +9,7 @@ import 'package:pub_semver/pub_semver.dart';
 
 import 'entrypoint.dart';
 import 'log.dart' as log;
+import 'sdk.dart';
 import 'utils.dart';
 import 'validator/compiled_dartdoc.dart';
 import 'validator/dependency.dart';
@@ -63,20 +64,20 @@ abstract class Validator {
       return;
     }
 
-    // Suggest that users use a non-dev SDK constraint, even if there were some
-    // dev versions that are allowed.
-    var nextNonDevVersion = firstSdkVersion.isPreRelease
-        ? firstSdkVersion.nextMinor
-        : firstSdkVersion;
-    var allowedSdks =
-        new VersionConstraint.compatibleWith(nextNonDevVersion) as VersionRange;
+    if (firstSdkVersion.isPreRelease &&
+        !_isSamePreRelease(firstSdkVersion, sdk.version)) {
+      // Unless the user is using a dev SDK themselves, suggest that they use a
+      // non-dev SDK constraint, even if there were some dev versions that are
+      // allowed.
+      firstSdkVersion = firstSdkVersion.nextMinor;
+    }
 
-    // Avoid ^ constraints, since they aren't supported in SDK constraints.
-    allowedSdks = new VersionRange(
-        min: allowedSdks.min,
-        max: allowedSdks.max,
-        includeMin: allowedSdks.includeMin,
-        includeMax: allowedSdks.includeMax);
+    var allowedSdks = new VersionRange(
+        min: firstSdkVersion,
+        includeMin: true,
+        max: firstSdkVersion.isPreRelease
+            ? firstSdkVersion.nextMinor
+            : firstSdkVersion.nextBreaking);
 
     var newSdkConstraint = entrypoint.root.pubspec.originalDartSdkConstraint
         .intersect(allowedSdks);
@@ -88,6 +89,14 @@ abstract class Validator {
         "environment:\n"
         "  sdk: \"$newSdkConstraint\"");
   }
+
+  /// Returns whether [version1] and [version2] are pre-releases of the same version.
+  bool _isSamePreRelease(Version version1, Version version2) =>
+      version1.isPreRelease &&
+      version2.isPreRelease &&
+      version1.patch == version2.patch &&
+      version1.minor == version2.minor &&
+      version1.major == version2.major;
 
   /// Run all validators on the [entrypoint] package and print their results.
   ///

--- a/lib/src/validator/sdk_constraint.dart
+++ b/lib/src/validator/sdk_constraint.dart
@@ -7,11 +7,9 @@ import 'dart:async';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../entrypoint.dart';
+import '../sdk.dart';
+import '../utils.dart';
 import '../validator.dart';
-
-/// The range of all Dart SDK versions that don't support Flutter SDK
-/// constraints.
-final _preFlutterSupport = new VersionConstraint.parse("<1.19.0");
 
 /// A validator that validates that a package's SDK constraint doesn't use the
 /// "^" syntax.
@@ -41,22 +39,12 @@ class SdkConstraintValidator extends Validator {
       }
     }
 
-    if (entrypoint.root.pubspec.sdkConstraints.containsKey('flutter') &&
-        dartConstraint.allowsAny(_preFlutterSupport)) {
-      var newDartConstraint = dartConstraint.difference(_preFlutterSupport);
-      if (newDartConstraint.isEmpty ||
-          newDartConstraint ==
-              VersionConstraint.any.difference(_preFlutterSupport)) {
-        newDartConstraint = new VersionConstraint.parse("<2.0.0")
-            .difference(_preFlutterSupport);
+    for (var sdk in sdks.values) {
+      if (sdk.identifier == 'dart') continue;
+      if (entrypoint.root.pubspec.sdkConstraints.containsKey(sdk.identifier)) {
+        validateSdkConstraint(sdk.firstPubVersion,
+            "Older versions of pub don't support ${sdk.name} SDK constraints.");
       }
-
-      errors
-          .add("Older versions of pub don't support Flutter SDK constraints.\n"
-              "Make sure your SDK constraint excludes those old versions:\n"
-              "\n"
-              "environment:\n"
-              "  sdk: \"$newDartConstraint\"");
     }
   }
 }

--- a/test/deps_test.dart
+++ b/test/deps_test.dart
@@ -140,6 +140,16 @@ main() {
           output: contains('Flutter SDK 4.3.2+1'),
           environment: {"FLUTTER_ROOT": p.join(d.sandbox, 'flutter')});
     });
+
+    test("with the Fuchsia SDK, if applicable", () async {
+      await pubGet();
+
+      await d.dir('fuchsia', [d.file('version', '4.3.2+1')]).create();
+      await runPub(
+          args: ['deps'],
+          output: contains('Fuchsia SDK 4.3.2+1'),
+          environment: {"FUCHSIA_DART_SDK_ROOT": p.join(d.sandbox, 'fuchsia')});
+    });
   });
 
   group("lists non-dev dependencies", () {

--- a/test/lock_file_test.dart
+++ b/test/lock_file_test.dart
@@ -110,6 +110,7 @@ packages:
             containsPair(
                 'dart', new VersionConstraint.parse('>=1.2.3 <4.0.0')));
         expect(lockFile.sdkConstraints, isNot(contains('flutter')));
+        expect(lockFile.sdkConstraints, isNot(contains('fuchsia')));
       });
 
       test("allows new-style SDK constraints", () {
@@ -117,6 +118,7 @@ packages:
 sdks:
   dart: ">=1.2.3 <4.0.0"
   flutter: ^0.1.2
+  fuchsia: ^5.6.7
 ''', sources);
         expect(
             lockFile.sdkConstraints,
@@ -124,6 +126,8 @@ sdks:
                 'dart', new VersionConstraint.parse('>=1.2.3 <4.0.0')));
         expect(lockFile.sdkConstraints,
             containsPair('flutter', new VersionConstraint.parse('^0.1.2')));
+        expect(lockFile.sdkConstraints,
+            containsPair('fuchsia', new VersionConstraint.parse('^5.6.7')));
       });
 
       test("throws if the top level is not a map", () {

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -466,12 +466,14 @@ dependencies:
         var pubspec = new Pubspec.parse('name: testing', sources);
         expectDefaultSdkConstraint(pubspec);
         expect(pubspec.sdkConstraints, isNot(contains('flutter')));
+        expect(pubspec.sdkConstraints, isNot(contains('fuchsia')));
       });
 
       test("default SDK constraint can be omitted with empty environment", () {
         var pubspec = new Pubspec.parse('', sources);
         expectDefaultSdkConstraint(pubspec);
         expect(pubspec.sdkConstraints, isNot(contains('flutter')));
+        expect(pubspec.sdkConstraints, isNot(contains('fuchsia')));
       });
 
       test("defaults the upper constraint for the SDK", () {
@@ -482,6 +484,7 @@ dependencies:
   ''', sources);
         expectDefaultSdkConstraint(pubspec);
         expect(pubspec.sdkConstraints, isNot(contains('flutter')));
+        expect(pubspec.sdkConstraints, isNot(contains('fuchsia')));
       });
 
       test(
@@ -494,6 +497,7 @@ dependencies:
         expect(pubspec.sdkConstraints,
             containsPair('dart', new VersionConstraint.parse(">3.0.0")));
         expect(pubspec.sdkConstraints, isNot(contains('flutter')));
+        expect(pubspec.sdkConstraints, isNot(contains('fuchsia')));
       });
 
       test("throws if the environment value isn't a map", () {
@@ -506,6 +510,7 @@ dependencies:
 environment:
   sdk: ">=1.2.3 <2.3.4"
   flutter: ^0.1.2
+  fuchsia: ^5.6.7
 ''', sources);
         expect(
             pubspec.sdkConstraints,
@@ -513,6 +518,8 @@ environment:
                 'dart', new VersionConstraint.parse(">=1.2.3 <2.3.4")));
         expect(pubspec.sdkConstraints,
             containsPair('flutter', new VersionConstraint.parse("^0.1.2")));
+        expect(pubspec.sdkConstraints,
+            containsPair('fuchsia', new VersionConstraint.parse("^5.6.7")));
       });
 
       test("throws if the sdk isn't a string", () {
@@ -741,6 +748,7 @@ features:
     environment:
       sdk: ^1.0.0
       flutter: ^2.0.0
+      fuchsia: ^3.0.0
 ''', sources);
 
         expect(pubspec.features, contains('foobar'));
@@ -750,6 +758,8 @@ features:
             containsPair('dart', new VersionConstraint.parse("^1.0.0")));
         expect(feature.sdkConstraints,
             containsPair('flutter', new VersionConstraint.parse("^2.0.0")));
+        expect(feature.sdkConstraints,
+            containsPair('fuchsia', new VersionConstraint.parse("^3.0.0")));
       });
 
       test("throws if the default value isn't a boolean", () {

--- a/test/sdk_test.dart
+++ b/test/sdk_test.dart
@@ -7,6 +7,7 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:pub/src/io.dart';
 
 import 'descriptor.dart' as d;
 import 'test_pub.dart';

--- a/test/sdk_test.dart
+++ b/test/sdk_test.dart
@@ -148,5 +148,24 @@ main() {
             """), exitCode: exit_codes.UNAVAILABLE);
       });
     });
+
+    test("supports the Fuchsia SDK", () async {
+      await renameDir(
+          p.join(d.sandbox, 'flutter'), p.join(d.sandbox, 'fuchsia'));
+
+      await d.appDir({
+        "foo": {"sdk": "fuchsia"}
+      }).create();
+      await pubCommand(command,
+          environment: {'FUCHSIA_DART_SDK_ROOT': p.join(d.sandbox, 'fuchsia')});
+
+      await d.dir(appPath, [
+        d.packagesFile({
+          'myapp': '.',
+          'foo': p.join(d.sandbox, 'fuchsia', 'packages', 'foo'),
+          'bar': '1.0.0'
+        })
+      ]).validate();
+    });
   });
 }

--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -132,7 +132,7 @@ main() {
         d.pubspec({
           "name": "test_pkg",
           "version": "1.0.0",
-          "environment": {"sdk": ">=2.0.0-dev.48.0 <2.0.0"},
+          "environment": {"sdk": ">=2.0.0-dev.51.0 <2.0.0"},
           "dependencies": {
             "foo": {"sdk": "fuchsia", "version": ">=1.2.3 <2.0.0"}
           }
@@ -617,14 +617,14 @@ main() {
         d.pubspec({
           "name": "test_pkg",
           "version": "1.0.0",
-          "environment": {"sdk": ">=2.0.0-dev.47.0 <2.0.0"},
+          "environment": {"sdk": ">=2.0.0-dev.50.0 <2.0.0"},
           "dependencies": {
             "foo": {"sdk": "fuchsia", "version": ">=1.2.3 <2.0.0"}
           }
         })
       ]).create();
 
-      expectDependencyValidationError('sdk: ">=2.0.0-dev.48.0 <2.0.0"');
+      expectDependencyValidationError('sdk: ">=2.0.0-dev.51.0 <2.0.0"');
     });
 
     test("depends on a Fuchsia package with no SDK constraint", () async {
@@ -638,7 +638,7 @@ main() {
         })
       ]).create();
 
-      expectDependencyValidationError('sdk: ">=2.0.0-dev.48.0 <2.0.0"');
+      expectDependencyValidationError('sdk: ">=2.0.0-dev.51.0 <2.0.0"');
     });
   });
 }

--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -95,8 +95,47 @@ main() {
 
     test('depends on Flutter from an SDK source', () async {
       await d.dir(appPath, [
-        d.libPubspec("test_pkg", "1.0.0", deps: {
-          "flutter": {"sdk": ">=1.2.3 <2.0.0"}
+        d.pubspec({
+          "name": "test_pkg",
+          "version": "1.0.0",
+          "environment": {"sdk": ">=1.19.0 <2.0.0"},
+          "dependencies": {
+            "flutter": {"sdk": "flutter"}
+          }
+        })
+      ]).create();
+
+      expectNoValidationError(dependency);
+    });
+
+    test(
+        'depends on a package from Flutter with an appropriate Dart SDK '
+        'constraint', () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "test_pkg",
+          "version": "1.0.0",
+          "environment": {"sdk": ">=1.19.0 <2.0.0"},
+          "dependencies": {
+            "foo": {"sdk": "flutter", "version": ">=1.2.3 <2.0.0"}
+          }
+        })
+      ]).create();
+
+      expectNoValidationError(dependency);
+    });
+
+    test(
+        'depends on a package from Fuchsia with an appropriate Dart SDK '
+        'constraint', () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "test_pkg",
+          "version": "1.0.0",
+          "environment": {"sdk": ">=2.0.0-dev.48.0 <2.0.0"},
+          "dependencies": {
+            "foo": {"sdk": "fuchsia", "version": ">=1.2.3 <2.0.0"}
+          }
         })
       ]).create();
 
@@ -461,7 +500,8 @@ main() {
 
         expect(
             validatePackage(dependency),
-            completion(pairOf(anyElement(contains('  sdk: ">=2.0.0 <3.0.0"')),
+            completion(pairOf(
+                anyElement(contains('  sdk: ">=2.0.0-dev.1.0 <2.0.0"')),
                 anyElement(contains('  foo: any')))));
       });
 
@@ -481,7 +521,8 @@ main() {
 
         expect(
             validatePackage(dependency),
-            completion(pairOf(anyElement(contains('  sdk: ">=2.0.0 <3.0.0"')),
+            completion(pairOf(
+                anyElement(contains('  sdk: ">=2.0.0-dev.1.0 <2.0.0"')),
                 anyElement(contains('  foo: any')))));
       });
     });
@@ -523,6 +564,81 @@ main() {
       ]).create();
 
       expectDependencyValidationError('sdk: >=1.2.3 <2.0.0');
+    });
+
+    test("depends on a Flutter package from an unknown SDK", () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "test_pkg",
+          "version": "1.0.0",
+          "dependencies": {
+            "foo": {"sdk": "fblthp", "version": ">=1.2.3 <2.0.0"}
+          }
+        })
+      ]).create();
+
+      expectDependencyValidationError(
+          'Unknown SDK "fblthp" for dependency "foo".');
+    });
+
+    test("depends on a Flutter package with a too-broad SDK constraint",
+        () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "test_pkg",
+          "version": "1.0.0",
+          "environment": {"sdk": ">=1.18.0 <2.0.0"},
+          "dependencies": {
+            "foo": {"sdk": "flutter", "version": ">=1.2.3 <2.0.0"}
+          }
+        })
+      ]).create();
+
+      expectDependencyValidationError('sdk: ">=1.19.0 <2.0.0"');
+    });
+
+    test("depends on a Flutter package with no SDK constraint", () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "test_pkg",
+          "version": "1.0.0",
+          "dependencies": {
+            "foo": {"sdk": "flutter", "version": ">=1.2.3 <2.0.0"}
+          }
+        })
+      ]).create();
+
+      expectDependencyValidationError('sdk: ">=1.19.0 <2.0.0"');
+    });
+
+    test("depends on a Fuchsia package with a too-broad SDK constraint",
+        () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "test_pkg",
+          "version": "1.0.0",
+          "environment": {"sdk": ">=2.0.0-dev.47.0 <2.0.0"},
+          "dependencies": {
+            "foo": {"sdk": "fuchsia", "version": ">=1.2.3 <2.0.0"}
+          }
+        })
+      ]).create();
+
+      expectDependencyValidationError('sdk: ">=2.0.0-dev.48.0 <2.0.0"');
+    });
+
+    test("depends on a Fuchsia package with no SDK constraint", () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "test_pkg",
+          "version": "1.0.0",
+          "dependencies": {
+            "foo": {"sdk": "fuchsia", "version": ">=1.2.3 <2.0.0"}
+          }
+        })
+      ]).create();
+
+      expectDependencyValidationError('sdk: ">=2.0.0-dev.48.0 <2.0.0"');
     });
   });
 }

--- a/test/validator/sdk_constraint_test.dart
+++ b/test/validator/sdk_constraint_test.dart
@@ -48,7 +48,7 @@ main() {
         d.pubspec({
           "name": "test_pkg",
           "version": "1.0.0",
-          "environment": {"sdk": ">=2.0.0-dev.48.0 <2.0.0", "fuchsia": "^1.2.3"}
+          "environment": {"sdk": ">=2.0.0-dev.51.0 <2.0.0", "fuchsia": "^1.2.3"}
         })
       ]).create();
       expectNoValidationError(sdkConstraint);
@@ -121,13 +121,13 @@ main() {
         d.pubspec({
           "name": "test_pkg",
           "version": "1.0.0",
-          "environment": {"sdk": ">=2.0.0-dev.47.0 <2.0.0", "fuchsia": "^1.2.3"}
+          "environment": {"sdk": ">=2.0.0-dev.50.0 <2.0.0", "fuchsia": "^1.2.3"}
         })
       ]).create();
       expect(
           validatePackage(sdkConstraint),
           completion(pairOf(
-              anyElement(contains('">=2.0.0-dev.48.0 <2.0.0"')), isEmpty)));
+              anyElement(contains('">=2.0.0-dev.51.0 <2.0.0"')), isEmpty)));
     });
 
     test("has a Fuchsia SDK constraint with no SDK constraint", () async {
@@ -141,7 +141,7 @@ main() {
       expect(
           validatePackage(sdkConstraint),
           completion(pairOf(
-              anyElement(contains('">=2.0.0-dev.48.0 <2.0.0"')), isEmpty)));
+              anyElement(contains('">=2.0.0-dev.51.0 <2.0.0"')), isEmpty)));
     });
   });
 }

--- a/test/validator/sdk_constraint_test.dart
+++ b/test/validator/sdk_constraint_test.dart
@@ -40,6 +40,19 @@ main() {
       ]).create();
       expectNoValidationError(sdkConstraint);
     });
+
+    test(
+        'has a Fuchsia SDK constraint with an appropriate Dart SDK '
+        'constraint', () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "test_pkg",
+          "version": "1.0.0",
+          "environment": {"sdk": ">=2.0.0-dev.48.0 <2.0.0", "fuchsia": "^1.2.3"}
+        })
+      ]).create();
+      expectNoValidationError(sdkConstraint);
+    });
   });
 
   group("should consider a package invalid if it", () {
@@ -99,6 +112,36 @@ main() {
           validatePackage(sdkConstraint),
           completion(
               pairOf(anyElement(contains('">=1.19.0 <2.0.0"')), isEmpty)));
+    });
+
+    test(
+        "has a Fuchsia SDK constraint with a too-broad SDK "
+        "constraint", () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "test_pkg",
+          "version": "1.0.0",
+          "environment": {"sdk": ">=2.0.0-dev.47.0 <2.0.0", "fuchsia": "^1.2.3"}
+        })
+      ]).create();
+      expect(
+          validatePackage(sdkConstraint),
+          completion(pairOf(
+              anyElement(contains('">=2.0.0-dev.48.0 <2.0.0"')), isEmpty)));
+    });
+
+    test("has a Fuchsia SDK constraint with no SDK constraint", () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "test_pkg",
+          "version": "1.0.0",
+          "environment": {"fuchsia": "^1.2.3"}
+        })
+      ]).create();
+      expect(
+          validatePackage(sdkConstraint),
+          completion(pairOf(
+              anyElement(contains('">=2.0.0-dev.48.0 <2.0.0"')), isEmpty)));
     });
   });
 }

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -24,7 +24,7 @@ main() {
   group('bad source', badSource);
   group('backtracking', backtracking);
   group('Dart SDK constraint', dartSdkConstraint);
-  group('Flutter SDK constraint', flutterSdkConstraint);
+  group('SDK constraint', sdkConstraint);
   group('pre-release', prerelease);
   group('override', override);
   group('downgrade', downgrade);
@@ -1431,7 +1431,7 @@ void dartSdkConstraint() {
   });
 }
 
-void flutterSdkConstraint() {
+void sdkConstraint() {
   group('without a Flutter SDK', () {
     test('fails for the root package', () async {
       await d.dir(appPath, [
@@ -1491,6 +1491,22 @@ void flutterSdkConstraint() {
         Flutter users should run `flutter packages get` instead of `pub get`.
       '''));
     });
+  });
+
+  test('without a Fuchsia SDK fails for the root package', () async {
+    await d.dir(appPath, [
+      await d.pubspec({
+        'name': 'myapp',
+        'environment': {'fuchsia': '1.2.3'}
+      })
+    ]).create();
+
+    await expectResolves(error: equalsIgnoringWhitespace('''
+        Because myapp requires the Fuchsia SDK, version solving failed.
+
+        Please set the FUCHSIA_DART_SDK_ROOT environment variable to point to
+          the root of the Fuchsia SDK for Dart.
+      '''));
   });
 
   group('with a Flutter SDK', () {


### PR DESCRIPTION
This also adds validation that requires an appropriate Dartk SDK
constraint in order for a package that has a dependency from the
Flutter SDK to be published.

Closes #1862