### PR TITLE
add functionality and tests for pubspec.override.yaml

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -128,6 +128,9 @@ class Entrypoint {
   /// The path to the entrypoint package's pubspec.
   String get pubspecPath => root.path('pubspec.yaml');
 
+  /// The path to the entrypoint package's pubspec.
+  String get pubspecOverridePath => root.path('pubspec.override.yaml');
+
   /// The path to the entrypoint package's lockfile.
   String get lockFilePath => root.path('pubspec.lock');
 
@@ -394,10 +397,13 @@ class Entrypoint {
     var hasPathDependencies = lockFileText.contains("\n    source: path\n");
 
     var pubspecModified = File(pubspecPath).lastModifiedSync();
+    var pubspecOverrideModified = File(pubspecOverridePath).lastModifiedSync();
     var lockFileModified = File(lockFilePath).lastModifiedSync();
 
     var touchedLockFile = false;
-    if (lockFileModified.isBefore(pubspecModified) || hasPathDependencies) {
+    if (lockFileModified.isBefore(pubspecModified)
+        || lockFileModified.isBefore(pubspecOverrideModified)
+        || hasPathDependencies) {
       _assertLockFileUpToDate();
       if (_arePackagesAvailable()) {
         touchedLockFile = true;

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:collection/collection.dart';
@@ -452,7 +453,10 @@ class Pubspec {
   factory Pubspec.load(String packageDir, SourceRegistry sources,
       {String expectedName, bool includeDefaultSdkConstraint}) {
     var pubspecPath = path.join(packageDir, 'pubspec.yaml');
+    var pubspecOverridePath = path.join(packageDir, 'pubspec.override.yaml');
     var pubspecUri = path.toUri(pubspecPath);
+    var pubspecOverrideUri = path.toUri(pubspecOverridePath);
+
     if (!fileExists(pubspecPath)) {
       throw FileException(
           // Make the package dir absolute because for the entrypoint it'll just
@@ -461,11 +465,40 @@ class Pubspec {
           '"${canonicalize(packageDir)}".',
           pubspecPath);
     }
+    if (fileExists(pubspecOverridePath)) {
+      YamlMap pubspecMap;
+      YamlMap pubspecOverrideMap;
+      try {
+        pubspecMap = loadYaml(readTextFile(pubspecPath), sourceUrl: pubspecUri);
+        pubspecOverrideMap = loadYaml(readTextFile(pubspecOverridePath), sourceUrl: pubspecOverrideUri);
+      } on YamlException catch (error) {
+        throw PubspecException(error.message, error.span);
+      }
+      var combined = _merge(pubspecMap, pubspecOverrideMap);
+
+      return Pubspec.parse(jsonEncode(combined), sources,
+        expectedName: expectedName,
+        includeDefaultSdkConstraint: includeDefaultSdkConstraint,
+        location: pubspecUri);
+    }
 
     return Pubspec.parse(readTextFile(pubspecPath), sources,
         expectedName: expectedName,
         includeDefaultSdkConstraint: includeDefaultSdkConstraint,
         location: pubspecUri);
+  }
+
+  static _merge(Map mainMap, Map mergeMap) {
+    final mutableMain = {}..addAll(mainMap);
+    final mutableMerge = {}..addAll(mergeMap);
+    mutableMerge.forEach((key,value) {
+      if(mutableMain[key] is Map) {
+        mutableMain[key] = _merge(mutableMain[key], value);
+      } else {
+        mutableMain[key] = mutableMerge[key];
+      }
+    });
+    return Map.unmodifiable(mutableMain);
   }
 
   Pubspec(this._name,

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -47,6 +47,8 @@ FileDescriptor outOfDateSnapshot(String name) =>
 /// which may in turn contain [Future]s recursively.
 Descriptor pubspec(Map<String, Object> contents) =>
     file("pubspec.yaml", yaml(contents));
+Descriptor pubspecOverride(Map<String, Object> contents) =>
+    file("pubspec.override.yaml", yaml(contents));
 
 /// Describes a file named `pubspec.yaml` for an application package with the
 /// given [dependencies].

--- a/test/pubspec_override_test.dart
+++ b/test/pubspec_override_test.dart
@@ -1,0 +1,142 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:path/path.dart' as path;
+
+import 'descriptor.dart' as d;
+import 'test_pub.dart';
+
+main() {
+  forBothPubGetAndUpgrade((command) {
+    test("chooses best version matching override constraint", () async {
+      await servePackages((builder) {
+        builder.serve("foo", "1.0.0");
+        builder.serve("foo", "2.0.0");
+        builder.serve("foo", "3.0.0");
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "myapp",
+          "dependencies": {"foo": ">2.0.0"},
+        }),
+        d.pubspecOverride({
+          "dependencies": {"foo": "<3.0.0"}
+        })
+      ]).create();
+
+      await pubCommand(command);
+
+      await d.appPackagesFile({"foo": "2.0.0"}).validate();
+    });
+
+    test("treats override as implicit dependency", () async {
+      await servePackages((builder) {
+        builder.serve("foo", "1.0.0");
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "myapp"
+        }),
+        d.pubspecOverride({
+          "dependencies": {"foo": "any"}
+        })
+      ]).create();
+
+      await pubCommand(command);
+
+      await d.appPackagesFile({"foo": "1.0.0"}).validate();
+    });
+
+    test("ignores SDK constraints", () async {
+      await servePackages((builder) {
+        builder.serve("foo", "1.0.0", pubspec: {
+          "environment": {"sdk": "5.6.7-fblthp"}
+        });
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "myapp",
+          "dependency_overrides": {"foo": "0.0.9"}
+        }),
+        d.pubspecOverride({
+          "dependency_overrides": {"foo": "any"}
+        })
+      ]).create();
+
+      await pubCommand(command);
+
+      await d.appPackagesFile({"foo": "1.0.0"}).validate();
+    });
+
+    test("uses overridden version correctly", () async {
+      await servePackages((builder) {
+        builder.serve("foo", "1.0.0");
+        builder.serve("foo", "2.0.0");
+        builder.serve("foo", "3.0.0");
+        builder.serve("bar", "1.0.0");
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "myapp",
+          "dependencies": {"foo": "<2.0.0"},
+          "dev_dependencies": {"bar": "1.0.0"}
+        }),
+        d.pubspecOverride({
+          "dependencies": {"foo": "<3.0.0"},
+          "dev_dependencies": {
+            "bar": {"path": "../bardev"}
+          }
+        })
+      ]).create();
+
+      await d
+          .dir("bardev", [d.libDir("bar"), d.libPubspec("bar", "0.0.1")]).create();
+      var bardevPath = path.join("..", "bardev");
+
+      await pubCommand(command);
+
+      await d.appPackagesFile({"foo": "2.0.0", "bar": "$bardevPath"}).validate();
+    });
+
+//TODO: warn about overrides in pubspec.override.yaml
+  //   test("warns about overridden dependencies", () async {
+  //     await servePackages((builder) {
+  //       builder.serve("foo", "1.0.0");
+  //       builder.serve("bar", "1.0.0");
+  //     });
+
+  //     await d
+  //         .dir("baz", [d.libDir("baz"), d.libPubspec("baz", "0.0.1")]).create();
+
+  //     await d.dir(appPath, [
+  //       d.pubspec({
+  //         "name": "myapp",
+  //         "dependency_overrides": {
+  //           "foo": "any",
+  //           "bar": "any",
+  //           "baz": {"path": "../baz"}
+  //         }
+  //       })
+  //     ]).create();
+
+  //     var bazPath = path.join("..", "baz");
+
+  //     await runPub(
+  //         args: [command.name],
+  //         output: command.success,
+  //         error: """
+  //         Warning: You are using these overridden dependencies:
+  //         ! bar 1.0.0
+  //         ! baz 0.0.1 from path $bazPath
+  //         ! foo 1.0.0
+  //         """);
+  //   });
+  });
+}


### PR DESCRIPTION
Hey my team is starting using Dart for our mobile and web applications, using a shared Dart business library we are publishing to a private pub repository. Currently, we use the 'dependency_overrides' pubspec.yaml key when we are working locally on the shared library.

As detailed in issue #1867, developers want a way to ignore the overrides. I proposed a solution mimicking the way docker-compose solves this issue. Here is my PR with a simple implementation and test for this solution. Let me know what you think. Thanks.