### PR TITLE
Restore default server for uploader command

### DIFF
--- a/lib/src/command/uploader.dart
+++ b/lib/src/command/uploader.dart
@@ -24,6 +24,7 @@ class UploaderCommand extends PubCommand {
 
   UploaderCommand() {
     argParser.addOption('server',
+        defaultsTo: cache.sources.hosted.defaultUrl,
         help: 'The package server on which the package is hosted.');
     argParser.addOption('package',
         help: 'The package whose uploaders will be modified.\n'

--- a/test/pub_uploader_test.dart
+++ b/test/pub_uploader_test.dart
@@ -21,6 +21,8 @@ Manage uploaders for a package on pub.dartlang.org.
 Usage: pub uploader [options] {add/remove} <email>
 -h, --help       Print this usage information.
     --server     The package server on which the package is hosted.
+                 (defaults to "https://pub.dartlang.org")
+
     --package    The package whose uploaders will be modified.
                  (defaults to the current package)
 


### PR DESCRIPTION
This was incorrectly removed in #1972. In the case of the `lish` command
the default was unused, but the `uplaoders` command still used it.