### PR TITLE
Don't line wrap output if not connected to a terminal.

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -66,16 +66,15 @@ const reservedWords = const [
 /// An cryptographically secure instance of [math.Random].
 final random = new math.Random.secure();
 
-/// The default line length for output when there isn't a terminal attached to
-/// stdout.
-const _defaultLineLength = 100;
-
 /// The maximum line length for output.
+///
+/// If pub isn't attached to a terminal, uses an infinite line length and does
+/// not wrap text.
 final int lineLength = () {
   try {
     return stdout.terminalColumns;
   } on StdoutException {
-    return _defaultLineLength;
+    return null;
   }
 }();
 
@@ -727,7 +726,7 @@ String createUuid([List<int> bytes]) {
       '${chars.substring(12, 16)}-${chars.substring(16, 20)}-${chars.substring(20, 32)}';
 }
 
-/// Wraps [text] so that it fits within [lineLength].
+/// Wraps [text] so that it fits within [lineLength], if there is a line length.
 ///
 /// This preserves existing newlines and doesn't consider terminal color escapes
 /// part of a word's length. It only splits words on spaces, not on other sorts
@@ -735,6 +734,9 @@ String createUuid([List<int> bytes]) {
 ///
 /// If [prefix] is passed, it's added at the beginning of any wrapped lines.
 String wordWrap(String text, {String prefix}) {
+  // If there is no limit, don't wrap.
+  if (lineLength == null) return text;
+
   prefix ??= "";
   return text.split("\n").map((originalLine) {
     var buffer = new StringBuffer();

--- a/test/get/hosted/get_test.dart
+++ b/test/get/hosted/get_test.dart
@@ -33,8 +33,7 @@ main() {
         error: allOf([
           contains(
               "Because myapp depends on bad name! any which doesn't exist (could "
-              "not find package bad name! at\n"),
-          contains("http://localhost:"),
+              "not find package bad name! at http://localhost:"),
           contains("), version solving failed.")
         ]),
         exitCode: exit_codes.UNAVAILABLE);

--- a/test/get/path/nonexistent_dir_test.dart
+++ b/test/get/path/nonexistent_dir_test.dart
@@ -23,7 +23,7 @@ main() {
     await pubGet(
         error: allOf([
           contains("Because myapp depends on foo from path which doesn't exist "
-              "(could not find package foo at\n"),
+              "(could not find package foo at"),
           contains('bad_path"), version solving failed.')
         ]),
         exitCode: exit_codes.NO_INPUT);

--- a/test/global/activate/unknown_package_test.dart
+++ b/test/global/activate/unknown_package_test.dart
@@ -16,8 +16,7 @@ main() {
         error: allOf([
           contains(
               "Because pub global activate depends on foo any which doesn't "
-              "exist (could not find package foo at\n"),
-          contains("http://localhost:"),
+              "exist (could not find package foo at http://localhost:"),
           contains("), version solving failed.")
         ]),
         exitCode: exit_codes.UNAVAILABLE);

--- a/test/hosted/fail_gracefully_on_missing_package_test.dart
+++ b/test/hosted/fail_gracefully_on_missing_package_test.dart
@@ -20,8 +20,7 @@ main() {
           error: allOf([
             contains(
                 "Because myapp depends on foo any which doesn't exist (could "
-                "not find package foo at\n"),
-            contains("http://localhost:"),
+                "not find package foo at http://localhost:"),
             contains("), version solving failed.")
           ]),
           exitCode: exit_codes.UNAVAILABLE);

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -503,9 +503,9 @@ void unsolvable() {
         error: allOf([
       contains('Because every version of foo depends on shared from hosted on '
           'http://localhost:'),
-      contains(' and every\n  version of bar depends on shared from hosted on '
+      contains(' and every version of bar depends on shared from hosted on '
           'http://localhost:'),
-      contains(', foo is incompatible with\n  bar.'),
+      contains(', foo is incompatible with bar.'),
       contains('So, because myapp depends on both bar 1.0.0 and foo 1.0.0, '
           'version solving failed.')
     ]));
@@ -753,14 +753,12 @@ void backtracking() {
         // We avoid equalsIgnoringWhitespace() here because we want to test the
         // formatting of the line number.
         error: '    Because foo <1.1.0 depends on a ^1.0.0 which depends on b '
-            '^2.0.0, foo <1.1.0 requires b\n'
-            '      ^2.0.0.\n'
+            '^2.0.0, foo <1.1.0 requires b ^2.0.0.\n'
             '(1) So, because foo <1.1.0 depends on b ^1.0.0, foo <1.1.0 is '
             'forbidden.\n'
             '\n'
             '    Because foo >=1.1.0 depends on x ^1.0.0 which depends on y '
-            '^2.0.0, foo >=1.1.0 requires y\n'
-            '      ^2.0.0.\n'
+            '^2.0.0, foo >=1.1.0 requires y ^2.0.0.\n'
             '    And because foo >=1.1.0 depends on y ^1.0.0, foo >=1.1.0 is '
             'forbidden.\n'
             '    And because foo <1.1.0 is forbidden (1), foo is forbidden.\n'
@@ -931,7 +929,7 @@ void backtracking() {
         error: allOf([
       contains('Because every version of b depends on a from hosted on '
           'http://localhost:'),
-      contains(' and myapp depends on\n  a from hosted on http://localhost:'),
+      contains(' and myapp depends on a from hosted on http://localhost:'),
       contains(', b is forbidden.'),
       contains('So, because myapp depends on b any, version solving failed.')
     ]));


### PR DESCRIPTION
I think this is a generally good change -- if you're piping to a file
or something, the word wrapping is probably just going to annoying. But
it also makes the tests less brittle to line wrapping differences.

In particular, some tests fail on Mac because the sandbox path lengths
are different, which in turn causes the output to word wrap differently.