### PR TITLE
Filter out `null` from `getCachedPackages`.

### DIFF
--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -298,16 +298,19 @@ class BoundHostedSource extends CachedSource {
     var cacheDir = p.join(systemCacheRoot, _urlToDirectory(source.defaultUrl));
     if (!dirExists(cacheDir)) return [];
 
-    return listDir(cacheDir).map((entry) {
-      try {
-        return Package.load(null, entry, systemCache.sources);
-      } catch (error, stackTrace) {
-        log.fine("Failed to load package from $entry:\n"
-            "$error\n"
-            "${Chain.forTrace(stackTrace)}");
-        return null;
-      }
-    }).toList();
+    return listDir(cacheDir)
+        .map((entry) {
+          try {
+            return Package.load(null, entry, systemCache.sources);
+          } catch (error, stackTrace) {
+            log.fine("Failed to load package from $entry:\n"
+                "$error\n"
+                "${Chain.forTrace(stackTrace)}");
+            return null;
+          }
+        })
+        .where((e) => e != null)
+        .toList();
   }
 
   /// Downloads package [package] at [version] from [server], and unpacks it


### PR DESCRIPTION
The caller in `CacheListCommand.run` does not appear capable of handling
`null` values. Hence, filtering it out seems reasonable in this case.

Cherrypicking the minor fix from https://github.com/dart-lang/pub/pull/2270 onto master after landing https://github.com/dart-lang/pub/pull/2290