### PR TITLE
Request openid and email scopes from oauth2

### DIFF
--- a/lib/src/oauth2.dart
+++ b/lib/src/oauth2.dart
@@ -58,7 +58,7 @@ final _tokenEndpoint = Uri.parse('https://accounts.google.com/o/oauth2/token');
 ///
 /// Currently the client only needs the user's email so that the server can
 /// verify their identity.
-final _scopes = ['https://www.googleapis.com/auth/userinfo.email'];
+final _scopes = ['openid', 'email'];
 
 /// An in-memory cache of the user's OAuth2 credentials.
 ///

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -145,7 +145,7 @@ Descriptor credentialsFile(ShelfTestServer server, String accessToken,
         oauth2.Credentials(accessToken,
                 refreshToken: refreshToken,
                 tokenEndpoint: server.url.resolve('/token'),
-                scopes: ['https://www.googleapis.com/auth/userinfo.email'],
+                scopes: ['openid', 'email'],
                 expiration: expiration)
             .toJson())
   ]);


### PR DESCRIPTION
This ensures that we always have an email and a user_id / id_token
on the server.