### PR TITLE
After install scripts (#1904)

### DIFF
--- a/lib/src/after_install.dart
+++ b/lib/src/after_install.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+/// Stores timestamps of the absolute paths to Dart scripts
+/// specified in packages' "after_install" fields, and the
+/// last times they were run.
+class AfterInstallCache {
+  final Map<String, int> _cache;
+
+  const AfterInstallCache._(this._cache);
+
+  /// Returns the name of the file that would hold an "after_install" cache in the [rootDir].
+  static String resolveCacheFilePath(String rootDir) {
+    return p.join(rootDir, "after_install_cache.json");
+  }
+
+  /// Loads from a given [rootDir].
+  static Future<AfterInstallCache> load(String rootDir) async {
+    var filename = resolveCacheFilePath(rootDir);
+    var cacheFile = new File(filename);
+
+    // If the file does not exist, return the default.
+    if (!await cacheFile.exists()) return new AfterInstallCache._({});
+
+    var map = json.decode(await cacheFile.readAsString());
+    var isValidMap = map is Map &&
+        map.keys.every((k) => k is String) &&
+        map.values.every((k) => k is int);
+
+    // If the file is formatted improperly, return the default.
+    //
+    // Whatever corrupted data was stored in the cache file, will
+    // ultimately be overwritten.
+    if (!isValidMap) return new AfterInstallCache._({});
+
+    // If everything went well, return the parsed cache.
+    return new AfterInstallCache._(map.cast<String, int>());
+  }
+
+  /// Determines if the script at [path] should be re-run.
+  ///
+  /// This is `true` if any of the following is true:
+  ///   * The cache contains no entry for the [path].
+  ///   * The file at [path] was modified after the timestamp in the cache.
+  Future<bool> isOutdated(String path) async {
+    if (!_cache.containsKey(path)) return true;
+    var stat = await FileStat.stat(path);
+    return _cache[path] < stat.modified.millisecondsSinceEpoch;
+  }
+
+  /// Saves the contents of the cache to a file in the given [rootDir].
+  Future save(String rootDir) => new File(resolveCacheFilePath(rootDir))
+      .writeAsString(json.encode(_cache));
+
+  /// Returns a combined cache containing the contents of both `this` and [other].
+  ///
+  /// Where there are conflicts, values in [other] are prioritized.
+  ///
+  /// Does not modify the caches of either `this` or [other].
+  AfterInstallCache merge(AfterInstallCache other) {
+    return new AfterInstallCache._(
+        <String, int>{}..addAll(_cache)..addAll(other._cache));
+  }
+}

--- a/lib/src/after_install.dart
+++ b/lib/src/after_install.dart
@@ -52,9 +52,11 @@ class AfterInstallCache {
 
   /// Saves the contents of the cache to a file in the given [rootDir].
   Future save(String rootDir) async {
-    var file = new File(resolveCacheFilePath(rootDir));
-    await file.create(recursive: true);
-    await file.writeAsString(json.encode(_cache));
+    if (_cache.isNotEmpty) {
+      var file = new File(resolveCacheFilePath(rootDir));
+      await file.create(recursive: true);
+      await file.writeAsString(json.encode(_cache));
+    }
   }
 
   /// Updates the cached timestamp for [path].
@@ -70,4 +72,6 @@ class AfterInstallCache {
     return new AfterInstallCache._(
         <String, int>{}..addAll(_cache)..addAll(other._cache));
   }
+
+  Map<String, int> toMap() => new Map<String, int>.from(_cache);
 }

--- a/lib/src/after_install.dart
+++ b/lib/src/after_install.dart
@@ -51,8 +51,11 @@ class AfterInstallCache {
   }
 
   /// Saves the contents of the cache to a file in the given [rootDir].
-  Future save(String rootDir) => new File(resolveCacheFilePath(rootDir))
-      .writeAsString(json.encode(_cache));
+  Future save(String rootDir) async {
+    var file = new File(resolveCacheFilePath(rootDir));
+    await file.create(recursive: true);
+    await file.writeAsString(json.encode(_cache));
+  }
 
   /// Updates the cached timestamp for [path].
   void update(String path) =>

--- a/lib/src/after_install.dart
+++ b/lib/src/after_install.dart
@@ -54,6 +54,10 @@ class AfterInstallCache {
   Future save(String rootDir) => new File(resolveCacheFilePath(rootDir))
       .writeAsString(json.encode(_cache));
 
+  /// Updates the cached timestamp for [path].
+  void update(String path) =>
+      _cache[path] = new DateTime.now().millisecondsSinceEpoch;
+
   /// Returns a combined cache containing the contents of both `this` and [other].
   ///
   /// Where there are conflicts, values in [other] are prioritized.

--- a/lib/src/after_install.dart
+++ b/lib/src/after_install.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -672,7 +672,7 @@ class Entrypoint {
 
     // Run scripts in dependencies.
     for (var package in result.changedPackages) {
-      var scripts = allScripts[package];
+      var scripts = allScripts[package] ?? [];
       if (scripts.isEmpty) continue;
 
       var pkg = package == root.name

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -731,7 +731,9 @@ class Entrypoint {
 
           try {
             Isolate.spawnUri(p.toUri(absolutePath), [], null,
-                onExit: onExit.sendPort, onError: onError.sendPort);
+                onExit: onExit.sendPort,
+                onError: onError.sendPort,
+                automaticPackageResolution: true);
             await onComplete.future;
 
             // Update the cache so this script does not run again redundantly.

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 
-import 'package:async/async.dart';
 import 'package:collection/collection.dart';
 import 'package:package_config/packages_file.dart' as packages_file;
 import 'package:path/path.dart' as p;

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -252,9 +252,9 @@ class Pubspec {
       return [];
     else if (value is String)
       return [value];
-    else if (value is List) {
+    else if (value is YamlList) {
       int i = 0;
-      for (YamlNode child in fields['after_install'].value) {
+      for (var child in value.nodes) {
         if (child.value is! String)
           _error('Value at index $i of "after_install" field must be a string.',
               child.span);

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -241,6 +241,33 @@ class Pubspec {
     return _features;
   }
 
+  /// An optional list of paths to *.dart scripts that will be executed
+  /// upon package installation.
+  ///
+  /// This can be expressed in YAML as either a list, or a single string.
+  List<String> get afterInstall {
+    var value = fields['after_install'];
+
+    if (value == null)
+      return [];
+    else if (value is String)
+      return [value];
+    else if (value is List) {
+      int i = 0;
+      for (YamlNode child in fields['after_install'].value) {
+        if (child.value is! String)
+          _error('Value at index $i of "after_install" field must be a string.',
+              child.span);
+        i++;
+      }
+
+      return value.cast<String>();
+    } else {
+      _error('"after_install" field must be a string, or a list thereof."',
+          fields.nodes['after_install'].span);
+    }
+  }
+
   Map<String, Feature> _features;
 
   /// A map from SDK identifiers to constraints on those SDK versions.

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -253,12 +253,12 @@ class Pubspec {
     else if (value is String)
       return [value];
     else if (value is YamlList) {
-      int i = 0;
-      for (var child in value.nodes) {
-        if (child.value is! String)
+      for (int i = 0; i < value.nodes.length; i++) {
+        var child = value.nodes[i];
+        if (child.value is! String) {
           _error('Value at index $i of "after_install" field must be a string.',
               child.span);
-        i++;
+        }
       }
 
       return value.cast<String>();

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -633,6 +633,35 @@ features:
               (pubspec) => pubspec.features);
         });
       });
+
+      group("after_install", () {
+        test("can be null", () {
+          var pubspec = new Pubspec.parse('after_install:', sources);
+          expect(pubspec.afterInstall, isEmpty);
+        });
+
+        test("can be a single string", () {
+          var pubspec =
+              new Pubspec.parse("after_install: tool/foo.dart", sources);
+          expect(pubspec.afterInstall, ["tool/foo.dart"]);
+        });
+
+        test("can be a string list", () {
+          var pubspec = new Pubspec.parse(
+              "after_install: [tool/foo.dart, tool/bar.dart]", sources);
+          expect(pubspec.afterInstall, ["tool/foo.dart", "tool/bar.dart"]);
+        });
+
+        test("must be a list", () {
+          expectPubspecException(
+              "after_install: {foo: bar}", (pubspec) => pubspec.afterInstall);
+        });
+
+        test("must be a string list", () {
+          expectPubspecException(
+              "after_install: [1, 2, 3, 4]", (pubspec) => pubspec.afterInstall);
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
This is a working implementation of the changes proposed in #1904.

I've added tests for parsing the necessary value (an `after_install` field in the pubspec), but I'm not so sure of how to test the functionality, other than physically running it myself.

To clarify, the behavior verifiably works when run by a human, but I'm not so sure how to run it via computer.

One other thing I'd like to propose is an additional check upon running `pub lish` that throws an error if a script specified the pubspec does not actually exist on disk (to prevent breaks on end-user machines).

I'm willing to fix anything that needs to be fixed to land this PR. I really feel like something so simple as support for post-install scripts could go a long way to growing the Dart ecosystem.