### PR TITLE
Omit languageVersion when there is no SDK constraint

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -676,18 +676,18 @@ class Entrypoint {
         continue;
       }
 
-      String languageVersion;
       try {
-        languageVersion = extractLanguageVersion(
+        final languageVersion = extractLanguageVersion(
           cache.load(id).pubspec.sdkConstraints[sdk.identifier],
         );
+        if (pkg.languageVersion != languageVersion) {
+          dataError('${p.join(source.getDirectory(id), 'pubspec.yaml')} has '
+              'changed since the pubspec.lock file was generated, please run '
+              '"pub get" again.');
+        }
       } on FileException {
-        languageVersion = null;
-      }
-      if (languageVersion == null || pkg.languageVersion != languageVersion) {
-        dataError('${p.join(source.getDirectory(id), 'pubspec.yaml')} has '
-            'changed since the pubspec.lock file was generated, please run "pub '
-            'get" again.');
+        dataError('Failed to read pubspec.yaml for "${pkg.name}", perhaps the '
+            'entry is missing, please run "pub get".');
       }
     }
   }

--- a/lib/src/package_config.dart
+++ b/lib/src/package_config.dart
@@ -5,7 +5,6 @@
 import 'package:meta/meta.dart';
 
 import 'package:pub_semver/pub_semver.dart';
-import 'sdk.dart' show sdk;
 
 /// Contents of a `.dart_tool/package_config.json` file.
 class PackageConfig {
@@ -248,27 +247,30 @@ class PackageConfigEntry {
   Map<String, Object> toJson() => {
         'name': name,
         'rootUri': rootUri.toString(),
-        'packageUri': packageUri?.toString(),
-        'languageVersion': languageVersion,
+        if (packageUri != null) 'packageUri': packageUri?.toString(),
+        if (languageVersion != null) 'languageVersion': languageVersion,
       }..addAll(additionalProperties ?? {});
 }
 
 /// Extract the _language version_ from an SDK constraint from `pubspec.yaml`.
+///
+/// This returns `null` if there is no language version.
 String extractLanguageVersion(VersionConstraint c) {
   Version minVersion;
   if (c == null || c.isEmpty) {
-    // If we have no language version, we use the version of the current
-    // SDK processing the 'pubspec.yaml' file.
-    minVersion = sdk.version;
+    return null;
   } else if (c is Version) {
     minVersion = c;
   } else if (c is VersionRange) {
-    minVersion = c.min ?? sdk.version;
+    minVersion = c.min;
   } else if (c is VersionUnion) {
     // `ranges` is non-empty and sorted.
-    minVersion = c.ranges.first.min ?? sdk.version;
+    minVersion = c.ranges.first.min;
   } else {
     throw ArgumentError('Unknown VersionConstraint type $c.');
+  }
+  if (minVersion == null) {
+    return null;
   }
   return '${minVersion.major}.${minVersion.minor}';
 }

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -188,8 +188,6 @@ Descriptor packageConfigFile(List<PackageConfigEntry> packages) =>
 
 /// Create a [PackageConfigEntry] which assumes package with [name] is either
 /// a cached package with given [version] or a path dependency at given [path].
-///
-/// If not given [languageVersion] will be inferred from current SDK version.
 PackageConfigEntry packageConfigEntry({
   @required String name,
   String version,
@@ -214,7 +212,7 @@ PackageConfigEntry packageConfigEntry({
     name: name,
     rootUri: rootUri,
     packageUri: Uri(path: 'lib/'),
-    languageVersion: languageVersion ?? '0.1', // from '0.1.2+3'
+    languageVersion: languageVersion,
   );
 }
 

--- a/test/package_config_file_test.dart
+++ b/test/package_config_file_test.dart
@@ -206,5 +206,47 @@ void main() {
         ]),
       ]).validate();
     });
+
+    test('package_config.json has no default language version', () async {
+      await servePackages((builder) {
+        builder.serve(
+          'foo',
+          '1.2.3',
+          pubspec: {
+            'environment': {
+              'sdk': '>=0.0.1 <=0.2.2+2', // tests runs with '0.1.2+3'
+            },
+          },
+          contents: [d.dir('lib', [])],
+        );
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'dependencies': {
+            'foo': '^1.2.3',
+          },
+        }),
+        d.dir('lib')
+      ]).create();
+
+      await pubCommand(command);
+
+      await d.dir(appPath, [
+        d.packageConfigFile([
+          d.packageConfigEntry(
+            name: 'foo',
+            version: '1.2.3',
+            languageVersion: '0.0',
+          ),
+          d.packageConfigEntry(
+            name: 'myapp',
+            path: '.',
+            languageVersion: null,
+          ),
+        ]),
+      ]).validate();
+    });
   });
 }


### PR DESCRIPTION
Instead of writing a language version based on the current SDK.
This causes the fallback to using the latest version to happen
at runtime instead of at `pub get` time.