### PR TITLE
Add back build/serve argparser options

### DIFF
--- a/lib/src/command/barback.dart
+++ b/lib/src/command/barback.dart
@@ -2,21 +2,17 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:args/command_runner.dart';
-
 import '../command.dart';
 import '../log.dart' as log;
 import '../utils.dart';
 
 /// Shared base class for [BuildCommand] and [ServeCommand].
 abstract class BarbackCommand extends PubCommand {
-  @override
-  usageException(_) => throw new UsageException(_deprecationError, '');
-
-  String get _deprecationError =>
-      log.red("Dart 2 has a new build system. Learn how to migrate "
-          "from ${log.bold('pub build')} and\n"
-          "${log.bold('pub serve')}: https://webdev.dartlang.org/dart-2\n");
+  BarbackCommand() {
+    argParser.addOption("mode", hide: true);
+    argParser.addFlag("all", hide: true);
+    argParser.addOption("web-compiler", hide: true);
+  }
 
   run() {
     // Switch to JSON output if specified. We need to do this before parsing
@@ -25,6 +21,8 @@ abstract class BarbackCommand extends PubCommand {
     log.json.enabled =
         argResults.options.contains("format") && argResults["format"] == "json";
 
-    fail(_deprecationError);
+    fail(log.red("Dart 2 has a new build system. Learn how to migrate "
+        "from ${log.bold('pub build')} and\n"
+        "${log.bold('pub serve')}: https://webdev.dartlang.org/dart-2\n"));
   }
 }

--- a/lib/src/command/barback.dart
+++ b/lib/src/command/barback.dart
@@ -4,14 +4,12 @@
 
 import 'package:args/command_runner.dart';
 
+import '../command.dart';
 import '../log.dart' as log;
 import '../utils.dart';
 
 /// Shared base class for [BuildCommand] and [ServeCommand].
-abstract class BarbackCommand extends Command {
-  @override
-  bool get takesArguments => false;
-
+abstract class BarbackCommand extends PubCommand {
   @override
   usageException(_) => throw new UsageException(_deprecationError, '');
 

--- a/lib/src/command/barback.dart
+++ b/lib/src/command/barback.dart
@@ -2,12 +2,24 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import '../command.dart';
+import 'package:args/command_runner.dart';
+
 import '../log.dart' as log;
 import '../utils.dart';
 
 /// Shared base class for [BuildCommand] and [ServeCommand].
-abstract class BarbackCommand extends PubCommand {
+abstract class BarbackCommand extends Command {
+  @override
+  bool get takesArguments => false;
+
+  @override
+  usageException(_) => throw new UsageException(_deprecationError, '');
+
+  String get _deprecationError =>
+      log.red("Dart 2 has a new build system. Learn how to migrate "
+          "from ${log.bold('pub build')} and\n"
+          "${log.bold('pub serve')}: https://webdev.dartlang.org/dart-2\n");
+
   run() {
     // Switch to JSON output if specified. We need to do this before parsing
     // the source directories so an error will be correctly reported in JSON
@@ -15,8 +27,6 @@ abstract class BarbackCommand extends PubCommand {
     log.json.enabled =
         argResults.options.contains("format") && argResults["format"] == "json";
 
-    fail(log.red("Dart 2 has a new build system. Learn how to migrate "
-        "from ${log.bold('pub build')} and\n"
-        "${log.bold('pub serve')}: https://webdev.dartlang.org/dart-2\n"));
+    fail(_deprecationError);
   }
 }

--- a/lib/src/command/build.dart
+++ b/lib/src/command/build.dart
@@ -9,4 +9,10 @@ class BuildCommand extends BarbackCommand {
   String get name => "build";
   String get description => "Deprecated command";
   bool get hidden => true;
+
+  BuildCommand() {
+    argParser.addOption("define", hide: true);
+    argParser.addOption("format", hide: true);
+    argParser.addOption("output", hide: true);
+  }
 }

--- a/lib/src/command/serve.dart
+++ b/lib/src/command/serve.dart
@@ -9,4 +9,15 @@ class ServeCommand extends BarbackCommand {
   String get name => "serve";
   String get description => "Deprecated command";
   bool get hidden => true;
+
+  ServeCommand() {
+    argParser.addOption("define", hide: true);
+    argParser.addOption('hostname', hide: true);
+    argParser.addOption('port', hide: true);
+    argParser.addFlag('log-admin-url', hide: true);
+    argParser.addOption('admin-port', hide: true);
+    argParser.addOption('build-delay', hide: true);
+    argParser.addFlag('dart2js', hide: true);
+    argParser.addFlag('force-poll', hide: true);
+  }
 }


### PR DESCRIPTION
Closes #1891

It's not possible to customize the `argParser` in a `Command` such that
it ignores these invalid options, instead customize the UsageException
to have the same message as running the command.

The difference now is that with arguments it will exit with code 64 and
without arguments it will exit with code 1.