### PR TITLE
Don't mention 'transformed dependencies'.

### DIFF
--- a/lib/src/command/get.dart
+++ b/lib/src/command/get.dart
@@ -28,7 +28,7 @@ class GetCommand extends PubCommand {
 
     argParser.addFlag('precompile',
         defaultsTo: true,
-        help: "Precompile executables and transformed dependencies.");
+        help: "Precompile executables in immediate dependencies.");
 
     argParser.addFlag('packages-dir', negatable: true, hide: true);
   }

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -30,7 +30,7 @@ class UpgradeCommand extends PubCommand {
 
     argParser.addFlag('precompile',
         defaultsTo: true,
-        help: "Precompile executables and transformed dependencies.");
+        help: "Precompile executables in immediate dependencies.");
 
     argParser.addFlag('packages-dir', negatable: true, hide: true);
   }


### PR DESCRIPTION
I think this documentation relates to when Dart 1.x when pub did more than
fetching dependencies and pre-compiling executables.

-----
Doing a bit of archaeology I find that it was introduced in c1405b945c6d818c8cfe78334e8d4b11fd913103 along with a similar phrase in documentation comment for `EntryPoint.acquireDependencies`, but this comment was removed by @natebosch in 5ca86eb6e7be45ade4e44cbb7402d296cdf8b32f which removed other Dart 1.x related features.

So I'm inclined to think this had to do with the code-transformer features in Dart 1.x.