### PR TITLE
Reference "$HOME" instead of "~" in PATH message

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -802,8 +802,8 @@ pub global run ${package.name}:$script "\$@"
 
       var binDir = _binStubDir;
       if (binDir.startsWith(Platform.environment['HOME'])) {
-        binDir =
-            p.join("~", p.relative(binDir, from: Platform.environment['HOME']));
+        binDir = p.join(
+            r'$HOME', p.relative(binDir, from: Platform.environment['HOME']));
       }
 
       log.warning("${log.yellow('Warning:')} Pub installs executables into "


### PR DESCRIPTION
Closes https://github.com/dart-lang/sdk/issues/33256

The details of variable expansion when setting the PATH variable are a
little hard to follow. `"$HOME"` should work in more places than `"~"`