### PR TITLE
Use a unqiue file name for the snapshot during testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
 env:
   global:
     - SPLIT=`which gsplit || which split`
+    - _PUB_TEST_SNAPSHOT="`pwd`/.dart_tool//pub.dart.snapshot.dart2"
 
 dart_task:
   - test: --preset travis `$SPLIT -n l/1/7 .dart_tool/test_files`
@@ -32,9 +33,8 @@ dart_task:
 # Create a snapshot to improve startup time. Tests will automatically use this
 # snapshot if it's available.
 before_script:
-  - dart --snapshot=bin/pub.dart.snapshot.dart2 bin/pub.dart
+  - dart --snapshot="$_PUB_TEST_SNAPSHOT" bin/pub.dart
   - find test -name "*_test\\.dart" | sort > .dart_tool/test_files
-  -
 
 # Only building these branches means that we don't run two builds for each pull
 # request.

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -349,14 +349,19 @@ Future<PubProcess> startPub(
     dartBin = p.absolute(dartBin);
   }
 
-  // If there's a snapshot available, use it. The user is responsible for
-  // ensuring this is up-to-date..
+  var pubPath = p.absolute(p.join(pubRoot, 'bin/pub.dart'));
+
+  // If there's a snapshot for "pub" available we use it. If the snapshot is
+  // out-of-date local source the tests will be useless, therefore it is
+  // recommended to use a temporary file with a unique name for each test run.
+  // Note: running tests without a snapshot is significantly slower.
   //
   // TODO(nweiz): When the test runner supports plugins, create one to
   // auto-generate the snapshot before each run.
-  var pubPath = p.absolute(p.join(pubRoot, 'bin/pub.dart'));
-  var snapshotPath = '$pubPath.snapshot.dart2';
-  if (fileExists(snapshotPath)) pubPath = snapshotPath;
+  final snapshotPath = Platform.environment['_PUB_TEST_SNAPSHOT'] ?? '';
+  if (snapshotPath.isNotEmpty && fileExists(snapshotPath)) {
+    pubPath = snapshotPath;
+  }
 
   var dartArgs = [await PackageResolver.current.processArgument];
   dartArgs..addAll([pubPath, '--verbose'])..addAll(args);


### PR DESCRIPTION
Testing `pub` without a snapshot is slow because many tests
invokes `pub` as a commandline tool. Supplying the snapshot
using a fixed filename is risky as it's easy to forget to
delete/rebuild the snapshot causing test results to be
out-of-date.

By using an environment variable to specify the name of the
`pub` snapshot, we can create a random temporary file for
each test run. This minimizes the risk that we accidentally
run tests with an outdated snapshot of `pub`.