### PR TITLE
Add deps for testing with build_runner

### DIFF
--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -1,0 +1,1 @@
+export 'package:pub/src/command_runner.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,8 +25,11 @@ dependencies:
   yaml: "^2.0.0"
 
 dev_dependencies:
+  build_runner: ^0.9.0
+  build_test: ^0.10.0
+  build_vm_compilers: ^0.1.0
   shelf_test_handler: "^1.0.0"
-  test: ^0.12.42
+  test: ^1.3.0
   test_descriptor: "^1.0.0"
   test_process: "^1.0.0"
 


### PR DESCRIPTION
Testing from kernel files saves time over testing from source. This does
not switch Travis to test this way yet, but adds the deps to make it
easier to use locally.

Add a non-src lib file so get better behavior out of the coarse module
strategy. Without this file every library ends up becoming it's own
module.