### PR TITLE
Use Platform.version even when running from the repo

### DIFF
--- a/lib/src/sdk/dart.dart
+++ b/lib/src/sdk/dart.dart
@@ -38,11 +38,10 @@ class DartSdk extends Sdk {
     // Some of the pub integration tests require an SDK version number, but the
     // tests on the bots are not run from a built SDK so this lets us avoid
     // parsing the missing version file.
-    var sdkVersion = Platform.environment["_PUB_TEST_SDK_VERSION"];
-    if (sdkVersion != null) return new Version.parse(sdkVersion);
+    var sdkVersion = Platform.environment["_PUB_TEST_SDK_VERSION"] ??
+        Platform.version.split(' ').first;
 
-    var version = Platform.version.split(' ').first;
-    return new Version.parse(version);
+    return new Version.parse(sdkVersion);
   }();
 
   String get rootDirectory => _rootDirectory;

--- a/lib/src/sdk/dart.dart
+++ b/lib/src/sdk/dart.dart
@@ -41,37 +41,7 @@ class DartSdk extends Sdk {
     var sdkVersion = Platform.environment["_PUB_TEST_SDK_VERSION"];
     if (sdkVersion != null) return new Version.parse(sdkVersion);
 
-    if (!runningFromDartRepo) {
-      var version = Platform.version.split(' ').first;
-      return new Version.parse(version);
-    }
-
-    // When running from the Dart repo, read the canonical VERSION file in
-    // tools/. This makes it possible to run pub without having built the SDK
-    // first.
-    var contents = readTextFile(p.join(dartRepoRoot, "tools/VERSION"));
-
-    parseField(name) {
-      var pattern = new RegExp("^$name ([a-z0-9]+)", multiLine: true);
-      var match = pattern.firstMatch(contents);
-      return match[1];
-    }
-
-    var channel = parseField("CHANNEL");
-    var major = parseField("MAJOR");
-    var minor = parseField("MINOR");
-    var patch = parseField("PATCH");
-    var prerelease = parseField("PRERELEASE");
-    var prereleasePatch = parseField("PRERELEASE_PATCH");
-
-    var version = "$major.$minor.$patch";
-    if (channel == "be") {
-      // TODO(rnystrom): tools/utils.py includes the svn commit here. Should we?
-      version += "-edge";
-    } else if (channel == "dev") {
-      version += "-dev.$prerelease.$prereleasePatch";
-    }
-
+    var version = Platform.version.split(' ').first;
     return new Version.parse(version);
   }();
 


### PR DESCRIPTION
Follow-up to https://github.com/dart-lang/pub/commit/3d7ae0cdf0
Hopefully really fixes https://github.com/dart-lang/pub/issues/1887