### PR TITLE
implementation and tests of --ignore-overrides for get and upgrade

### DIFF
--- a/lib/src/command/get.dart
+++ b/lib/src/command/get.dart
@@ -44,13 +44,11 @@ class GetCommand extends PubCommand {
       log.warning(log.yellow(
           'The --packages-dir flag is no longer used and does nothing.'));
     }
-    var _entrypoint = super.entrypoint;
-    if (argResults.wasParsed("ignore-overrides")) {
+    if (argResults.wasParsed('ignore-overrides')) {
       log.message("Ignoring 'dependency_overrides'.");
-      _entrypoint = Entrypoint.current(cache,
-          ignoreOverrides: argResults['ignore-overrides']);
     }
-    return _entrypoint.acquireDependencies(SolveType.GET,
+    final ep = Entrypoint.current(cache, ignoreOverrides: argResults['ignore-overrides']);
+    return ep.acquireDependencies(SolveType.GET,
         dryRun: argResults['dry-run'], precompile: argResults['precompile']);
   }
 }

--- a/lib/src/command/get.dart
+++ b/lib/src/command/get.dart
@@ -47,7 +47,8 @@ class GetCommand extends PubCommand {
     if (argResults.wasParsed('ignore-overrides')) {
       log.message("Ignoring 'dependency_overrides'.");
     }
-    final ep = Entrypoint.current(cache, ignoreOverrides: argResults['ignore-overrides']);
+    final ep = Entrypoint.current(cache,
+        ignoreOverrides: argResults['ignore-overrides']);
     return ep.acquireDependencies(SolveType.GET,
         dryRun: argResults['dry-run'], precompile: argResults['precompile']);
   }

--- a/lib/src/command/get.dart
+++ b/lib/src/command/get.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import '../command.dart';
+import '../entrypoint.dart';
 import '../log.dart' as log;
 import '../solver.dart';
 
@@ -26,6 +27,11 @@ class GetCommand extends PubCommand {
         negatable: false,
         help: "Report what dependencies would change but don't change any.");
 
+    argParser.addFlag('ignore-overrides',
+        defaultsTo: false,
+        negatable: false,
+        help: "Ignore 'dependency_overrides' in pubspec.yaml.");
+
     argParser.addFlag('precompile',
         defaultsTo: true,
         help: "Precompile executables and transformed dependencies.");
@@ -38,7 +44,13 @@ class GetCommand extends PubCommand {
       log.warning(log.yellow(
           'The --packages-dir flag is no longer used and does nothing.'));
     }
-    return entrypoint.acquireDependencies(SolveType.GET,
+    var _entrypoint = super.entrypoint;
+    if (argResults.wasParsed("ignore-overrides")) {
+      log.message("Ignoring 'dependency_overrides'.");
+      _entrypoint = Entrypoint.current(cache,
+          ignoreOverrides: argResults['ignore-overrides']);
+    }
+    return _entrypoint.acquireDependencies(SolveType.GET,
         dryRun: argResults['dry-run'], precompile: argResults['precompile']);
   }
 }

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -46,13 +46,11 @@ class UpgradeCommand extends PubCommand {
       log.warning(log.yellow(
           'The --packages-dir flag is no longer used and does nothing.'));
     }
-    var _entrypoint = super.entrypoint;
-    if (argResults.wasParsed("ignore-overrides")) {
+    if (argResults.wasParsed('ignore-overrides')) {
       log.message("Ignoring 'dependency_overrides'.");
-      _entrypoint = Entrypoint.current(cache,
-          ignoreOverrides: argResults['ignore-overrides']);
     }
-    await _entrypoint.acquireDependencies(SolveType.UPGRADE,
+    final ep = Entrypoint.current(cache, ignoreOverrides: argResults['ignore-overrides']);
+    await ep.acquireDependencies(SolveType.UPGRADE,
         useLatest: argResults.rest,
         dryRun: argResults['dry-run'],
         precompile: argResults['precompile']);

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -49,7 +49,8 @@ class UpgradeCommand extends PubCommand {
     if (argResults.wasParsed('ignore-overrides')) {
       log.message("Ignoring 'dependency_overrides'.");
     }
-    final ep = Entrypoint.current(cache, ignoreOverrides: argResults['ignore-overrides']);
+    final ep = Entrypoint.current(cache,
+        ignoreOverrides: argResults['ignore-overrides']);
     await ep.acquireDependencies(SolveType.UPGRADE,
         useLatest: argResults.rest,
         dryRun: argResults['dry-run'],

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import '../command.dart';
+import '../entrypoint.dart';
 import '../log.dart' as log;
 import '../solver.dart';
 
@@ -28,6 +29,11 @@ class UpgradeCommand extends PubCommand {
         negatable: false,
         help: "Report what dependencies would change but don't change any.");
 
+    argParser.addFlag('ignore-overrides',
+        defaultsTo: false,
+        negatable: false,
+        help: "Ignore 'dependency_overrides' in pubspec.yaml.");
+
     argParser.addFlag('precompile',
         defaultsTo: true,
         help: "Precompile executables and transformed dependencies.");
@@ -40,7 +46,13 @@ class UpgradeCommand extends PubCommand {
       log.warning(log.yellow(
           'The --packages-dir flag is no longer used and does nothing.'));
     }
-    await entrypoint.acquireDependencies(SolveType.UPGRADE,
+    var _entrypoint = super.entrypoint;
+    if (argResults.wasParsed("ignore-overrides")) {
+      log.message("Ignoring 'dependency_overrides'.");
+      _entrypoint = Entrypoint.current(cache,
+          ignoreOverrides: argResults['ignore-overrides']);
+    }
+    await _entrypoint.acquireDependencies(SolveType.UPGRADE,
         useLatest: argResults.rest,
         dryRun: argResults['dry-run'],
         precompile: argResults['precompile']);

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -152,14 +152,16 @@ class Entrypoint {
   String get _snapshotPath => p.join(cachePath, 'bin');
 
   /// Loads the entrypoint for the package at the current directory.
-  Entrypoint.current(this.cache)
-      : root = Package.load(null, '.', cache.sources, isRootPackage: true),
+  Entrypoint.current(this.cache, {bool ignoreOverrides = false})
+      : root = Package.load(null, '.', cache.sources,
+            isRootPackage: true, ignoreOverrides: ignoreOverrides),
         _inMemory = false,
         isGlobal = false;
 
   /// Loads the entrypoint from a package at [rootDir].
-  Entrypoint(String rootDir, this.cache)
-      : root = Package.load(null, rootDir, cache.sources, isRootPackage: true),
+  Entrypoint(String rootDir, this.cache, {bool ignoreOverrides = false})
+      : root = Package.load(null, rootDir, cache.sources,
+            isRootPackage: true, ignoreOverrides: ignoreOverrides),
         _inMemory = false,
         isGlobal = true;
 

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -132,9 +132,11 @@ class Package {
   /// dependency), or `null` if the package being loaded is the entrypoint
   /// package.
   Package.load(String name, this.dir, SourceRegistry sources,
-      {bool isRootPackage = false})
+      {bool isRootPackage = false, bool ignoreOverrides = false})
       : pubspec = Pubspec.load(dir, sources,
-            expectedName: name, includeDefaultSdkConstraint: !isRootPackage);
+            expectedName: name,
+            includeDefaultSdkConstraint: !isRootPackage,
+            ignoreOverrides: ignoreOverrides);
 
   /// Constructs a package with the given pubspec.
   ///

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -450,7 +450,9 @@ class Pubspec {
   /// If [expectedName] is passed and the pubspec doesn't have a matching name
   /// field, this will throw a [PubspecError].
   factory Pubspec.load(String packageDir, SourceRegistry sources,
-      {String expectedName, bool includeDefaultSdkConstraint}) {
+      {String expectedName,
+      bool includeDefaultSdkConstraint,
+      bool ignoreOverrides = false}) {
     var pubspecPath = path.join(packageDir, 'pubspec.yaml');
     var pubspecUri = path.toUri(pubspecPath);
     if (!fileExists(pubspecPath)) {
@@ -465,7 +467,8 @@ class Pubspec {
     return Pubspec.parse(readTextFile(pubspecPath), sources,
         expectedName: expectedName,
         includeDefaultSdkConstraint: includeDefaultSdkConstraint,
-        location: pubspecUri);
+        location: pubspecUri,
+        ignoreOverrides: ignoreOverrides);
   }
 
   Pubspec(this._name,
@@ -529,7 +532,10 @@ class Pubspec {
   /// If the pubspec doesn't define a version for itself, it defaults to
   /// [Version.none].
   factory Pubspec.parse(String contents, SourceRegistry sources,
-      {String expectedName, bool includeDefaultSdkConstraint, Uri location}) {
+      {String expectedName,
+      bool includeDefaultSdkConstraint,
+      Uri location,
+      bool ignoreOverrides = false}) {
     YamlNode pubspecNode;
     try {
       pubspecNode = loadYamlNode(contents, sourceUrl: location);
@@ -545,6 +551,12 @@ class Pubspec {
     } else {
       throw PubspecException(
           'The pubspec must be a YAML mapping.', pubspecNode.span);
+    }
+
+    if (ignoreOverrides) {
+      var mutableMap = {}..addAll(pubspecMap);
+      mutableMap.remove("dependency_overrides");
+      pubspecMap = Map.unmodifiable(mutableMap);
     }
 
     return Pubspec.fromMap(pubspecMap, sources,

--- a/test/get/ignore_overrides_test.dart
+++ b/test/get/ignore_overrides_test.dart
@@ -31,4 +31,24 @@ main() {
 
     await d.appPackagesFile({"foo": "1.0.0"}).validate();
   });
+  
+  test("'dependency_overrides' works when not ignored", () async {
+    await servePackages((builder) {
+      builder.serve("foo", "1.0.0");
+      builder.serve("foo", "2.0.0");
+    });
+
+    await d.dir(appPath, [
+      d.pubspec({
+        "name": "myapp",
+        "version": "1.0.0",
+        "dependencies": {"foo": "1.0.0"},
+        "dependency_overrides": {"foo": "2.0.0"}
+      })
+    ]).create();
+
+    await pubGet();
+
+    await d.appPackagesFile({"foo": "2.0.0"}).validate();
+  });
 }

--- a/test/get/ignore_overrides_test.dart
+++ b/test/get/ignore_overrides_test.dart
@@ -31,7 +31,7 @@ main() {
 
     await d.appPackagesFile({"foo": "1.0.0"}).validate();
   });
-  
+
   test("'dependency_overrides' works when not ignored", () async {
     await servePackages((builder) {
       builder.serve("foo", "1.0.0");

--- a/test/get/ignore_overrides_test.dart
+++ b/test/get/ignore_overrides_test.dart
@@ -1,0 +1,34 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+main() {
+  test("--ignore-overrides correctly ignores 'dependency_overrides'", () async {
+    await servePackages((builder) {
+      builder.serve("foo", "1.0.0");
+      builder.serve("foo", "2.0.0");
+    });
+
+    await d.dir(appPath, [
+      d.pubspec({
+        "name": "myapp",
+        "version": "1.0.0",
+        "dependencies": {"foo": "1.0.0"},
+        "dependency_overrides": {"foo": "2.0.0"}
+      })
+    ]).create();
+
+    await pubGet(
+        args: ["--ignore-overrides"],
+        output: allOf([
+          contains("Ignoring 'dependency_overrides'."),
+        ]));
+
+    await d.appPackagesFile({"foo": "1.0.0"}).validate();
+  });
+}

--- a/test/upgrade/ignore_overrides_test.dart
+++ b/test/upgrade/ignore_overrides_test.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+main() {
+  test("--ignore-overrides correctly ignores 'dependency_overrides'", () async {
+    await servePackages((builder) {
+      builder.serve("foo", "1.0.0");
+      builder.serve("foo", "2.0.0");
+    });
+
+    await d.dir(appPath, [
+      d.pubspec({
+        "name": "myapp",
+        "version": "1.0.0",
+        "dependencies": {"foo": "1.0.0"},
+        "dependency_overrides": {"foo": "2.0.0"}
+      })
+    ]).create();
+
+    await pubGet();
+    await d.appPackagesFile({"foo": "2.0.0"}).validate();
+
+    await pubUpgrade(
+        args: ["--ignore-overrides"],
+        output: allOf([
+          contains("Ignoring 'dependency_overrides'."),
+          contains("< foo 1.0.0 (was 2.0.0) (2.0.0 available)"),
+          contains("Downloading foo 1.0.0..."),
+          contains("Changed 1 dependency!")
+        ]));
+
+    await d.appPackagesFile({"foo": "1.0.0"}).validate();
+  });
+}


### PR DESCRIPTION
Added implementation and tests of `--ignore-overrides` for `pub get` and `pub upgrade` per issue #1867.  I didn't touch `pub publish` or `pub global activate` for now.

Let me know what you think of the implementation and if you have any fixes or suggestions for other commands etc. Thanks.