### PR TITLE
Retry on all SocketExceptions

### DIFF
--- a/test/hosted/fail_gracefully_on_url_resolve_test.dart
+++ b/test/hosted/fail_gracefully_on_url_resolve_test.dart
@@ -22,7 +22,10 @@ void main() {
 
       await pubCommand(command,
           error: 'Could not resolve URL "http://pub.invalid".',
-          exitCode: exit_codes.UNAVAILABLE);
+          exitCode: exit_codes.UNAVAILABLE,
+          environment: {
+            'PUB_MAX_HTTP_RETRIES': '2',
+          });
     });
   });
 }


### PR DESCRIPTION
Do not retry on OS specific error codes for `SocketException`.
These OS error codes are not documented in the code, and they
may change behavior depending on OS and architecture.

Furthermore, many seemingly persistent errors such as DNS lookup
failures should be retried.

Finally, if we retry a `SocketException` unnecessarily this is of
little impact. It means that if the user doesn't have a network
connection, or tries to use a `PUB_HOSTED_URL` pointing to a
non-existent pub server, then it will take a bit longer before
the user is informed of the problem.