### PR TITLE
Update last modified date directly in `touch`

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -799,13 +799,7 @@ _doProcess(Function fn, String executable, List<String> args,
 }
 
 /// Updates [path]'s modification time.
-void touch(String path) {
-  var file = File(path).openSync(mode: FileMode.append);
-  var originalLength = file.lengthSync();
-  file.writeByteSync(0);
-  file.truncateSync(originalLength);
-  file.closeSync();
-}
+void touch(String path) => File(path).setLastModifiedSync(DateTime.now());
 
 /// Creates a temporary directory and passes its path to [fn].
 ///


### PR DESCRIPTION
This mitigates race conditions in which concurrent Pub processes "touch"
pubspec.lock at the same time and leave it with a trailing NUL character.

---

### Long-winded background info

We've been seeing intermittent failures in our automated builds for some time now, which looked like this:
```
Error on line 1177, column 1 of pubspec.lock: Unexpected character.

^
```
However, we had a hard time tracking them down. Eventually, we determined that the unexpected character in that message was actually a NUL character.

"What was modifying `pubspec.lock` and adding a NUL character?" We weren't in our scripts, and there shouldn't be any reason for Pub to modify it since in all cases we've seen this issue, the pubspec.lock is checked in and didn't change after `pub get`.

However, looking at Pub's source, it looks like its `touch` utility operates by writing a NUL character to the end of the file and then writing to it again with the original contents.

We were running multiple Pub commands in parallel, which would explain this issue: two Pub processes could be performing `touch` at the same time,
resulting in a NUL character being preserved in the output.

`pub run` also always touches `pubspec.lock` when there are path dependencies, which we had in all the repos we encountered this issue in, which explains why we were seeing it so often.

To reproduce locally: with the following files...
- pubspec.yaml
    ```yaml
    name: foo
    dependencies:
      path_dep:
        path: ./path_dep
    ```
- foo.dart
    ```dart
    main() {}
    ```
- path_dep/pubspec.yaml
    ```yaml
    name: path_dep
    ```

... run the following command in several of terminals at once; 
eventually you'll get "Unexpected character" errors.
```bash
while true; do pub run ./foo.dart; done
```