### PR TITLE
Use LOCALAPPDATA for system cache on windows

### DIFF
--- a/lib/src/system_cache.dart
+++ b/lib/src/system_cache.dart
@@ -38,8 +38,9 @@ class SystemCache {
       // If a cache dir already exists in %APPDATA%, use it, else default to %LOCALAPPDATA%
       var appData = Platform.environment['APPDATA'];
       var appDataCacheDir = p.join(appData, 'Pub', 'Cache');
-      if (Directory(appDataCacheDir).existsSync())
+      if (Directory(appDataCacheDir).existsSync()) {
         return appDataCacheDir;
+      }
       var localAppData = Platform.environment['LOCALAPPDATA'];
       return p.join(localAppData, 'Pub', 'Cache');
     } else {

--- a/lib/src/system_cache.dart
+++ b/lib/src/system_cache.dart
@@ -38,7 +38,7 @@ class SystemCache {
       // If a cache dir already exists in %APPDATA%, use it, else default to %LOCALAPPDATA%
       var appData = Platform.environment['APPDATA'];
       var appDataCacheDir = p.join(appData, 'Pub', 'Cache');
-      if (Directory(appDataCacheDir).existsSync()) {
+      if (dirExists(appDataCacheDir)) {
         return appDataCacheDir;
       }
       var localAppData = Platform.environment['LOCALAPPDATA'];

--- a/lib/src/system_cache.dart
+++ b/lib/src/system_cache.dart
@@ -35,7 +35,11 @@ class SystemCache {
     if (Platform.environment.containsKey('PUB_CACHE')) {
       return Platform.environment['PUB_CACHE'];
     } else if (Platform.isWindows) {
-      // If a cache dir already exists in %APPDATA%, use it, else default to %LOCALAPPDATA%
+      // %LOCALAPPDATA% is preferred as the cache location over %APPDATA%, because the latter is synchronised between
+      // devices when the user roams between them, whereas the former is not.
+      // The default cache dir used to be in %APPDATA%, so to avoid breaking old installs,
+      // we use the old dir in %APPDATA% if it exists. Else, we use the new default location
+      // in %LOCALAPPDATA%.
       var appData = Platform.environment['APPDATA'];
       var appDataCacheDir = p.join(appData, 'Pub', 'Cache');
       if (dirExists(appDataCacheDir)) {

--- a/lib/src/system_cache.dart
+++ b/lib/src/system_cache.dart
@@ -35,8 +35,13 @@ class SystemCache {
     if (Platform.environment.containsKey('PUB_CACHE')) {
       return Platform.environment['PUB_CACHE'];
     } else if (Platform.isWindows) {
+      // If a cache dir already exists in %APPDATA%, use it, else default to %LOCALAPPDATA%
       var appData = Platform.environment['APPDATA'];
-      return p.join(appData, 'Pub', 'Cache');
+      var appDataCacheDir = p.join(appData, 'Pub', 'Cache');
+      if (Directory(appDataCacheDir).existsSync())
+        return appDataCacheDir;
+      var localAppData = Platform.environment['LOCALAPPDATA'];
+      return p.join(localAppData, 'Pub', 'Cache');
     } else {
       return '${Platform.environment['HOME']}/.pub-cache';
     }


### PR DESCRIPTION
Currently, the default location for pub's system cache is in %APPDATA%, which means it is in the roaming profile that gets synced across devices. This is less than ideal because it can get pretty large.

This PR moves the default location of the cache to %LOCALAPPDATA%, but will use %APPDATA% if the cache already exists there to avoid breaking existing installs linking to that location

Fixes #1273