### PR TITLE
Use an import for the module hack

### DIFF
--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -1,1 +1,1 @@
-export 'package:pub/src/command_runner.dart';
+import 'package:pub/src/command_runner.dart';


### PR DESCRIPTION
This library only exists to be an "entrypoint" in `lib/` rather than
`lib/src/` and allow all other files to get rolled up into a single
module. We don't publish this package anyway, but an `import` is more in
line with our intentions here than `export`.

See discussion in https://github.com/dart-lang/pub/pull/1955