### PR TITLE
Look for the new snapshot error message from the Dart 2 VM.

### DIFF
--- a/lib/src/command/run.dart
+++ b/lib/src/command/run.dart
@@ -61,8 +61,8 @@ class RunCommand extends PubCommand {
     // to actually execute will always have one.
     if (p.extension(executable) != ".dart") executable += ".dart";
 
-    var snapshotPath =
-        p.join(entrypoint.cachePath, "bin", package, "$executable.snapshot.dart2");
+    var snapshotPath = p.join(
+        entrypoint.cachePath, "bin", package, "$executable.snapshot.dart2");
 
     // Don't ever compile snapshots for mutable packages, since their code may
     // change later on.

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -59,8 +59,8 @@ Future snapshot(Uri executableUrl, String snapshotPath,
     // Don't leave partial results.
     deleteEntry(snapshotPath);
 
-    throw new ApplicationException(log.yellow("Failed to precompile $name:\n") +
-        result.stderr.join('\n'));
+    throw new ApplicationException(
+        log.yellow("Failed to precompile $name:\n") + result.stderr.join('\n'));
   }
 }
 

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -242,8 +242,8 @@ class Entrypoint {
       deleteEntry(packagesPath);
     }
 
-    await Future
-        .wait(result.packages.map((id) => _get(id, packagesDir: packagesDir)));
+    await Future.wait(
+        result.packages.map((id) => _get(id, packagesDir: packagesDir)));
     _saveLockFile(result);
 
     if (packagesDir) _linkSelf();
@@ -304,7 +304,8 @@ class Entrypoint {
       cleanDir(dir);
       return waitAndPrintErrors(executables[package].map((path) {
         var url = p.toUri(p.join(packageGraph.packages[package].dir, path));
-        return dart.snapshot(url, p.join(dir, p.basename(path) + '.snapshot.dart2'),
+        return dart.snapshot(
+            url, p.join(dir, p.basename(path) + '.snapshot.dart2'),
             packagesFile: p.toUri(packagesFile),
             name: '$package:${p.basenameWithoutExtension(path)}');
       }));
@@ -368,8 +369,8 @@ class Entrypoint {
     // some executables do exist and some do not, the directory is corrupted and
     // it's good to start from scratch anyway.
     var executablesExist = executables.every((executable) {
-      var snapshotPath = p.join(
-          _snapshotPath, packageName, "${p.basename(executable)}.snapshot.dart2");
+      var snapshotPath = p.join(_snapshotPath, packageName,
+          "${p.basename(executable)}.snapshot.dart2");
       return fileExists(snapshotPath);
     });
     if (!executablesExist) return executables;

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -168,7 +168,9 @@ Future<int> runSnapshot(String path, Iterable<String> args,
         packageConfig: packageConfig);
   } on IsolateSpawnException catch (error) {
     if (recompile == null) rethrow;
-    if (!error.message.contains("Wrong script snapshot version")) rethrow;
+    if (!error.message.contains("Invalid kernel binary format version")) {
+      rethrow;
+    }
 
     log.fine("Precompiled executable is out of date.");
     await recompile();

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -387,7 +387,8 @@ class GlobalPackages {
             entrypoint.isCached ? _getPackagesFilePath(package) : null,
         // Don't use snapshots for executables activated from paths.
         snapshotPath: entrypoint.isCached
-            ? p.join(_directory, package, 'bin', '$executable.dart.snapshot.dart2')
+            ? p.join(
+                _directory, package, 'bin', '$executable.dart.snapshot.dart2')
             : null,
         recompile: () => _precompileExecutables(entrypoint, package));
   }

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -597,8 +597,8 @@ Future<bool> confirm(String message) {
 /// exited already. This is useful to prevent Future chains from proceeding
 /// after you've decided to exit.
 Future flushThenExit(int status) {
-  return Future
-      .wait([stdout.close(), stderr.close()]).then((_) => exit(status));
+  return Future.wait([stdout.close(), stderr.close()])
+      .then((_) => exit(status));
 }
 
 /// Returns a [EventSink] that pipes all data to [consumer] and a [Future] that

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -127,8 +127,7 @@ abstract class Validator {
       validators.add(new SizeValidator(entrypoint, packageSize));
     }
 
-    return Future
-        .wait(validators.map((validator) => validator.validate()))
+    return Future.wait(validators.map((validator) => validator.validate()))
         .then((_) {
       var errors = validators.expand((validator) => validator.errors).toList();
       var warnings =

--- a/test/global/binstubs/outdated_snapshot_test.dart
+++ b/test/global/binstubs/outdated_snapshot_test.dart
@@ -28,7 +28,7 @@ main() {
     await d.dir(cachePath, [
       d.dir('global_packages', [
         d.dir('foo', [
-          d.dir('bin', [d.outOfDateSnapshot('script.dart.snapshot')])
+          d.dir('bin', [d.outOfDateSnapshot('script.dart.snapshot.dart2')])
         ])
       ])
     ]).create();
@@ -38,14 +38,15 @@ main() {
         ["arg1", "arg2"],
         environment: getEnvironment());
 
-    expect(process.stderr, emits(startsWith("Wrong script snapshot version")));
+    expect(process.stderr,
+        emits(contains("Invalid kernel binary format version.")));
     expect(process.stdout, emitsThrough("ok [arg1, arg2]"));
     await process.shouldExit();
 
     await d.dir(cachePath, [
       d.dir('global_packages/foo/bin', [
         d.file(
-            'script.dart.snapshot',
+            'script.dart.snapshot.dart2',
             isNot(equals(
                 readBinaryFile(testAssetPath('out-of-date.snapshot.dart2')))))
       ])

--- a/test/global/binstubs/utils.dart
+++ b/test/global/binstubs/utils.dart
@@ -12,6 +12,16 @@ import '../../test_pub.dart';
 /// their PATH, so we need to spawn the binstub process with a PATH that
 /// explicitly includes it.
 Map getEnvironment() {
+  // TODO(rnystrom): This doesn't do the right thing when running pub's tests
+  // from pub's own repo instead of from within the Dart SDK repo. This always
+  // sets up the PATH to point to the directory where the Dart VM was run from,
+  // which will be unrelated to the path where pub itself is located when
+  // running from pub's repo.
+  //
+  // However, pub's repo doesn't actually have the shell scripts required to
+  // run "pub". Those live in the Dart SDK repo. One fix would be to make shell
+  // scripts in pub's repo that can act like those scripts but invoke pub from
+  // source from the pub repo.
   var binDir = p.dirname(Platform.executable);
   var separator = Platform.isWindows ? ";" : ":";
   var path = "${Platform.environment["PATH"]}$separator$binDir";

--- a/test/global/run/recompiles_if_snapshot_is_out_of_date_test.dart
+++ b/test/global/run/recompiles_if_snapshot_is_out_of_date_test.dart
@@ -20,7 +20,7 @@ main() {
     await d.dir(cachePath, [
       d.dir('global_packages', [
         d.dir('foo', [
-          d.dir('bin', [d.outOfDateSnapshot('script.dart.snapshot')])
+          d.dir('bin', [d.outOfDateSnapshot('script.dart.snapshot.dart2')])
         ])
       ])
     ]).create();
@@ -35,7 +35,7 @@ main() {
     await d.dir(cachePath, [
       d.dir('global_packages', [
         d.dir('foo', [
-          d.dir('bin', [d.file('script.dart.snapshot', contains('ok'))])
+          d.dir('bin', [d.file('script.dart.snapshot.dart2', contains('ok'))])
         ])
       ])
     ]).validate();

--- a/test/global/run/runs_script_in_checked_mode_test.dart
+++ b/test/global/run/runs_script_in_checked_mode_test.dart
@@ -18,8 +18,7 @@ main() {
     await runPub(args: ["global", "activate", "foo"]);
 
     var pub = await pubRun(global: true, args: ["--checked", "foo:script"]);
-    expect(pub.stderr,
-        emitsThrough(contains("Failed assertion")));
+    expect(pub.stderr, emitsThrough(contains("Failed assertion")));
     await pub.shouldExit(255);
   });
 }

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -200,8 +200,7 @@ Future pubDowngrade(
 /// "pub run".
 ///
 /// Returns the `pub run` process.
-Future<PubProcess> pubRun(
-    {bool global: false, Iterable<String> args}) async {
+Future<PubProcess> pubRun({bool global: false, Iterable<String> args}) async {
   var pubArgs = global ? ["global", "run"] : ["run"];
   pubArgs.addAll(args);
   var pub = await startPub(args: pubArgs);
@@ -250,9 +249,7 @@ Future runPub(
   assert(output == null || outputJson == null);
 
   var pub = await startPub(
-      args: args,
-      workingDirectory: workingDirectory,
-      environment: environment);
+      args: args, workingDirectory: workingDirectory, environment: environment);
   await pub.shouldExit(exitCode);
 
   expect(() async {


### PR DESCRIPTION
This should fix https://github.com/dart-lang/sdk/issues/33577.

I discovered (after painful trial and error) that the tests for binstubs are basically broken. They don't run pub from its own repo and instead run the pub that's currently in the Dart repo where you invoked the Dart VM from. I left a comment to that effect, but I don't want to fix it now.

I did verify that this fixes the issue by:

1. Copying the latest pub over to the Dart SDK.
2. Then running these tests.
