### PR TITLE
Use canonical oauth2 scope for email

### DIFF
--- a/lib/src/oauth2.dart
+++ b/lib/src/oauth2.dart
@@ -58,7 +58,7 @@ final _tokenEndpoint = Uri.parse('https://accounts.google.com/o/oauth2/token');
 ///
 /// Currently the client only needs the user's email so that the server can
 /// verify their identity.
-final _scopes = ['openid', 'email'];
+final _scopes = ['openid', 'https://www.googleapis.com/auth/userinfo.email'];
 
 /// An in-memory cache of the user's OAuth2 credentials.
 ///

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -145,7 +145,10 @@ Descriptor credentialsFile(ShelfTestServer server, String accessToken,
         oauth2.Credentials(accessToken,
                 refreshToken: refreshToken,
                 tokenEndpoint: server.url.resolve('/token'),
-                scopes: ['openid', 'email'],
+                scopes: [
+                  'openid',
+                  'https://www.googleapis.com/auth/userinfo.email',
+                ],
                 expiration: expiration)
             .toJson())
   ]);


### PR DESCRIPTION
Now that we know this is the canonical scope, then let's use that.