### PR TITLE
return the hashCode of the description

### DIFF
--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -95,7 +95,7 @@ class HostedSource extends Source {
   bool descriptionsEqual(description1, description2) =>
       _parseDescription(description1) == _parseDescription(description2);
 
-  int hashDescription(description) => description.hashCode;
+  int hashDescription(description) => _parseDescription(description).hashCode;
 
   /// Ensures that [description] is a valid hosted package description.
   ///

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -95,7 +95,7 @@ class HostedSource extends Source {
   bool descriptionsEqual(description1, description2) =>
       _parseDescription(description1) == _parseDescription(description2);
 
-  int hashDescription(description) => _parseDescription.hashCode;
+  int hashDescription(description) => description.hashCode;
 
   /// Ensures that [description] is a valid hosted package description.
   ///


### PR DESCRIPTION
From reading through the code I think `_parseDescription.hashCode` was a possible typo and it was actually meant to be `description.hashCode`.

Should there be a corresponding test for this method?