### PR TITLE
Use Platform.version for the SDK version

### DIFF
--- a/lib/src/sdk/dart.dart
+++ b/lib/src/sdk/dart.dart
@@ -42,8 +42,7 @@ class DartSdk extends Sdk {
     if (sdkVersion != null) return new Version.parse(sdkVersion);
 
     if (!runningFromDartRepo) {
-      // Read the "version" file.
-      var version = readTextFile(p.join(_rootDirectory, "version")).trim();
+      var version = Platform.version.split(' ').first;
       return new Version.parse(version);
     }
 


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/