### PR TITLE
Don't precompile on pub get/upgrade by default

### DIFF
--- a/lib/src/command/get.dart
+++ b/lib/src/command/get.dart
@@ -27,8 +27,9 @@ class GetCommand extends PubCommand {
         help: "Report what dependencies would change but don't change any.");
 
     argParser.addFlag('precompile',
-        defaultsTo: true,
-        help: "Precompile executables in immediate dependencies.");
+        defaultsTo: false,
+        help: "Precompile executables in immediate dependencies.\n"
+            "If false executables will be precompiled on first run.");
 
     argParser.addFlag('packages-dir', negatable: true, hide: true);
   }

--- a/lib/src/command/get.dart
+++ b/lib/src/command/get.dart
@@ -28,8 +28,7 @@ class GetCommand extends PubCommand {
 
     argParser.addFlag('precompile',
         defaultsTo: false,
-        help: "Precompile executables in immediate dependencies.\n"
-            "If false executables will be precompiled on first run.");
+        help: "Precompile executables in immediate dependencies.");
 
     argParser.addFlag('packages-dir', negatable: true, hide: true);
   }

--- a/lib/src/command/run.dart
+++ b/lib/src/command/run.dart
@@ -69,14 +69,13 @@ class RunCommand extends PubCommand {
         (package != entrypoint.root.name &&
             !entrypoint.packageGraph.isPackageMutable(package));
 
-    final executablePath = entrypoint.packageGraph.packages[package]
-        ?.path(p.join("bin", executable));
-
     var exitCode = await runExecutable(entrypoint, package, executable, args,
         checked: argResults['enable-asserts'] || argResults['checked'],
-        snapshotPath: useSnapshot ? snapshotPath : null,
-        recompile: () =>
-            entrypoint.precompileExecutable(package, executablePath));
+        snapshotPath: useSnapshot ? snapshotPath : null, recompile: () {
+      final executablePath = entrypoint.packageGraph.packages[package]
+          ?.path(p.join("bin", executable));
+      return entrypoint.precompileExecutable(package, executablePath);
+    });
     await flushThenExit(exitCode);
   }
 }

--- a/lib/src/command/run.dart
+++ b/lib/src/command/run.dart
@@ -69,10 +69,14 @@ class RunCommand extends PubCommand {
         (package != entrypoint.root.name &&
             !entrypoint.packageGraph.isPackageMutable(package));
 
+    final executablePath = entrypoint.packageGraph.packages[package]
+        ?.path(p.join("bin", executable));
+
     var exitCode = await runExecutable(entrypoint, package, executable, args,
         checked: argResults['enable-asserts'] || argResults['checked'],
         snapshotPath: useSnapshot ? snapshotPath : null,
-        recompile: entrypoint.precompileExecutables);
+        recompile: () =>
+            entrypoint.precompileExecutable(package, executablePath));
     await flushThenExit(exitCode);
   }
 }

--- a/lib/src/command/run.dart
+++ b/lib/src/command/run.dart
@@ -72,8 +72,10 @@ class RunCommand extends PubCommand {
     var exitCode = await runExecutable(entrypoint, package, executable, args,
         checked: argResults['enable-asserts'] || argResults['checked'],
         snapshotPath: useSnapshot ? snapshotPath : null, recompile: () {
-      final executablePath = entrypoint.packageGraph.packages[package]
-          ?.path(p.join("bin", executable));
+      final pkg = entrypoint.packageGraph.packages[package];
+      // The recompile function will only be called when [package] exists.
+      assert(pkg != null);
+      final executablePath = pkg.path(p.join("bin", executable));
       return entrypoint.precompileExecutable(package, executablePath);
     });
     await flushThenExit(exitCode);

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -29,8 +29,9 @@ class UpgradeCommand extends PubCommand {
         help: "Report what dependencies would change but don't change any.");
 
     argParser.addFlag('precompile',
-        defaultsTo: true,
-        help: "Precompile executables in immediate dependencies.");
+        defaultsTo: false,
+        help: "Precompile executables in immediate dependencies.\n"
+            "If false executables will be precompiled on first run.");
 
     argParser.addFlag('packages-dir', negatable: true, hide: true);
   }

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -30,8 +30,7 @@ class UpgradeCommand extends PubCommand {
 
     argParser.addFlag('precompile',
         defaultsTo: false,
-        help: "Precompile executables in immediate dependencies.\n"
-            "If false executables will be precompiled on first run.");
+        help: "Precompile executables in immediate dependencies.");
 
     argParser.addFlag('packages-dir', negatable: true, hide: true);
   }

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -58,8 +58,9 @@ Future<int> runExecutable(Entrypoint entrypoint, String package,
   entrypoint.migrateCache();
 
   // Unless the user overrides the verbosity, we want to filter out the
-  // normal pub output that may be shown when recompiling snapshots.
-  if (log.verbosity == log.Verbosity.NORMAL) {
+  // normal pub output that may be shown when recompiling snapshots if we are
+  // not attached to a terminal.
+  if (log.verbosity == log.Verbosity.NORMAL && !stdout.hasTerminal) {
     log.verbosity = log.Verbosity.WARNING;
   }
 

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -59,7 +59,8 @@ Future<int> runExecutable(Entrypoint entrypoint, String package,
 
   // Unless the user overrides the verbosity, we want to filter out the
   // normal pub output that may be shown when recompiling snapshots if we are
-  // not attached to a terminal.
+  // not attached to a terminal. This is to not pollute stdout when the output
+  // of `pub run` is piped somewhere.
   if (log.verbosity == log.Verbosity.NORMAL && !stdout.hasTerminal) {
     log.verbosity = log.Verbosity.WARNING;
   }

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -145,7 +145,7 @@ class GlobalPackages {
     var entrypoint = Entrypoint(path, cache);
 
     // Get the package's dependencies.
-    await entrypoint.acquireDependencies(SolveType.GET);
+    await entrypoint.acquireDependencies(SolveType.GET, precompile: true);
     var name = entrypoint.root.name;
 
     // Call this just to log what the current active package is, if any.

--- a/test/run/package_api_test.dart
+++ b/test/run/package_api_test.dart
@@ -56,10 +56,12 @@ main() {
       d.appPubspec({"foo": "any"})
     ]).create();
 
-    await pubGet(output: contains("Precompiled foo:script."));
+    await pubGet();
 
     var pub = await pubRun(args: ["foo:script"]);
 
+    expect(pub.stdout, emits('Precompiling executable...'));
+    expect(pub.stdout, emits('Precompiled foo:script.'));
     expect(pub.stdout, emits("null"));
     expect(pub.stdout,
         emits(p.toUri(p.join(d.sandbox, "myapp/.packages")).toString()));

--- a/test/run/runs_from_a_dependency_override_after_dependency_test.dart
+++ b/test/run/runs_from_a_dependency_override_after_dependency_test.dart
@@ -23,7 +23,7 @@ main() {
       d.appPubspec({"foo": null})
     ]).create();
 
-    await pubGet();
+    await pubGet(args: ['--precompile']);
 
     var pub = await pubRun(args: ["foo:bar"]);
     expect(pub.stdout, emits("foobar"));

--- a/test/snapshot_test.dart
+++ b/test/snapshot_test.dart
@@ -118,7 +118,8 @@ main() {
           ]);
         });
 
-        await pubUpgrade(output: contains("Precompiled foo:hello."));
+        await pubUpgrade(
+            args: ['--precompile'], output: contains("Precompiled foo:hello."));
 
         await d.dir(p.join(appPath, '.dart_tool', 'pub', 'bin', 'foo'), [
           d.file('hello.dart.snapshot.dart2', contains('hello 2!'))
@@ -162,7 +163,8 @@ main() {
           ]);
         });
 
-        await pubUpgrade(output: contains("Precompiled foo:hello."));
+        await pubUpgrade(
+            args: ['--precompile'], output: contains("Precompiled foo:hello."));
 
         await d.dir(p.join(appPath, '.dart_tool', 'pub', 'bin', 'foo'), [
           d.file('hello.dart.snapshot.dart2', contains('hello 2!'))
@@ -198,7 +200,8 @@ main() {
               [d.file("hello.dart", "void main() => print('Goodbye!');")])
         ]).commit();
 
-        await pubUpgrade(output: contains("Precompiled foo:hello."));
+        await pubUpgrade(
+            args: ['--precompile'], output: contains("Precompiled foo:hello."));
 
         await d.dir(p.join(appPath, '.dart_tool', 'pub', 'bin', 'foo'), [
           d.file('hello.dart.snapshot.dart2', contains('Goodbye!'))

--- a/test/snapshot_test.dart
+++ b/test/snapshot_test.dart
@@ -26,10 +26,11 @@ main() {
       await d.appDir({"foo": "1.2.3"}).create();
 
       await pubGet(
+          args: ['--precompile'],
           output: allOf([
-        contains("Precompiled foo:hello."),
-        contains("Precompiled foo:goodbye.")
-      ]));
+            contains("Precompiled foo:hello."),
+            contains("Precompiled foo:goodbye.")
+          ]));
 
       await d.dir(p.join(appPath, '.dart_tool', 'pub', 'bin'), [
         d.file('sdk-version', '0.1.2+3\n'),
@@ -67,10 +68,11 @@ main() {
       await d.appDir({"foo": "1.2.3"}).create();
 
       await pubGet(
+          args: ['--precompile'],
           output: allOf([
-        contains("Precompiled foo:hello."),
-        contains("Precompiled foo:goodbye.")
-      ]));
+            contains("Precompiled foo:hello."),
+            contains("Precompiled foo:goodbye.")
+          ]));
 
       await d.dir(p.join(appPath, '.dart_tool', 'pub', 'bin'), [
         d.file('sdk-version', '0.1.2+3\n'),
@@ -102,7 +104,8 @@ main() {
 
         await d.appDir({"foo": "any"}).create();
 
-        await pubGet(output: contains("Precompiled foo:hello."));
+        await pubGet(
+            args: ['--precompile'], output: contains("Precompiled foo:hello."));
 
         await d.dir(p.join(appPath, '.dart_tool', 'pub', 'bin', 'foo'), [
           d.file('hello.dart.snapshot.dart2', contains('hello!'))
@@ -146,7 +149,8 @@ main() {
 
         await d.appDir({"foo": "any"}).create();
 
-        await pubGet(output: contains("Precompiled foo:hello."));
+        await pubGet(
+            args: ['--precompile'], output: contains("Precompiled foo:hello."));
 
         await d.dir(p.join(appPath, '.dart_tool', 'pub', 'bin', 'foo'), [
           d.file('hello.dart.snapshot.dart2', contains('hello!'))
@@ -182,7 +186,8 @@ main() {
           "foo": {"git": "../foo.git"}
         }).create();
 
-        await pubGet(output: contains("Precompiled foo:hello."));
+        await pubGet(
+            args: ['--precompile'], output: contains("Precompiled foo:hello."));
 
         await d.dir(p.join(appPath, '.dart_tool', 'pub', 'bin', 'foo'), [
           d.file('hello.dart.snapshot.dart2', contains('Hello!'))
@@ -214,7 +219,8 @@ main() {
 
         await d.appDir({"foo": "5.6.7"}).create();
 
-        await pubGet(output: contains("Precompiled foo:hello."));
+        await pubGet(
+            args: ['--precompile'], output: contains("Precompiled foo:hello."));
 
         await d.dir(p.join(appPath, '.dart_tool', 'pub', 'bin'), [
           d.dir('foo', [d.outOfDateSnapshot('hello.dart.snapshot.dart2')])
@@ -224,7 +230,7 @@ main() {
 
         // In the real world this would just print "hello!", but since we collect
         // all output we see the precompilation messages as well.
-        expect(process.stdout, emits("Precompiling executables..."));
+        expect(process.stdout, emits("Precompiling executable..."));
         expect(process.stdout, emitsThrough("hello!"));
         await process.shouldExit();
 

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -31,4 +31,4 @@ echo 'Building snapshot'
 
 # Run tests
 echo 'Running tests'
-pub run test -r expanded "$@"
+pub run test "$@"

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -31,4 +31,4 @@ echo 'Building snapshot'
 
 # Run tests
 echo 'Running tests'
-pub run test "$@"
+pub run test -r expanded "$@"


### PR DESCRIPTION
And only precompile the single desired executable on `pub run`.

Following the suggestion from the discussion on https://github.com/dart-lang/pub/issues/1683#issuecomment-390717324 we avoid printing "precompiling executable..." on `pub run` if we don't have a terminal attached. That allows `pub run` to be used in scripts without polluting `stdout` but still explains the user where time is going on first run of eg. `pub run test`.

This PR does not change `pub global` behavior. We probably want to continue recompiling all executables on `pub global activate`.

This PR still allows --precompile for those who prefer the old behavior.

