### PR TITLE
Don't validate imports in `example/` if it contains its own pubspec.yaml

### DIFF
--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -74,7 +74,7 @@ class StrictDependenciesValidator extends Validator {
       ..add(entrypoint.root.name);
     var devDependencies = MapKeySet(entrypoint.root.devDependencies);
     _validateLibBin(dependencies, devDependencies);
-    _validateBenchmarkExampleTestTool(dependencies, devDependencies);
+    _validateBenchmarkTestTool(dependencies, devDependencies);
   }
 
   /// Validates that no Dart files in `lib/` or `bin/` have dependencies that
@@ -94,9 +94,9 @@ class StrictDependenciesValidator extends Validator {
     }
   }
 
-  /// Validates that no Dart files in `benchmark/`, `example/, `test/` or
+  /// Validates that no Dart files in `benchmark/`, `test/` or
   /// `tool/` have dependencies that aren't in [deps] or [devDeps].
-  void _validateBenchmarkExampleTestTool(
+  void _validateBenchmarkTestTool(
       Set<String> deps, Set<String> devDeps) {
     var directories = ['benchmark', 'test', 'tool'];
     for (var usage in _usagesBeneath(directories)) {

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -96,8 +96,7 @@ class StrictDependenciesValidator extends Validator {
 
   /// Validates that no Dart files in `benchmark/`, `test/` or
   /// `tool/` have dependencies that aren't in [deps] or [devDeps].
-  void _validateBenchmarkTestTool(
-      Set<String> deps, Set<String> devDeps) {
+  void _validateBenchmarkTestTool(Set<String> deps, Set<String> devDeps) {
     var directories = ['benchmark', 'test', 'tool'];
     for (var usage in _usagesBeneath(directories)) {
       if (!deps.contains(usage.package) && !devDeps.contains(usage.package)) {

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -96,14 +96,9 @@ class StrictDependenciesValidator extends Validator {
 
   /// Validates that no Dart files in `benchmark/`, `example/, `test/` or
   /// `tool/` have dependencies that aren't in [deps] or [devDeps].
-  ///
-  /// `example/` is only validated if it does not contain its own pubspec.
   void _validateBenchmarkExampleTestTool(
       Set<String> deps, Set<String> devDeps) {
     var directories = ['benchmark', 'test', 'tool'];
-    if (!fileExists(entrypoint.root.path('example', 'pubspec.yaml'))) {
-      directories.add('example');
-    }
     for (var usage in _usagesBeneath(directories)) {
       if (!deps.contains(usage.package) && !devDeps.contains(usage.package)) {
         warnings.add(usage.dependencyMissingMessage());

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -101,7 +101,7 @@ class StrictDependenciesValidator extends Validator {
   void _validateBenchmarkExampleTestTool(
       Set<String> deps, Set<String> devDeps) {
     var directories = ['benchmark', 'test', 'tool'];
-    if (!fileExists('example/pubspec.yaml')) {
+    if (!fileExists(entrypoint.root.path('example', 'pubspec.yaml'))) {
       directories.add('example');
     }
     for (var usage in _usagesBeneath(directories)) {

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -96,10 +96,15 @@ class StrictDependenciesValidator extends Validator {
 
   /// Validates that no Dart files in `benchmark/`, `example/, `test/` or
   /// `tool/` have dependencies that aren't in [deps] or [devDeps].
+  ///
+  /// `example/` is only validated if it does not contain its own pubspec.
   void _validateBenchmarkExampleTestTool(
       Set<String> deps, Set<String> devDeps) {
-    for (var usage
-        in _usagesBeneath(['benchmark', 'example', 'test', 'tool'])) {
+    var directories = ['benchmark', 'test', 'tool'];
+    if (!fileExists('example/pubspec.yaml')) {
+      directories.add('example');
+    }
+    for (var usage in _usagesBeneath(directories)) {
       if (!deps.contains(usage.package) && !devDeps.contains(usage.package)) {
         warnings.add(usage.dependencyMissingMessage());
       }

--- a/test/validator/strict_dependencies_test.dart
+++ b/test/validator/strict_dependencies_test.dart
@@ -150,23 +150,6 @@ main() {
 
       expectNoValidationError(strictDeps);
     });
-
-    test(
-        'has undeclared import and export beneath `example/`, but has an `example/pubspec.yaml`',
-        () async {
-      await d.dir(appPath, [
-        d.libPubspec("test_pkg", "1.0.0", sdk: ">=1.8.0 <2.0.0"),
-        d.dir('example', [
-          d.appPubspec(),
-          d.file('library.dart', '''
-        import 'package:silly_monkey/silly_monkey.dart';
-        export 'package:silly_monkey/silly_monkey.dart';
-      '''),
-        ]),
-      ]).create();
-
-      expectNoValidationError(strictDeps);
-    });
   });
 
   group('should consider a package invalid if it', () {
@@ -215,7 +198,7 @@ main() {
     }
 
     for (var port in ['import', 'export']) {
-      for (var devDir in ['benchmark', 'example', 'test', 'tool']) {
+      for (var devDir in ['benchmark', 'test', 'tool']) {
         test('does not declare an "$port" as a dependency in $devDir/',
             () async {
           await d.dir(appPath, [

--- a/test/validator/strict_dependencies_test.dart
+++ b/test/validator/strict_dependencies_test.dart
@@ -150,6 +150,23 @@ main() {
 
       expectNoValidationError(strictDeps);
     });
+
+    test(
+        'has undeclared import and export beneath `example/`, but has an `example/pubspec.yaml`',
+        () async {
+      await d.dir(appPath, [
+        d.libPubspec("test_pkg", "1.0.0", sdk: ">=1.8.0 <2.0.0"),
+        d.dir('example', [
+          d.appPubspec(),
+          d.file('library.dart', '''
+        import 'package:silly_monkey/silly_monkey.dart';
+        export 'package:silly_monkey/silly_monkey.dart';
+      '''),
+        ]),
+      ]).create();
+
+      expectNoValidationError(strictDeps);
+    });
   });
 
   group('should consider a package invalid if it', () {


### PR DESCRIPTION
Proposed fix of: https://github.com/dart-lang/pub/issues/1813
