### PR TITLE
Update tests for SDK constraint validation

### DIFF
--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -500,7 +500,7 @@ main() {
         expect(
             validatePackage(dependency),
             completion(pairOf(
-                anyElement(contains('  sdk: ">=2.0.0-dev.1.0 <2.0.0"')),
+                anyElement(contains('  sdk: ">=2.0.0 <3.0.0"')),
                 anyElement(contains('  foo: any')))));
       });
 
@@ -521,7 +521,7 @@ main() {
         expect(
             validatePackage(dependency),
             completion(pairOf(
-                anyElement(contains('  sdk: ">=2.0.0-dev.1.0 <2.0.0"')),
+                anyElement(contains('  sdk: ">=2.0.0 <3.0.0"')),
                 anyElement(contains('  foo: any')))));
       });
     });
@@ -623,7 +623,7 @@ main() {
         })
       ]).create();
 
-      expectDependencyValidationError('sdk: ">=2.0.0-dev.51.0 <2.0.0"');
+      expectDependencyValidationError('sdk: ">=2.0.0 <3.0.0"');
     });
 
     test("depends on a Fuchsia package with no SDK constraint", () async {
@@ -637,7 +637,7 @@ main() {
         })
       ]).create();
 
-      expectDependencyValidationError('sdk: ">=2.0.0-dev.51.0 <2.0.0"');
+      expectDependencyValidationError('sdk: ">=2.0.0 <3.0.0"');
     });
   });
 }

--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -499,8 +499,7 @@ main() {
 
         expect(
             validatePackage(dependency),
-            completion(pairOf(
-                anyElement(contains('  sdk: ">=2.0.0 <3.0.0"')),
+            completion(pairOf(anyElement(contains('  sdk: ">=2.0.0 <3.0.0"')),
                 anyElement(contains('  foo: any')))));
       });
 
@@ -520,8 +519,7 @@ main() {
 
         expect(
             validatePackage(dependency),
-            completion(pairOf(
-                anyElement(contains('  sdk: ">=2.0.0 <3.0.0"')),
+            completion(pairOf(anyElement(contains('  sdk: ">=2.0.0 <3.0.0"')),
                 anyElement(contains('  foo: any')))));
       });
     });

--- a/test/validator/sdk_constraint_test.dart
+++ b/test/validator/sdk_constraint_test.dart
@@ -126,8 +126,8 @@ main() {
       ]).create();
       expect(
           validatePackage(sdkConstraint),
-          completion(pairOf(
-              anyElement(contains('">=2.0.0 <3.0.0"')), isEmpty)));
+          completion(
+              pairOf(anyElement(contains('">=2.0.0 <3.0.0"')), isEmpty)));
     });
 
     test("has a Fuchsia SDK constraint with no SDK constraint", () async {
@@ -140,8 +140,8 @@ main() {
       ]).create();
       expect(
           validatePackage(sdkConstraint),
-          completion(pairOf(
-              anyElement(contains('">=2.0.0 <3.0.0"')), isEmpty)));
+          completion(
+              pairOf(anyElement(contains('">=2.0.0 <3.0.0"')), isEmpty)));
     });
   });
 }

--- a/test/validator/sdk_constraint_test.dart
+++ b/test/validator/sdk_constraint_test.dart
@@ -127,7 +127,7 @@ main() {
       expect(
           validatePackage(sdkConstraint),
           completion(pairOf(
-              anyElement(contains('">=2.0.0-dev.51.0 <2.0.0"')), isEmpty)));
+              anyElement(contains('">=2.0.0 <3.0.0"')), isEmpty)));
     });
 
     test("has a Fuchsia SDK constraint with no SDK constraint", () async {
@@ -141,7 +141,7 @@ main() {
       expect(
           validatePackage(sdkConstraint),
           completion(pairOf(
-              anyElement(contains('">=2.0.0-dev.51.0 <2.0.0"')), isEmpty)));
+              anyElement(contains('">=2.0.0 <3.0.0"')), isEmpty)));
     });
   });
 }


### PR DESCRIPTION
According to the comment at `lib/src/validator.dart` lines 70-73 this
behavior was intended to change when the stable SDK was released, so
update the tests.