### PR TITLE
Resolve API URL's relative to the base URL, consistently

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
 
 import '../ascii_tree.dart' as tree;
 import '../command.dart';
@@ -67,7 +68,8 @@ class LishCommand extends PubCommand {
         return log.progress('Uploading', () async {
           // TODO(nweiz): Cloud Storage can provide an XML-formatted error. We
           // should report that error and exit.
-          var newUri = server.resolve("api/packages/versions/new");
+          var newUri = server.replace(
+              path: p.join(server.path, 'api/packages/versions/new'));
           var response = await client.get(newUri, headers: pubApiHeaders);
           var parameters = parseJsonResponse(response);
 

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -67,7 +67,7 @@ class LishCommand extends PubCommand {
         return log.progress('Uploading', () async {
           // TODO(nweiz): Cloud Storage can provide an XML-formatted error. We
           // should report that error and exit.
-          var newUri = server.resolve("/api/packages/versions/new");
+          var newUri = server.resolve("api/packages/versions/new");
           var response = await client.get(newUri, headers: pubApiHeaders);
           var parameters = parseJsonResponse(response);
 

--- a/lib/src/command/uploader.dart
+++ b/lib/src/command/uploader.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:path/path.dart' as p;
+
 import '../command.dart';
 import '../exit_codes.dart' as exit_codes;
 import '../http.dart';
@@ -61,15 +63,21 @@ class UploaderCommand extends PubCommand {
           var uploader = rest[0];
           return oauth2.withClient(cache, (client) {
             if (command == 'add') {
-              var url = server.resolve("/api/packages/"
-                  "${Uri.encodeComponent(package)}/uploaders");
+              var url = server.replace(
+                  path: p.join(
+                      server.path,
+                      "api/packages/"
+                      "${Uri.encodeComponent(package)}/uploaders"));
               return client
                   .post(url, headers: pubApiHeaders, body: {"email": uploader});
             } else {
               // command == 'remove'
-              var url = server.resolve("/api/packages/"
-                  "${Uri.encodeComponent(package)}/uploaders/"
-                  "${Uri.encodeComponent(uploader)}");
+              var url = server.replace(
+                  path: p.join(
+                      server.path,
+                      "api/packages/"
+                      "${Uri.encodeComponent(package)}/uploaders/"
+                      "${Uri.encodeComponent(uploader)}"));
               return client.delete(url, headers: pubApiHeaders);
             }
           });

--- a/test/lish/uses_relative_resolution.dart
+++ b/test/lish/uses_relative_resolution.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:shelf/shelf.dart' as shelf;
+import 'package:shelf_test_handler/shelf_test_handler.dart';
+import 'package:test/test.dart';
+
+import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+import 'utils.dart';
+
+main() {
+  setUp(d.validPackage.create);
+
+  test('resolves URL relative to base URI', () async {
+    var server = await ShelfTestServer.create();
+    var baseUri = server.url.resolve('/sub/dir');
+    await d.credentialsFile(server, 'access token').create();
+    var pub = await startPublish(server);
+
+    await confirmPublish(pub);
+    handleUploadForm(server);
+    handleUpload(server);
+
+    // Because we are testing that the URL for publishing is resolved relative to the
+    // base URL, instead of using handleUploadForm(...), we expect that Pub sends
+    // a request to /sub/dir/api/..., not /api/...
+    server.handler.expect('GET', '/sub/dir/api/packages/versions/new',
+        (request) {
+      expect(request.headers,
+          containsPair('authorization', 'Bearer access token'));
+      var body = {
+        'url': baseUri.resolve('upload').toString(),
+        'fields': {'field1': 'value1', 'field2': 'value2'}
+      };
+      return shelf.Response.ok(jsonEncode(body),
+          headers: {'content-type': 'application/json'});
+    });
+
+    // Likewise, we can't use handleUpload(...), because that expects a request to
+    // /upload, not /sub/dir/upload, which is what we are testing for.
+    server.handler.expect('POST', '/sub/dir/upload', (request) {
+      // Note: The below TODO was present in ./archives_and_uploads_a_package_test.dart,
+      // where the majority of this testing code is taken from, so the comment was left here
+      // as well.
+      //
+      // TODO(nweiz): Once a multipart/form-data parser in Dart exists, validate
+      // that the request body is correctly formatted. See issue 6952.
+      return request
+          .read()
+          .drain()
+          .then((_) => server.url)
+          .then((url) => shelf.Response.found(baseUri.resolve('create')));
+    });
+
+    server.handler.expect('GET', '/sub/dir/create', (request) {
+      return shelf.Response.ok(jsonEncode({
+        'success': {'message': 'Package test_pkg 1.0.0 uploaded!'}
+      }));
+    });
+
+    expect(pub.stdout, emits(startsWith('Uploading...')));
+    expect(pub.stdout, emits('Publishing test_pkg 1.0.0 to $baseUri'));
+    expect(pub.stdout, emits('Package test_pkg 1.0.0 uploaded!'));
+    await pub.shouldExit(exit_codes.SUCCESS);
+  });
+}


### PR DESCRIPTION
Hello! 

This pull request makes the way that API URL's resolved, consistent across all commands. This was originally part of https://github.com/dart-lang/pub/pull/2167, but has now been updated, and with unit tests added.

If this gets merged, then next I'll get working on the pull request to implement the rest of the features discussed in #2167 and #1381 (storing credentials for 3rd-party servers in `$PUB_CACHE/tokens.json`).

Thanks!!

## Changes to Existing Functionality
* Resolve the URLs for `api/versions/new`, `api/packages/:package/uploaders`, and `api/packages/:package/uploaders/:uploader` relative to the `$PUB_HOSTED_URL`. In my testing, I noticed that calls to `pub get`, `pub upgrade`, `pub global activate`, (basically any command that involved a download) worked fine when the `$PUB_HOSTED_URL` included a path, because their implementations append the desired URI to `$PUB_HOSTED_URL` (ex. `https://foo.com/my/path` -> `https://foo.com/my/path/api/packages/string_scanner`). However, since `pub uploaders` and `pub lish` were using `Uri.resolve` with absolute URIs, whatever path was in `$PUB_HOSTED_URL` would be obliterated. 