### PR TITLE
Remove validation for library file paths

### DIFF
--- a/lib/src/validator/name.dart
+++ b/lib/src/validator/name.dart
@@ -10,21 +10,16 @@ import '../entrypoint.dart';
 import '../utils.dart';
 import '../validator.dart';
 
-/// A validator that validates the name of the package and its libraries.
+/// A validator that the name of a package is legal and matches the library name
+/// in the case of a single library.
 class NameValidator extends Validator {
   NameValidator(Entrypoint entrypoint) : super(entrypoint);
 
   Future validate() {
     return Future.sync(() {
-      _checkName(entrypoint.root.name, 'Package name "${entrypoint.root.name}"',
-          isPackage: true);
+      _checkName(entrypoint.root.name);
 
       var libraries = _libraries;
-      for (var library in libraries) {
-        var libName = path.basenameWithoutExtension(library);
-        _checkName(libName, 'The name of "$library", "$libName",',
-            isPackage: false);
-      }
 
       if (libraries.length == 1) {
         var libName = path.basenameWithoutExtension(libraries[0]);
@@ -49,21 +44,19 @@ class NameValidator extends Validator {
         .toList();
   }
 
-  void _checkName(String name, String description, {bool isPackage}) {
-    // Packages names are more stringent than libraries.
-    var messages = isPackage ? errors : warnings;
-
+  void _checkName(String name) {
+    final description = 'Package name "$name"';
     if (name == "") {
       errors.add("$description may not be empty.");
     } else if (!RegExp(r"^[a-zA-Z0-9_]*$").hasMatch(name)) {
-      messages.add("$description may only contain letters, numbers, and "
+      errors.add("$description may only contain letters, numbers, and "
           "underscores.\n"
           "Using a valid Dart identifier makes the name usable in Dart code.");
     } else if (!RegExp(r"^[a-zA-Z_]").hasMatch(name)) {
-      messages.add("$description must begin with a letter or underscore.\n"
+      errors.add("$description must begin with a letter or underscore.\n"
           "Using a valid Dart identifier makes the name usable in Dart code.");
     } else if (reservedWords.contains(name.toLowerCase())) {
-      messages.add("$description may not be a reserved word in Dart.\n"
+      errors.add("$description may not be a reserved word in Dart.\n"
           "Using a valid Dart identifier makes the name usable in Dart code.");
     } else if (RegExp(r"[A-Z]").hasMatch(name)) {
       warnings.add('$description should be lower-case. Maybe use '

--- a/test/validator/name_test.dart
+++ b/test/validator/name_test.dart
@@ -22,12 +22,12 @@ main() {
 
     test('looks normal', () => expectNoValidationError(name));
 
-    test('has a badly-named library in lib/src', () async {
+    test('has dots in potential library names', () async {
       await d.dir(appPath, [
         d.libPubspec("test_pkg", "1.0.0"),
         d.dir("lib", [
           d.file("test_pkg.dart", "int i = 1;"),
-          d.dir("src", [d.file("8ball.dart", "int j = 2;")])
+          d.file("test_pkg.g.dart", "int j = 2;")
         ])
       ]).create();
       expectNoValidationError(name);
@@ -47,38 +47,6 @@ main() {
 
     test('has a package name that contains upper-case letters', () async {
       await d.dir(appPath, [d.libPubspec("TestPkg", "1.0.0")]).create();
-      expectValidationWarning(name);
-    });
-
-    test('has a library name with an invalid character', () async {
-      await d.dir(appPath, [
-        d.libPubspec("test_pkg", "1.0.0"),
-        d.dir("lib", [d.file("test-pkg.dart", "int i = 0;")])
-      ]).create();
-      expectValidationWarning(name);
-    });
-
-    test('has a library name that begins with a number', () async {
-      await d.dir(appPath, [
-        d.libPubspec("test_pkg", "1.0.0"),
-        d.dir("lib", [d.file("8ball.dart", "int i = 0;")])
-      ]).create();
-      expectValidationWarning(name);
-    });
-
-    test('has a library name that contains upper-case letters', () async {
-      await d.dir(appPath, [
-        d.libPubspec("test_pkg", "1.0.0"),
-        d.dir("lib", [d.file("TestPkg.dart", "int i = 0;")])
-      ]).create();
-      expectValidationWarning(name);
-    });
-
-    test('has a library name that is a Dart reserved word', () async {
-      await d.dir(appPath, [
-        d.libPubspec("test_pkg", "1.0.0"),
-        d.dir("lib", [d.file("for.dart", "int i = 0;")])
-      ]).create();
       expectValidationWarning(name);
     });
 


### PR DESCRIPTION
Fixes #2024

There is nothing that requires a library name to be a valid Dart
identifier, and it's common practices to at least have `part of` files
which include a `.` in the file name.