### PR TITLE
Support the latest pub_semver

### DIFF
--- a/lib/src/package_name.dart
+++ b/lib/src/package_name.dart
@@ -286,10 +286,11 @@ class PackageRange extends PackageName {
     if (constraint.toString().startsWith("^")) return this;
 
     var range = constraint as VersionRange;
-    if (range.includeMin &&
-        !range.includeMax &&
-        range.min != null &&
-        range.max == range.min.nextBreaking) {
+    if (!range.includeMin) return this;
+    if (range.includeMax) return this;
+    if (range.min == null) return this;
+    if (range.max == range.min.nextBreaking.firstPreRelease ||
+        (range.min.isPreRelease && range.max == range.min.nextBreaking)) {
       return withConstraint(new VersionConstraint.compatibleWith(range.min));
     } else {
       return this;

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -302,16 +302,15 @@ class Pubspec {
     if (sdkConstraint.includeMax) return false;
     if (sdkConstraint.min != null &&
         sdkConstraint.min.isPreRelease &&
-        sdkConstraint.min.major == sdk.version.major &&
-        sdkConstraint.min.minor == sdk.version.minor &&
-        sdkConstraint.min.patch == sdk.version.patch) {
+        equalsIgnoringPreRelease(sdkConstraint.min, sdk.version)) {
       return false;
     }
     if (sdkConstraint.max == null) return false;
-    if (sdkConstraint.max.isPreRelease) return false;
-    return sdkConstraint.max.major == sdk.version.major &&
-        sdkConstraint.max.minor == sdk.version.minor &&
-        sdkConstraint.max.patch == sdk.version.patch;
+    if (sdkConstraint.max.isPreRelease &&
+        !sdkConstraint.max.isFirstPreRelease) {
+      return false;
+    }
+    return equalsIgnoringPreRelease(sdkConstraint.max, sdk.version);
   }
 
   /// Parses the "environment" field in [parent] and returns a map from SDK

--- a/lib/src/solver/package_lister.dart
+++ b/lib/src/solver/package_lister.dart
@@ -264,7 +264,8 @@ class PackageLister {
           min: lower[package],
           includeMin: true,
           max: upper[package],
-          includeMax: false);
+          includeMax: false,
+          alwaysIncludeMaxPreRelease: true);
 
       _alreadyListedDependencies[package] = constraint.union(
           _alreadyListedDependencies[package] ?? VersionConstraint.empty);
@@ -298,7 +299,8 @@ class PackageLister {
         max: bounds.last == versions.length - 1
             ? null
             : versions[bounds.last + 1].version,
-        includeMax: false);
+        includeMax: false,
+        alwaysIncludeMaxPreRelease: true);
     _knownInvalidVersions = incompatibleVersions.union(_knownInvalidVersions);
 
     var sdkConstraint = await foldAsync(

--- a/lib/src/solver/reformat_ranges.dart
+++ b/lib/src/solver/reformat_ranges.dart
@@ -70,7 +70,7 @@ Term _reformatTerm(Map<PackageRef, PackageLister> packageListers, Term term) {
 Version _reformatMin(List<PackageId> versions, VersionRange range) {
   if (range.min == null) return null;
   if (!range.includeMin) return null;
-  if (!min.isFirstPreRelease) return null;
+  if (!range.min.isFirstPreRelease) return null;
 
   var index = _lowerBound(versions, range.min);
   var next = index == versions.length ? null : versions[index].version;
@@ -87,17 +87,19 @@ Version _reformatMin(List<PackageId> versions, VersionRange range) {
 Pair<Version, bool> _reformatMax(List<PackageId> versions, VersionRange range) {
   if (range.max == null) return null;
   if (!range.includeMax) return null;
-  if (max.isPreRelease) return null;
-  if (min != null && min.isPreRelease && equalsIgnoringPreRelease(min, max)) {
+  if (range.max.isPreRelease) return null;
+  if (range.min != null &&
+      range.min.isPreRelease &&
+      equalsIgnoringPreRelease(range.min, range.max)) {
     return null;
   }
 
-  var index = _lowerBound(versions, max);
+  var index = _lowerBound(versions, range.max);
   var previous = index == 0 ? null : versions[index - 1].version;
 
-  return previous != null && equalsIgnoringPreRelease(previous, max)
+  return previous != null && equalsIgnoringPreRelease(previous, range.max)
       ? new Pair(previous, true)
-      : new Pair(max.firstPreRelease, false);
+      : new Pair(range.max.firstPreRelease, false);
 }
 
 /// Returns the first index in [ids] (which is sorted by version) whose version

--- a/lib/src/solver/reformat_ranges.dart
+++ b/lib/src/solver/reformat_ranges.dart
@@ -47,6 +47,7 @@ Term _reformatTerm(Map<PackageRef, PackageLister> packageListers, Term term) {
   var versions = packageListers[term.package.toRef()]?.cachedVersions ?? [];
 
   if (term.package.constraint is! VersionRange) return term;
+  if (term.package.constraint is Version) return term;
   var range = term.package.constraint as VersionRange;
 
   var min = _reformatMin(versions, range);

--- a/lib/src/solver/reformat_ranges.dart
+++ b/lib/src/solver/reformat_ranges.dart
@@ -57,12 +57,14 @@ Term _reformatTerm(Map<PackageRef, PackageLister> packageListers, Term term) {
 
   if (min == null && max == null) return term;
   return new Term(
-      term.package.withConstraint(new VersionRange(
-          min: min ?? range.min,
-          max: max ?? range.max,
-          includeMin: range.includeMin,
-          includeMax: includeMax ?? range.includeMax,
-          alwaysIncludeMaxPreRelease: true)),
+      term.package
+          .withConstraint(new VersionRange(
+              min: min ?? range.min,
+              max: max ?? range.max,
+              includeMin: range.includeMin,
+              includeMax: includeMax ?? range.includeMax,
+              alwaysIncludeMaxPreRelease: true))
+          .withTerseConstraint(),
       term.isPositive);
 }
 
@@ -87,7 +89,7 @@ Version _reformatMin(List<PackageId> versions, VersionRange range) {
 /// is inclusive, or `null` if it doesn't need to be reformatted.
 Pair<Version, bool> _reformatMax(List<PackageId> versions, VersionRange range) {
   if (range.max == null) return null;
-  if (!range.includeMax) return null;
+  if (range.includeMax) return null;
   if (range.max.isPreRelease) return null;
   if (range.min != null &&
       range.min.isPreRelease &&

--- a/lib/src/solver/version_solver.dart
+++ b/lib/src/solver/version_solver.dart
@@ -23,6 +23,7 @@ import 'incompatibility.dart';
 import 'incompatibility_cause.dart';
 import 'package_lister.dart';
 import 'partial_solution.dart';
+import 'reformat_ranges.dart';
 import 'result.dart';
 import 'set_relation.dart';
 import 'term.dart';
@@ -305,7 +306,7 @@ class VersionSolver {
       _log("$bang thus: $incompatibility");
     }
 
-    throw new SolveFailure(incompatibility);
+    throw new SolveFailure(reformatRanges(_packageListers, incompatibility));
   }
 
   /// Tries to select a version of a required package.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -10,6 +10,7 @@ import 'dart:math' as math;
 
 import "package:crypto/crypto.dart" as crypto;
 import 'package:meta/meta.dart';
+import 'package:pub_semver/pub_semver.dart';
 import "package:stack_trace/stack_trace.dart";
 
 import 'exceptions.dart';
@@ -660,3 +661,10 @@ final _exceptionPrefix = new RegExp(r'^([A-Z][a-zA-Z]*)?(Exception|Error): ');
 /// [toString], so we remove that if it exists.
 String getErrorMessage(error) =>
     error.toString().replaceFirst(_exceptionPrefix, '');
+
+/// Returns whether [version1] and [version2] are the same, ignoring the
+/// pre-release modifiers on each if they exist.
+bool equalsIgnoringPreRelease(Version version1, Version version2) =>
+    version1.major == version2.major &&
+    version1.minor == version2.minor &&
+    version1.patch == version2.patch;

--- a/lib/src/validator/sdk_constraint.dart
+++ b/lib/src/validator/sdk_constraint.dart
@@ -19,13 +19,18 @@ class SdkConstraintValidator extends Validator {
     var dartConstraint = entrypoint.root.pubspec.originalDartSdkConstraint;
     if (dartConstraint is VersionRange) {
       if (dartConstraint.toString().startsWith("^")) {
+        var dartConstraintWithoutCaret = new VersionRange(
+            min: dartConstraint.min,
+            max: dartConstraint.max,
+            includeMin: dartConstraint.includeMin,
+            includeMax: dartConstraint.includeMax);
         errors.add(
             "^ version constraints aren't allowed for SDK constraints since "
             "older versions of pub don't support them.\n"
             "Expand it manually instead:\n"
             "\n"
             "environment:\n"
-            "  sdk: \">=${dartConstraint.min} <${dartConstraint.max}\"");
+            "  sdk: \"$dartConstraintWithoutCaret\"");
       }
 
       if (dartConstraint.max == null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   package_resolver: "^1.0.0"
   path: "^1.2.0"
   pool: "^1.0.0"
-  pub_semver: "^1.3.0"
+  pub_semver: "^1.4.0"
   shelf: ^0.7.0
   source_span: "^1.4.0"
   stack_trace: "^1.0.0"
@@ -32,4 +32,3 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0-dev.22.0 <2.0.0"
-


### PR DESCRIPTION
This rewrites failures' incompatibility graphs so that they refer to
real version numbers rather than the pessimistic ranges that
pub_semver can now generate.

Note that this is expected to have one failing test until
dart-lang/pub_semver#30 lands and pub_semver 1.4.1 is released.