### PR TITLE
Refactor Set.add following !Set.contains

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -140,8 +140,7 @@ String canonicalize(String pathString) {
 /// This accepts paths to non-links or broken links, and returns them as-is.
 String _resolveLink(String link) {
   var seen = <String>{};
-  while (linkExists(link) && !seen.contains(link)) {
-    seen.add(link);
+  while (linkExists(link) && seen.add(link)) {
     link =
         path.normalize(path.join(path.dirname(link), Link(link).targetSync()));
   }

--- a/lib/src/solver/version_solver.dart
+++ b/lib/src/solver/version_solver.dart
@@ -324,7 +324,6 @@ class VersionSolver {
           candidate.source.hasMultipleVersions) {
         var ref = candidate.toRef();
         if (_haveUsedLatest.add(ref)) {
-
           // All versions of [ref] other than the latest are forbidden.
           var latestVersion = (await _packageLister(ref).latest).version;
           _addIncompatibility(Incompatibility([

--- a/lib/src/solver/version_solver.dart
+++ b/lib/src/solver/version_solver.dart
@@ -323,8 +323,7 @@ class VersionSolver {
       if (_useLatest.contains(candidate.name) &&
           candidate.source.hasMultipleVersions) {
         var ref = candidate.toRef();
-        if (!_haveUsedLatest.contains(ref)) {
-          _haveUsedLatest.add(ref);
+        if (_haveUsedLatest.add(ref)) {
 
           // All versions of [ref] other than the latest are forbidden.
           var latestVersion = (await _packageLister(ref).latest).version;


### PR DESCRIPTION
The `.add` method returns a boolean indicating whether then value was
not already contained in the set. Find a few places where both are used
unnecessarily and refactor to only call `.add` and use the returned
boolean.