### PR TITLE
add functionality and tests for pubspec.override.yaml

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -128,6 +128,9 @@ class Entrypoint {
   /// The path to the entrypoint package's pubspec.
   String get pubspecPath => root.path('pubspec.yaml');
 
+  /// The path to the entrypoint package's pubspec.
+  String get pubspecOverridePath => root.path('pubspec.override.yaml');
+
   /// The path to the entrypoint package's lockfile.
   String get lockFilePath => root.path('pubspec.lock');
 
@@ -395,9 +398,14 @@ class Entrypoint {
 
     var pubspecModified = File(pubspecPath).lastModifiedSync();
     var lockFileModified = File(lockFilePath).lastModifiedSync();
+    var pubspecOverrideModified = File(pubspecOverridePath).existsSync()
+        ? File(pubspecOverridePath).lastModifiedSync()
+        : pubspecModified;
 
     var touchedLockFile = false;
-    if (lockFileModified.isBefore(pubspecModified) || hasPathDependencies) {
+    if (lockFileModified.isBefore(pubspecModified) ||
+        lockFileModified.isBefore(pubspecOverrideModified) ||
+        hasPathDependencies) {
       _assertLockFileUpToDate();
       if (_arePackagesAvailable()) {
         touchedLockFile = true;

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -47,6 +47,8 @@ FileDescriptor outOfDateSnapshot(String name) =>
 /// which may in turn contain [Future]s recursively.
 Descriptor pubspec(Map<String, Object> contents) =>
     file("pubspec.yaml", yaml(contents));
+Descriptor pubspecOverride(Map<String, Object> contents) =>
+    file("pubspec.override.yaml", yaml(contents));
 
 /// Describes a file named `pubspec.yaml` for an application package with the
 /// given [dependencies].

--- a/test/pubspec_override_test.dart
+++ b/test/pubspec_override_test.dart
@@ -1,0 +1,141 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:path/path.dart' as path;
+
+import 'descriptor.dart' as d;
+import 'test_pub.dart';
+
+main() {
+  forBothPubGetAndUpgrade((command) {
+    test("chooses best version matching override constraint", () async {
+      await servePackages((builder) {
+        builder.serve("foo", "1.0.0");
+        builder.serve("foo", "2.0.0");
+        builder.serve("foo", "3.0.0");
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "myapp",
+          "dependencies": {"foo": ">2.0.0"},
+        }),
+        d.pubspecOverride({
+          "dependencies": {"foo": "<3.0.0"}
+        })
+      ]).create();
+
+      await pubCommand(command);
+
+      await d.appPackagesFile({"foo": "2.0.0"}).validate();
+    });
+
+    test("treats override as implicit dependency", () async {
+      await servePackages((builder) {
+        builder.serve("foo", "1.0.0");
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({"name": "myapp"}),
+        d.pubspecOverride({
+          "dependencies": {"foo": "any"}
+        })
+      ]).create();
+
+      await pubCommand(command);
+
+      await d.appPackagesFile({"foo": "1.0.0"}).validate();
+    });
+
+    test("ignores SDK constraints", () async {
+      await servePackages((builder) {
+        builder.serve("foo", "1.0.0", pubspec: {
+          "environment": {"sdk": "5.6.7-fblthp"}
+        });
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "myapp",
+          "dependency_overrides": {"foo": "0.0.9"}
+        }),
+        d.pubspecOverride({
+          "dependency_overrides": {"foo": "any"}
+        })
+      ]).create();
+
+      await pubCommand(command);
+
+      await d.appPackagesFile({"foo": "1.0.0"}).validate();
+    });
+
+    test("uses overridden version correctly", () async {
+      await servePackages((builder) {
+        builder.serve("foo", "1.0.0");
+        builder.serve("foo", "2.0.0");
+        builder.serve("foo", "3.0.0");
+        builder.serve("bar", "1.0.0");
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          "name": "myapp",
+          "dependencies": {"foo": "<2.0.0"},
+          "dev_dependencies": {"bar": "1.0.0"}
+        }),
+        d.pubspecOverride({
+          "dependencies": {"foo": "<3.0.0"},
+          "dev_dependencies": {
+            "bar": {"path": "../bardev"}
+          }
+        })
+      ]).create();
+
+      await d.dir(
+          "bardev", [d.libDir("bar"), d.libPubspec("bar", "0.0.1")]).create();
+      var bardevPath = path.join("..", "bardev");
+
+      await pubCommand(command);
+
+      await d
+          .appPackagesFile({"foo": "2.0.0", "bar": "$bardevPath"}).validate();
+    });
+
+//TODO: warn about overrides in pubspec.override.yaml
+    //   test("warns about overridden dependencies", () async {
+    //     await servePackages((builder) {
+    //       builder.serve("foo", "1.0.0");
+    //       builder.serve("bar", "1.0.0");
+    //     });
+
+    //     await d
+    //         .dir("baz", [d.libDir("baz"), d.libPubspec("baz", "0.0.1")]).create();
+
+    //     await d.dir(appPath, [
+    //       d.pubspec({
+    //         "name": "myapp",
+    //         "dependency_overrides": {
+    //           "foo": "any",
+    //           "bar": "any",
+    //           "baz": {"path": "../baz"}
+    //         }
+    //       })
+    //     ]).create();
+
+    //     var bazPath = path.join("..", "baz");
+
+    //     await runPub(
+    //         args: [command.name],
+    //         output: command.success,
+    //         error: """
+    //         Warning: You are using these overridden dependencies:
+    //         ! bar 1.0.0
+    //         ! baz 0.0.1 from path $bazPath
+    //         ! foo 1.0.0
+    //         """);
+    //   });
+  });
+}


### PR DESCRIPTION
Hey my team is starting using Dart for our mobile and web applications, using a shared Dart business library we are publishing to a private pub repository. Currently, we use the `dependency_overrides` pubspec.yaml key when we are working locally on the shared library.

As detailed in issue #1867, developers want a way to ignore the overrides. I proposed a solution mimicking the way docker-compose solves this issue. Here is my PR with a simple implementation and test for this solution. Let me know what you think. Thanks.