### PR TITLE
A note on why we're not using pub.dev/api

### DIFF
--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -35,8 +35,21 @@ class HostedSource extends Source {
           : BoundHostedSource(this, systemCache);
 
   /// Gets the default URL for the package server for hosted dependencies.
-  String get defaultUrl =>
-      _defaultUrl ??= _pubHostedUrlConfig() ?? 'https://pub.dartlang.org';
+  String get defaultUrl {
+    // Changing this to pub.dev raises the following concerns:
+    //
+    //  1. It would blow through users caches.
+    //  2. It would cause conflicts for users checking pubspec.lock into git, if using
+    //     different versions of the dart-sdk / pub client.
+    //  3. It might cause other problems (investigation needed) for pubspec.lock across
+    //     different versions of the dart-sdk / pub client.
+    //  4. It would expand the API surface we're committed to supporting long-term.
+    //
+    // Clearly, a bit of investigation is necessary before we update this to
+    // pub.dev, it might be attractive to do next time we change the server API.
+    return _defaultUrl ??= _pubHostedUrlConfig() ?? 'https://pub.dartlang.org';
+  }
+
   String _defaultUrl;
   String _pubHostedUrlConfig() {
     var url = io.Platform.environment['PUB_HOSTED_URL'];


### PR DESCRIPTION
Just so that we don't forget why we didn't change this right now.