### PR TITLE
Add check for a scheme on PUB_HOSTED_URL

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -57,7 +57,6 @@ class LishCommand extends PubCommand {
         negatable: false,
         help: 'Publish without confirmation if there are no errors.');
     argParser.addOption('server',
-        defaultsTo: cache.sources.hosted.defaultUrl,
         help: 'The package server to which to upload this package.');
   }
 

--- a/lib/src/command/uploader.dart
+++ b/lib/src/command/uploader.dart
@@ -24,7 +24,6 @@ class UploaderCommand extends PubCommand {
 
   UploaderCommand() {
     argParser.addOption('server',
-        defaultsTo: cache.sources.hosted.defaultUrl,
         help: 'The package server on which the package is hosted.');
     argParser.addOption('package',
         help: 'The package whose uploaders will be modified.\n'

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -249,6 +249,8 @@ and include the logs in an issue on https://github.com/dart-lang/pub/issues/new
       return exit_codes.NO_INPUT;
     } else if (exception is FormatException || exception is DataException) {
       return exit_codes.DATA;
+    } else if (exception is ConfigException) {
+      return exit_codes.CONFIG;
     } else if (exception is UsageException) {
       return exit_codes.USAGE;
     } else {

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -62,9 +62,16 @@ class SilentException extends WrappedException {
 
 /// A class for errors in a command's input data.
 ///
-/// This corresponds to the [exit_codes.DATA] exit code.
+/// This corresponds to the `data` exit code.
 class DataException extends ApplicationException {
   DataException(String message) : super(message);
+}
+
+/// An exception indicating that the users configuration is invalid.
+///
+/// This corresponds to the `config` exit code;
+class ConfigException extends ApplicationException {
+  ConfigException(String message) : super(message);
 }
 
 /// An class for exceptions where a package could not be found in a [Source].

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -35,11 +35,19 @@ class HostedSource extends Source {
           : BoundHostedSource(this, systemCache);
 
   /// Gets the default URL for the package server for hosted dependencies.
-  String get defaultUrl {
-    var url = io.Platform.environment["PUB_HOSTED_URL"];
-    if (url != null) return url;
-
-    return "https://pub.dartlang.org";
+  String get defaultUrl =>
+      _defaultUrl ??= _pubHostedUrlConfig() ?? 'https://pub.dartlang.org';
+  String _defaultUrl;
+  String _pubHostedUrlConfig() {
+    var url = io.Platform.environment['PUB_HOSTED_URL'];
+    if (url == null) return null;
+    var uri = Uri.parse(url);
+    if (uri.scheme?.isEmpty ?? true) {
+      throw ConfigException(
+          '`PUB_HOSTED_URL` must include a scheme such as "https://". '
+          '$url is invalid');
+    }
+    return url;
   }
 
   /// Returns a reference to a hosted package named [name].

--- a/test/lish/force_cannot_be_combined_with_dry_run_test.dart
+++ b/test/lish/force_cannot_be_combined_with_dry_run_test.dart
@@ -21,7 +21,6 @@ main() {
           -n, --dry-run    Validate but do not publish the package.
           -f, --force      Publish without confirmation if there are no errors.
               --server     The package server to which to upload this package.
-                           (defaults to "https://pub.dartlang.org")
 
           Run "pub help" to see global options.
           See http://dartlang.org/tools/pub/cmd/pub-lish.html for detailed documentation.

--- a/test/pub_uploader_test.dart
+++ b/test/pub_uploader_test.dart
@@ -21,8 +21,6 @@ Manage uploaders for a package on pub.dartlang.org.
 Usage: pub uploader [options] {add/remove} <email>
 -h, --help       Print this usage information.
     --server     The package server on which the package is hosted.
-                 (defaults to "https://pub.dartlang.org")
-
     --package    The package whose uploaders will be modified.
                  (defaults to the current package)
 


### PR DESCRIPTION
If the environment variable does not have a scheme it will produce a
confusing error like `Bad state: Cannot use origin without a scheme`.

- Add a `ConfigException` to correspond to the config exit code.
- Change some non-reference usages of `[]` to backticks.
- Stop setting a default of the `server` option since it depends on user
  config and could be incorrect. We never read the default value anyway
  and now access of that field can throw and this would throw before
  proper exception handling is set up.
- Attempt to parse the scheme when we read `PUB_HOSTED_URL` and throw a
  more actionable exception when it is missing.
- Update tests hardcoding the usage string.