### PR TITLE
Fix 2032, ignore analysis_options.yaml in pub

### DIFF
--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -7,6 +7,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:analyzer/dart/analysis/analysis_context.dart';
+import 'package:analyzer/file_system/overlay_file_system.dart';
+import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:analyzer/dart/analysis/context_builder.dart';
 import 'package:analyzer/dart/analysis/context_locator.dart';
 import 'package:analyzer/dart/analysis/session.dart';
@@ -84,8 +86,18 @@ class AnalysisContextManager {
       return;
     }
 
+    // Overwrite the analysis_options.yaml to avoid loading the file included
+    // in the package, as this may result in some files not being analyzed.
+    final resourceProvider =
+        OverlayResourceProvider(PhysicalResourceProvider.INSTANCE);
+    resourceProvider.setOverlay(
+      p.join(path, 'analysis_options.yaml'),
+      content: '',
+      modificationStamp: 0,
+    );
+
     // Add new contexts for the given path.
-    var contextLocator = ContextLocator();
+    var contextLocator = ContextLocator(resourceProvider: resourceProvider);
     var roots = contextLocator.locateRoots(includedPaths: [path]);
     for (var root in roots) {
       var contextRootPath = root.root.path;

--- a/test/validator/strict_dependencies_test.dart
+++ b/test/validator/strict_dependencies_test.dart
@@ -150,6 +150,36 @@ main() {
 
       expectNoValidationError(strictDeps);
     });
+
+    test('has analysis_options.yaml that excludes files', () async {
+      await d.dir(appPath, [
+        d.libPubspec("test_pkg", "1.0.0",
+            deps: {"silly_monkey": "^1.2.3"}, sdk: ">=1.8.0 <2.0.0"),
+        d.dir('lib', [
+          d.file('library.dart', r'''
+            import 'package:silly_monkey/silly_monkey.dart';
+          '''),
+        ]),
+        d.dir('test', [
+          d.dir('data', [
+            d.dir('mypkg', [
+              d.dir('lib', [
+                d.file('dummy.dart', '\n'),
+              ]),
+            ]),
+          ]),
+        ]),
+        d.file('analysis_options.yaml', r'''analyzer:
+  exclude:
+    - test/data/**
+linter:
+  rules:
+    - avoid_catching_errors
+'''),
+      ]).create();
+
+      expectNoValidationError(strictDeps);
+    });
   });
 
   group('should consider a package invalid if it', () {


### PR DESCRIPTION
The `analysis_options.yaml` is not part of the package.
It's for the editor, it should not affect which binaries are loaded
or how dependencies are analyzer when publishing.