### PR TITLE
Remove newFuture utility

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -96,10 +96,6 @@ class Pair<E, F> {
   int get hashCode => first.hashCode ^ last.hashCode;
 }
 
-/// Like [new Future], but avoids around issue 11911 by using [new Future.value]
-/// under the covers.
-Future newFuture(callback()) => new Future.value().then((_) => callback());
-
 /// Runs [callback] in an error zone and pipes any unhandled error to the
 /// returned [Future].
 ///

--- a/test/error_group_test.dart
+++ b/test/error_group_test.dart
@@ -264,9 +264,7 @@ main() {
       expect(stream.first, throwsFormatException);
       errorGroup.signalError(new FormatException());
 
-      expect(newFuture(() {
-        controller.add('value');
-      }), completes);
+      expect(() => controller.add('value'), returnsNormally);
     });
 
     test(


### PR DESCRIPTION
This was unused except in one test where it isn't necessary