### PR TITLE
Retry on pub server status 500

### DIFF
--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -227,7 +227,8 @@ final httpClient = new ThrottleClient(
     16,
     new _ThrowingClient(new RetryClient(_pubClient,
         retries: 5,
-        when: (response) => const [502, 503, 504].contains(response.statusCode),
+        when: (response) =>
+            const [500, 502, 503, 504].contains(response.statusCode),
         whenError: (error, stackTrace) {
           if (error is! IOException) return false;
 


### PR DESCRIPTION
Previously, pub retried up to 5 times when it received a response with
HTTP status 502, 503, 504. This adds 500 to the list of retryable
response statuses.