### PR TITLE
Rephrase warnings for missing deps

### DIFF
--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -148,13 +148,15 @@ class _Usage {
 
   /// Returns an error message saying the package is not listed in dependencies.
   String dependencyMissingMessage() =>
-      _toMessage("This package doesn't depend on $package.");
+      _toMessage('This package does nt have $package in the `dependencies` '
+          'section of `pubspec.yaml`.');
 
   /// Returns an error message saying the package should be in `dependencies`.
   String dependencyMisplaceMessage() {
     var shortFile = p.split(p.relative(_file)).first;
     return _toMessage(
-        '$package is a dev dependency. Packages used in $shortFile/ must be '
-        'declared as normal dependencies.');
+        '$package is in the `dev_dependencies` section of `pubsepc.yaml`. '
+        'Packages used in $shortFile/ must be declared in the `dependencies` '
+        'section.');
   }
 }

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -148,7 +148,7 @@ class _Usage {
 
   /// Returns an error message saying the package is not listed in dependencies.
   String dependencyMissingMessage() =>
-      _toMessage('This package does nt have $package in the `dependencies` '
+      _toMessage('This package does not have $package in the `dependencies` '
           'section of `pubspec.yaml`.');
 
   /// Returns an error message saying the package should be in `dependencies`.

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -155,7 +155,7 @@ class _Usage {
   String dependencyMisplaceMessage() {
     var shortFile = p.split(p.relative(_file)).first;
     return _toMessage(
-        '$package is in the `dev_dependencies` section of `pubsepc.yaml`. '
+        '$package is in the `dev_dependencies` section of `pubspec.yaml`. '
         'Packages used in $shortFile/ must be declared in the `dependencies` '
         'section.');
   }


### PR DESCRIPTION
Fixes #2204

The phrase "doesn't depend on" can be interpreted as "doesn't use" and
considered an unnecessary import. Rephrase to be more clear that the
message is discussing the dependencies in pubspec.yaml.