### PR TITLE
Don't delete existing packages directories

### DIFF
--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -1,0 +1,1 @@
+export 'package:pub/src/command_runner.dart';

--- a/test/no_packages_dir_test.dart
+++ b/test/no_packages_dir_test.dart
@@ -9,42 +9,23 @@ import 'test_pub.dart';
 
 main() {
   forBothPubGetAndUpgrade((command) {
-    group("without --packages-dir", () {
-      test("removes package directories near entrypoints", () async {
+    group('without --packages-dir', () {
+      test('does not touch directories named "packages"', () async {
         await d.dir(appPath, [
           d.appPubspec(),
-          d.dir("packages"),
-          d.dir("bin/packages"),
-          d.dir("web/packages"),
-          d.dir("web/subdir/packages")
+          d.dir('packages'),
+          d.dir('bin/packages'),
+          d.dir('bin/subdir/packages'),
+          d.dir('lib/packages')
         ]).create();
 
         await pubCommand(command);
 
         await d.dir(appPath, [
-          d.nothing("packages"),
-          d.nothing("bin/packages"),
-          d.nothing("web/packages"),
-          d.nothing("web/subdir/packages")
-        ]).validate();
-      });
-
-      test(
-          "doesn't remove package directories that pub wouldn't "
-          "generate", () async {
-        await d.dir(appPath, [
-          d.appPubspec(),
-          d.dir("packages"),
-          d.dir("bin/subdir/packages"),
-          d.dir("lib/packages")
-        ]).create();
-
-        await pubCommand(command);
-
-        await d.dir(appPath, [
-          d.nothing("packages"),
-          d.dir("bin/subdir/packages"),
-          d.dir("lib/packages")
+          d.dir('packages'),
+          d.dir('bin/packages'),
+          d.dir('bin/subdir/packages'),
+          d.dir('lib/packages')
         ]).validate();
       });
     });


### PR DESCRIPTION
Fixes #1951

Continues to allow _creating_ packages directories for now, but if they
exist and aren't being created they won't be touched.