### PR TITLE
Fix parse errors with `--preview-dart-2`

### DIFF
--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -66,9 +66,9 @@ class _PubHttpClient extends http.BaseClient {
     var streamedResponse;
     try {
       streamedResponse = await _inner.send(request);
-    } on SocketException catch (error, stackTrace) {
+    } on SocketException catch (error, stackTraceOrNull) {
       // Work around issue 23008.
-      final defaultedStackTrace = stackTrace ?? new Chain.current();
+      var stackTrace = stackTraceOrNull ?? new Chain.current();
 
       if (error.osError == null) rethrow;
 
@@ -78,13 +78,13 @@ class _PubHttpClient extends http.BaseClient {
           error.osError.errorCode == 11001 ||
           error.osError.errorCode == 11004) {
         fail('Could not resolve URL "${request.url.origin}".', error,
-            defaultedStackTrace);
+            stackTrace);
       } else if (error.osError.errorCode == -12276) {
         fail(
             'Unable to validate SSL certificate for '
             '"${request.url.origin}".',
             error,
-            defaultedStackTrace);
+            stackTrace);
       } else {
         rethrow;
       }

--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -68,7 +68,7 @@ class _PubHttpClient extends http.BaseClient {
       streamedResponse = await _inner.send(request);
     } on SocketException catch (error, stackTrace) {
       // Work around issue 23008.
-      if (stackTrace == null) stackTrace = new Chain.current();
+      final defaultedStackTrace = stackTrace ?? new Chain.current();
 
       if (error.osError == null) rethrow;
 
@@ -78,13 +78,13 @@ class _PubHttpClient extends http.BaseClient {
           error.osError.errorCode == 11001 ||
           error.osError.errorCode == 11004) {
         fail('Could not resolve URL "${request.url.origin}".', error,
-            stackTrace);
+            defaultedStackTrace);
       } else if (error.osError.errorCode == -12276) {
         fail(
             'Unable to validate SSL certificate for '
             '"${request.url.origin}".',
             error,
-            stackTrace);
+            defaultedStackTrace);
       } else {
         rethrow;
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,9 +3,9 @@ name: pub
 dependencies:
   # Note: Pub's test infrastructure assumes that any dependencies used in tests
   # will be hosted dependencies.
-  analyzer: ">=0.25.0 <0.31.0"
+  analyzer: ^0.31.2-alpha.1
   args: ">=0.13.5 <2.0.0"
-  async: ">=1.12.0 <3.0.0"
+  async: ^2.0.0
   collection: "^1.8.0"
   crypto: ">=1.0.0 <3.0.0"
   http: "^0.11.0"
@@ -19,7 +19,7 @@ dependencies:
   path: "^1.2.0"
   pool: "^1.0.0"
   pub_semver: "^1.3.0"
-  shelf: ">=0.6.0 <0.7.0"
+  shelf: ^0.7.0
   source_span: "^1.4.0"
   stack_trace: "^1.0.0"
   yaml: "^2.0.0"


### PR DESCRIPTION
We need the latest analyzer, front_end, and async to get past static
errors in these packages. Shelf needs to be updated to get the latest
async.

Fix a static error that is not caught by the analyzer around reassigning
the final `stackTrace` variable in a catch clause.