### PR TITLE
Outline for a minimal repository specification

### DIFF
--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -1,0 +1,102 @@
+Hosted Pub Repository Specification Version 2
+=============================================
+
+This document specifies the REST API that a hosted pub package repository must
+implement.
+
+A hosted pub package repository is a server from which packages can be
+downloaded, the default public pub server is `'https://pub.dartlang.org'`.
+This can be overwritten in the `dependencies` of a `pubspec.yaml` or specified
+with the environment variable `PUB_HOSTED_URL`. In the rest of this document we
+shall refer to the base URL as `PUB_HOSTED_URL`.
+
+## Forward Compatibility
+To ensure forward compatibility API requests should carry an
+`Accept: application/vnd.pub.v2+json` header. As future versions of the API
+may have different responses.
+
+## Fetching Packages
+
+The following API end-points MUST be supported by a hosted pub package
+repository.
+
+**Optional headers** used for popularity metrics.
+
+* `X-Pub-OS: windows | macos | linux | ...`
+* `X-Pub-Command: get | upgrade | ...`
+* `X-Pub-Session-ID: <UUID>`
+* `X-Pub-Reason: direct | dev`
+* `X-Pub-Environment: ...`
+* `User-Agent: ...`
+
+### List all versions of a package
+
+**GET** `<PUB_HOSTED_URL>/api/packages/<PACKAGE>`
+
+**Headers:**
+* `Accept: application/vnd.pub.v2+json`
+
+**Response**
+* `Content-Type: application/vnd.pub.v2+json`
+
+```js
+{
+  "name": "<PACKAGE>",
+  "latest": {
+    "version": "<VERSION>",
+    "archive_url": "<PUB_HOSTED_URL>/packages/<PACKAGE>/versions/<VERSION>.tar.gz",
+    "pubspec": {
+      /* pubspec contents as JSON object */
+    }
+  },
+  "versions": [
+    {
+      "version": "<VERSION>",
+      "archive_url": "<PUB_HOSTED_URL>/packages/<PACKAGE>/versions/<VERSION>.tar.gz",
+      "pubspec": {
+        /* pubspec contents as JSON object */
+      }
+    },
+    /* additional versions */
+  ]
+}
+```
+
+### Inspect a specific version of a package
+
+**GET** `<PUB_HOSTED_URL>/api/packages/<PACKAGE>/versions/<VERSION>`
+
+**Headers:**
+* `Accept: application/vnd.pub.v2+json`
+
+**Response**
+* `Content-Type: application/vnd.pub.v2+json`
+
+```js
+{
+  "version": "1.1.0",
+  "archive_url": "<PUB_HOSTED_URL>/packages/<PACKAGE>/versions/<VERSION>.tar.gz",
+  "pubspec": {
+    /* pubspec contents as JSON object */
+  }
+}
+```
+
+### Download a specific version of a package
+
+**GET** `<PUB_HOSTED_URL>/packages/<PACKAGE>/versions/<VERSION>.tar.gz`
+
+**Headers**
+* `Accept: application/octet-stream` (optional)
+
+**Response** (typically through a ´30x` redirect)
+* `Content-Type: application/octet-stream`
+
+**Important:** The server MAY redirect the client to a different URL, clients
+MUST support redirects.
+
+## Publishing Packages
+
+The API for authenticating and publishing packages is not formalized yet, see
+[#1381](https://github.com/dart-lang/pub/issues/1381).
+


### PR DESCRIPTION
This is an attempt to create a specification from our current behavior.
The server doesn't care about the `Accept` header, and does not send
the correct `Content-Type`. But the client seems to get this right,
and it doesn't seems to care about the response header.

This makes is clear what we can't change, and how to deal with
versioning if we decide to change something. I want to further
document what API end-points `pub.dartlang.org` offers and how
stable they are. This is just a first step in that direction, since
we're probably not going to able to change end-points required by
old pub clients.

Expanding this to cover publishing would be nice, but at the momement
the authorization scheme is hardcoded to use the Goolge OAuth flow
for all hosted pub servers, which is a security concern should users
attept to publish packages to an untrusted server. It's also a security
concern for people writing custom pub servers, so that will probably
have to be redesigned a bit, before we can formalize it.

CC @isoos, @natebosch, @pq