### PR TITLE
Update to latest build_runner

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,5 @@
 name: pub
+publish_to: none
 
 dependencies:
   # Note: Pub's test infrastructure assumes that any dependencies used in tests
@@ -6,32 +7,32 @@ dependencies:
   analyzer: ^0.32.0
   args: ^1.4.1
   async: ^2.0.0
-  collection: "^1.8.0"
+  collection: ^1.8.0
   crypto: ">=1.0.0 <3.0.0"
-  http: "^0.11.0"
+  http: ^0.11.0
   http_multi_server: ">=1.0.0 <3.0.0"
-  http_retry: "^0.1.1"
-  http_throttle: "^1.0.0"
-  meta: "^1.1.0"
-  oauth2: "^1.0.0"
-  package_config: "^1.0.0"
-  package_resolver: "^1.0.0"
-  path: "^1.2.0"
-  pool: "^1.0.0"
-  pub_semver: "^1.4.0"
+  http_retry: ^0.1.1
+  http_throttle: ^1.0.0
+  meta: ^1.1.0
+  oauth2: ^1.0.0
+  package_config: ^1.0.0
+  package_resolver: ^1.0.0
+  path: ^1.2.0
+  pool: ^1.0.0
+  pub_semver: ^1.4.0
   shelf: ^0.7.0
-  source_span: "^1.4.0"
-  stack_trace: "^1.0.0"
-  yaml: "^2.0.0"
+  source_span: ^1.4.0
+  stack_trace: ^1.0.0
+  yaml: ^2.0.0
 
 dev_dependencies:
-  build_runner: ^0.9.0
+  build_runner: ^0.10.0
   build_test: ^0.10.0
   build_vm_compilers: ^0.1.0
-  shelf_test_handler: "^1.0.0"
+  shelf_test_handler: ^1.0.0
   test: ^1.3.0
-  test_descriptor: "^1.0.0"
-  test_process: "^1.0.0"
+  test_descriptor: ^1.0.0
+  test_process: ^1.0.0
 
 environment:
   sdk: ">=2.0.0-dev.61.0 <3.0.0"


### PR DESCRIPTION
Also add `publish_to: none` to document that this package will not be
published on pub, and consistently skip quotes for version strings which
don't need quotes.