### PR TITLE
Fix existing hints and lints

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -814,7 +814,7 @@ void touch(String path) => File(path).setLastModifiedSync(DateTime.now());
 ///
 /// Returns a future that completes to the value that the future returned from
 /// [fn] completes to.
-Future<T> withTempDir<T>(Future<T> fn(String path)) async {
+Future<T> withTempDir<T>(FutureOr<T> fn(String path)) async {
   var tempDir = _createSystemTempDir();
   try {
     return await fn(tempDir);

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -305,6 +305,7 @@ class BoundHostedSource extends CachedSource {
         log.fine("Failed to load package from $entry:\n"
             "$error\n"
             "${Chain.forTrace(stackTrace)}");
+        return null;
       }
     }).toList();
   }

--- a/test/descriptor_server.dart
+++ b/test/descriptor_server.dart
@@ -47,7 +47,7 @@ Future serveErrors() async {
 
 class DescriptorServer {
   /// The underlying server.
-  shelf.Server _server;
+  final shelf.Server _server;
 
   /// A future that will complete to the port used for the server.
   int get port => _server.url.port;
@@ -88,7 +88,7 @@ class DescriptorServer {
         return shelf.Response.notFound('File "$path" not found.');
       }
     });
-    addTearDown(() => _server.close());
+    addTearDown(_server.close);
   }
 
   DescriptorServer._errors(this._server) : _baseDir = d.dir("serve-dir", []) {
@@ -96,7 +96,7 @@ class DescriptorServer {
       fail("The HTTP server received an unexpected request:\n"
           "${request.method} ${request.requestedUri}");
     });
-    addTearDown(() => _server.close());
+    addTearDown(_server.close);
   }
 
   /// Closes this server.

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -347,7 +347,7 @@ void testExistencePredicate(String name, bool predicate(String path),
 }
 
 /// Like [withTempDir], but canonicalizes the path before passing it to [fn].
-Future _withCanonicalTempDir(Future fn(String path)) =>
+Future<T> _withCanonicalTempDir<T>(FutureOr<T> fn(String path)) =>
     withTempDir((temp) => fn(canonicalize(temp)));
 
 /// Creates a directory [dir].

--- a/test/package_server.dart
+++ b/test/package_server.dart
@@ -38,7 +38,7 @@ Future serveNoPackages() => servePackages((_) {});
 
 class PackageServer {
   /// The inner [DescriptorServer] that this uses to serve its descriptors.
-  DescriptorServer _inner;
+  final DescriptorServer _inner;
 
   /// The [d.DirectoryDescriptor] describing the server layout of
   /// `/api/packages` on the test server.


### PR DESCRIPTION
Fix 2 cases of `prefer_final_fields`. Fix some unnecessary_lambda
surfaced by making one field final.

Add a missing return on an argument to `List.map`.

Change the argument type on some utility methods to allow a function
returning `FutureOr` to avoid hints about missing returns on methods
expected to return a `Future`.