### PR TITLE
Rename some test utilities from Mock to Fake

### DIFF
--- a/test/lock_file_test.dart
+++ b/test/lock_file_test.dart
@@ -11,11 +11,11 @@ import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
 
-class MockSource extends Source {
-  final String name = 'mock';
+class FakeSource extends Source {
+  final String name = 'fake';
 
   BoundSource bind(SystemCache cache) =>
-      throw UnsupportedError("Cannot download mock packages.");
+      throw UnsupportedError("Cannot download fake packages.");
 
   PackageRef parseRef(String name, description, {String containingPath}) {
     if (!description.endsWith(' desc')) throw FormatException('Bad');
@@ -41,8 +41,8 @@ class MockSource extends Source {
 
 main() {
   var sources = SourceRegistry();
-  var mockSource = MockSource();
-  sources.register(mockSource);
+  var fakeSource = FakeSource();
+  sources.register(fakeSource);
 
   group('LockFile', () {
     group('parse()', () {
@@ -61,11 +61,11 @@ main() {
 packages:
   bar:
     version: 1.2.3
-    source: mock
+    source: fake
     description: bar desc
   foo:
     version: 2.3.4
-    source: mock
+    source: fake
     description: foo desc
 ''', sources);
 
@@ -74,13 +74,13 @@ packages:
         var bar = lockFile.packages['bar'];
         expect(bar.name, equals('bar'));
         expect(bar.version, equals(Version(1, 2, 3)));
-        expect(bar.source, equals(mockSource));
+        expect(bar.source, equals(fakeSource));
         expect(bar.description, equals('bar desc'));
 
         var foo = lockFile.packages['foo'];
         expect(foo.name, equals('foo'));
         expect(foo.version, equals(Version(2, 3, 4)));
-        expect(foo.source, equals(mockSource));
+        expect(foo.source, equals(fakeSource));
         expect(foo.description, equals('foo desc'));
       });
 
@@ -147,7 +147,7 @@ packages: not a map
           LockFile.parse('''
 packages:
   foo:
-    source: mock
+    source: fake
     description: foo desc
 ''', sources);
         }, throwsFormatException);
@@ -159,7 +159,7 @@ packages:
 packages:
   foo:
     version: vorpal
-    source: mock
+    source: fake
     description: foo desc
 ''', sources);
         }, throwsFormatException);
@@ -182,7 +182,7 @@ packages:
 packages:
   foo:
     version: 1.2.3
-    source: mock
+    source: fake
 ''', sources);
         }, throwsFormatException);
       });
@@ -193,7 +193,7 @@ packages:
 packages:
   foo:
     version: 1.2.3
-    source: mock
+    source: fake
     description: foo desc is bad
 ''', sources);
         }, throwsFormatException);
@@ -238,7 +238,7 @@ packages:
   foo:
     bonus: not used
     version: 1.2.3
-    source: mock
+    source: fake
     description: foo desc
 ''', sources);
       });
@@ -246,8 +246,8 @@ packages:
 
     test('serialize() dumps the lockfile to YAML', () {
       var lockfile = LockFile([
-        PackageId('foo', mockSource, Version.parse('1.2.3'), 'foo desc'),
-        PackageId('bar', mockSource, Version.parse('3.2.1'), 'bar desc')
+        PackageId('foo', fakeSource, Version.parse('1.2.3'), 'foo desc'),
+        PackageId('bar', fakeSource, Version.parse('3.2.1'), 'bar desc')
       ], devDependencies: {
         'bar'
       });
@@ -259,13 +259,13 @@ packages:
             'packages': {
               'foo': {
                 'version': '1.2.3',
-                'source': 'mock',
+                'source': 'fake',
                 'description': 'foo desc',
                 'dependency': 'transitive'
               },
               'bar': {
                 'version': '3.2.1',
-                'source': 'mock',
+                'source': 'fake',
                 'description': 'bar desc',
                 'dependency': 'direct dev'
               }

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -11,11 +11,11 @@ import 'package:pub/src/system_cache.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
-class MockSource extends Source {
-  final String name = "mock";
+class FakeSource extends Source {
+  final String name = "fake";
 
   BoundSource bind(SystemCache cache) =>
-      throw UnsupportedError("Cannot download mock packages.");
+      throw UnsupportedError("Cannot download fake packages.");
 
   PackageRef parseRef(String name, description, {String containingPath}) {
     if (description != 'ok') throw FormatException('Bad');
@@ -37,7 +37,7 @@ class MockSource extends Source {
 main() {
   group('parse()', () {
     var sources = SourceRegistry();
-    sources.register(MockSource());
+    sources.register(FakeSource());
 
     var throwsPubspecException = throwsA(const TypeMatcher<PubspecException>());
 
@@ -76,7 +76,7 @@ main() {
       var pubspec = Pubspec.parse('''
 dependencies:
   foo:
-    mock: ok
+    fake: ok
     version: ">=1.2.3 <3.4.5"
 ''', sources);
 
@@ -99,7 +99,7 @@ dependencies:
       var pubspec = Pubspec.parse('''
 dev_dependencies:
   foo:
-    mock: ok
+    fake: ok
     version: ">=1.2.3 <3.4.5"
 ''', sources);
 
@@ -122,7 +122,7 @@ dev_dependencies:
       var pubspec = Pubspec.parse('''
 dependency_overrides:
   foo:
-    mock: ok
+    fake: ok
     version: ">=1.2.3 <3.4.5"
 ''', sources);
 
@@ -170,7 +170,7 @@ dependencies:
 name: myapp
 dependencies:
   myapp:
-    mock: ok
+    fake: ok
 ''', (pubspec) => pubspec.dependencies);
     });
 
@@ -179,7 +179,7 @@ dependencies:
 name: myapp
 dev_dependencies:
   myapp:
-    mock: ok
+    fake: ok
 ''', (pubspec) => pubspec.devDependencies);
     });
 
@@ -188,7 +188,7 @@ dev_dependencies:
 name: myapp
 dependency_overrides:
   myapp:
-    mock: ok
+    fake: ok
 ''', (pubspec) => pubspec.dependencyOverrides);
     });
 
@@ -196,7 +196,7 @@ dependency_overrides:
       expectPubspecException('''
 dependencies:
   foo:
-    mock: bad
+    fake: bad
 ''', (pubspec) => pubspec.dependencies);
     });
 
@@ -204,7 +204,7 @@ dependencies:
       expectPubspecException('''
 dependencies:
   foo:
-    mock: ok
+    fake: ok
     version: 1.2
 ''', (pubspec) => pubspec.dependencies);
     });
@@ -213,7 +213,7 @@ dependencies:
       expectPubspecException('''
 dependencies:
   foo:
-    mock: ok
+    fake: ok
     version: not constraint
 ''', (pubspec) => pubspec.dependencies);
     });


### PR DESCRIPTION
A Mock is an object that can record and verify interaction during a
test, these classes are not mocks.