### PR TITLE
Lazily load Flutter's version

### DIFF
--- a/lib/src/sdk/flutter.dart
+++ b/lib/src/sdk/flutter.dart
@@ -22,12 +22,14 @@ class FlutterSdk extends Sdk {
   String get installMessage =>
       "Flutter users should run `flutter packages get` instead of `pub get`.";
 
-  final Version version = () {
+  Version get version {
     if (!_isAvailable) return null;
 
-    return new Version.parse(
+    _version ??= new Version.parse(
         readTextFile(p.join(_rootDirectory, "version")).trim());
-  }();
+    return _version;
+  }
+  Version _version;
 
   String packagePath(String name) {
     if (!isAvailable) return null;

--- a/lib/src/sdk/flutter.dart
+++ b/lib/src/sdk/flutter.dart
@@ -29,6 +29,7 @@ class FlutterSdk extends Sdk {
         readTextFile(p.join(_rootDirectory, "version")).trim());
     return _version;
   }
+
   Version _version;
 
   String packagePath(String name) {

--- a/lib/src/sdk/fuchsia.dart
+++ b/lib/src/sdk/fuchsia.dart
@@ -24,12 +24,14 @@ class FuchsiaSdk extends Sdk {
       "Please set the FUCHSIA_DART_SDK_ROOT environment variable to point to "
       "the root of the Fuchsia SDK for Dart.";
 
-  final Version version = () {
+  Version get version {
     if (!_isAvailable) return null;
 
-    return new Version.parse(
+    _version ??= new Version.parse(
         readTextFile(p.join(_rootDirectory, "version")).trim());
-  }();
+    return _version;
+  }
+  Version _version;
 
   String packagePath(String name) {
     if (!isAvailable) return null;

--- a/lib/src/sdk/fuchsia.dart
+++ b/lib/src/sdk/fuchsia.dart
@@ -31,6 +31,7 @@ class FuchsiaSdk extends Sdk {
         readTextFile(p.join(_rootDirectory, "version")).trim());
     return _version;
   }
+
   Version _version;
 
   String packagePath(String name) {

--- a/test/sdk_test.dart
+++ b/test/sdk_test.dart
@@ -88,6 +88,21 @@ main() {
           .validate();
     });
 
+    // Regression test for #1883
+    test("doesn't fail if the Flutter SDK's version file doesn't exist when "
+        "nothing depends on Flutter", () async {
+      await d.appDir().create();
+      await deleteEntry(p.join(d.sandbox, 'flutter', 'version'));
+      await pubCommand(command,
+          environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')});
+
+      await d.dir(appPath, [
+        d.packagesFile({
+          'myapp': '.'
+        })
+      ]).validate();
+    });
+
     group("fails if", () {
       test("the version constraint doesn't match", () async {
         await d.appDir({

--- a/test/sdk_test.dart
+++ b/test/sdk_test.dart
@@ -89,7 +89,8 @@ main() {
     });
 
     // Regression test for #1883
-    test("doesn't fail if the Flutter SDK's version file doesn't exist when "
+    test(
+        "doesn't fail if the Flutter SDK's version file doesn't exist when "
         "nothing depends on Flutter", () async {
       await d.appDir().create();
       await deleteEntry(p.join(d.sandbox, 'flutter', 'version'));
@@ -97,9 +98,7 @@ main() {
           environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')});
 
       await d.dir(appPath, [
-        d.packagesFile({
-          'myapp': '.'
-        })
+        d.packagesFile({'myapp': '.'})
       ]).validate();
     });
 


### PR DESCRIPTION
This ensures that we don't fail with Flutter-related errors when
nothing depends on Flutter, even if FLUTTER_ROOT points to an invalid
directory.

Closes #1883