### PR TITLE
Adds a changelog validator that checks if the current version is mentioned.

### DIFF
--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -101,9 +101,8 @@ class Package {
   /// Returns the path to the CHANGELOG file at the root of the entrypoint, or
   /// null if no CHANGELOG file is found.
   String get changelogPath {
-    return
-        listFiles(recursive: false, useGitIgnore: true)
-        .firstWhere((entry) => p.basename(entry).contains(_changelogRegexp),
+    return listFiles(recursive: false, useGitIgnore: true).firstWhere(
+        (entry) => p.basename(entry).contains(_changelogRegexp),
         orElse: () => null);
   }
 

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -15,6 +15,7 @@ import 'source_registry.dart';
 import 'utils.dart';
 
 final _readmeRegexp = RegExp(r"^README($|\.)", caseSensitive: false);
+final _changelogRegexp = RegExp(r"^CHANGELOG($|\.)", caseSensitive: false);
 
 /// A named, versioned, unit of code and resource reuse.
 class Package {
@@ -95,6 +96,15 @@ class Package {
       if (comparison == 0) comparison = readme1.compareTo(readme2);
       return (comparison <= 0) ? readme1 : readme2;
     }));
+  }
+
+  /// Returns the path to the CHANGELOG file at the root of the entrypoint, or
+  /// null if no CHANGELOG file is found.
+  String get changelogPath {
+    return
+        listFiles(recursive: false, useGitIgnore: true)
+        .firstWhere((entry) => p.basename(entry).contains(_changelogRegexp),
+        orElse: () => null);
   }
 
   /// Returns whether or not this package is in a Git repo.

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:meta/meta.dart';
+import 'package:pub/src/validator/changelog.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import 'entrypoint.dart';
@@ -120,6 +121,7 @@ abstract class Validator {
       ExecutableValidator(entrypoint),
       CompiledDartdocValidator(entrypoint),
       ReadmeValidator(entrypoint),
+      ChangelogValidator(entrypoint),
       SdkConstraintValidator(entrypoint),
       StrictDependenciesValidator(entrypoint),
     ];

--- a/lib/src/validator/changelog.dart
+++ b/lib/src/validator/changelog.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:path/path.dart' as path;
+
+import '../entrypoint.dart';
+import '../io.dart';
+import '../validator.dart';
+
+
+/// A validator that validates a package's changelog file.
+class ChangelogValidator extends Validator {
+  ChangelogValidator(Entrypoint entrypoint) : super(entrypoint);
+
+  Future validate() {
+    return Future.sync(() {
+      final changelog = entrypoint.root.changelogPath;
+
+      if (changelog == null) {
+        // No changelog was found, which is fine. Return with no warnings.
+        return;
+      }
+
+      var bytes = readBinaryFile(changelog);
+      var contents = '';
+
+      try {
+        // utf8.decode doesn't allow invalid UTF-8.
+        contents = utf8.decode(bytes);
+      } on FormatException catch (_) {
+        warnings.add("$changelog contains invalid UTF-8.\n"
+            "This will cause it to be displayed incorrectly on "
+            "pub.dartlang.org.");
+      }
+
+      final version = entrypoint.root.pubspec.version.toString();
+
+      if (!contents.contains(version)) {
+        warnings.add("Your package includes a changelog file that doesn\'t "
+            "mention version $version. Consider updating it prior to "
+            "publication.");
+      }
+    });
+  }
+}

--- a/lib/src/validator/changelog.dart
+++ b/lib/src/validator/changelog.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/lib/src/validator/changelog.dart
+++ b/lib/src/validator/changelog.dart
@@ -5,12 +5,9 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:path/path.dart' as path;
-
 import '../entrypoint.dart';
 import '../io.dart';
 import '../validator.dart';
-
 
 /// A validator that validates a package's changelog file.
 class ChangelogValidator extends Validator {

--- a/test/validator/changelog_test.dart
+++ b/test/validator/changelog_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/validator/changelog_test.dart
+++ b/test/validator/changelog_test.dart
@@ -1,0 +1,67 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:pub/src/entrypoint.dart';
+import 'package:pub/src/validator.dart';
+import 'package:pub/src/validator/changelog.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+import 'utils.dart';
+
+Validator changelog(Entrypoint entrypoint) => ChangelogValidator(entrypoint);
+
+main() {
+  group('should consider a package valid if it', () {
+    setUp(d.validPackage.create);
+
+    test('looks normal', () => expectNoValidationError(changelog));
+
+    test('has no CHANGELOG', () async {
+      await d.dir(appPath, [
+        d.libPubspec("test_pkg", "1.0.0"),
+      ]).create();
+      expectNoValidationError(changelog);
+    });
+
+    test('has a CHANGELOG that includes the current package version', () async {
+      await d.dir(appPath, [
+        d.libPubspec("test_pkg", "1.0.0"),
+        d.file("CHANGELOG.md", """
+          # 1.0.0
+          
+          * Solves traveling salesman problem in polynomial time.
+          * Passes Turing test.
+        """),
+      ]).create();
+      expectNoValidationError(changelog);
+    });
+  });
+
+  group('should consider a package invalid if it', () {
+    setUp(d.validPackage.create);
+
+    test('has a CHANGELOG that doesn\'t include the current package version', () async {
+      await d.dir(appPath, [
+        d.libPubspec("test_pkg", "1.0.1"),
+        d.file("CHANGELOG.md", """
+          # 1.0.0
+          
+          * Solves traveling salesman problem in polynomial time.
+          * Passes Turing test.
+        """),
+      ]).create();
+    });
+
+    test('has a CHANGELOG with invalid utf-8', () async {
+      await d.dir(appPath, [
+        d.libPubspec("test_pkg", "1.0.0"),
+        d.file("CHANGELOG.md", [192]),
+      ]).create();
+      expectValidationWarning(changelog);
+    });
+  });
+}

--- a/test/validator/changelog_test.dart
+++ b/test/validator/changelog_test.dart
@@ -44,7 +44,8 @@ main() {
   group('should consider a package invalid if it', () {
     setUp(d.validPackage.create);
 
-    test('has a CHANGELOG that doesn\'t include the current package version', () async {
+    test('has a CHANGELOG that doesn\'t include the current package version',
+        () async {
       await d.dir(appPath, [
         d.libPubspec("test_pkg", "1.0.1"),
         d.file("CHANGELOG.md", """


### PR DESCRIPTION
Fixes Issue #2003 by adding a new Validator class that looks for a CHANGELOG file and, if one is located, verifies that the current package version can be found somewhere in it.

This is my first contribution to pub, so literally anything in here could be wrong. I based the code mostly off of the README validator and the tests pass, so I've at least got that going for me. 😄 