### PR TITLE
Don't require homepage on `pub publish`

### DIFF
--- a/lib/src/validator/pubspec_field.dart
+++ b/lib/src/validator/pubspec_field.dart
@@ -15,8 +15,13 @@ class PubspecFieldValidator extends Validator {
   @override
   Future validate() {
     _validateFieldIsString('description');
-    _validateFieldIsString('homepage');
     _validateFieldUrl('homepage');
+    _validateFieldUrl('repository');
+    if (!_hasField('homepage') && !_hasField('repository')) {
+      warnings.add(
+          'You are strongly reccomended to add either a "homepage" or a "repository" field');
+    }
+
     _validateFieldUrl('documentation');
 
     // Any complex parsing errors in version will be exposed through
@@ -31,6 +36,8 @@ class PubspecFieldValidator extends Validator {
 
     return Future.value();
   }
+
+  bool _hasField(String field) => entrypoint.root.pubspec.fields[field] != null;
 
   /// Adds an error if [field] doesn't exist or isn't a string.
   void _validateFieldIsString(String field) {

--- a/test/lish/force_does_not_publish_if_there_are_errors_test.dart
+++ b/test/lish/force_does_not_publish_if_there_are_errors_test.dart
@@ -15,7 +15,7 @@ void main() {
 
   test('--force does not publish if there are errors', () async {
     var pkg = packageMap('test_pkg', '1.0.0');
-    pkg.remove('homepage');
+    pkg.remove('description');
     await d.dir(appPath, [d.pubspec(pkg)]).create();
 
     var server = await ShelfTestServer.create();

--- a/test/lish/package_validation_has_an_error_test.dart
+++ b/test/lish/package_validation_has_an_error_test.dart
@@ -15,7 +15,7 @@ void main() {
 
   test('package validation has an error', () async {
     var pkg = packageMap('test_pkg', '1.0.0');
-    pkg.remove('homepage');
+    pkg.remove('description');
     await d.dir(appPath, [d.pubspec(pkg)]).create();
 
     var server = await ShelfTestServer.create();

--- a/test/validator/pubspec_field_test.dart
+++ b/test/validator/pubspec_field_test.dart
@@ -29,6 +29,15 @@ void main() {
       expectNoValidationError(pubspecField);
     });
 
+    test('has an HTTPS repository URL instead of homepage', () async {
+      var pkg = packageMap('test_pkg', '1.0.0');
+      pkg.remove('homepage');
+      pkg['repository'] = 'https://pub.dartlang.org';
+      await d.dir(appPath, [d.pubspec(pkg)]).create();
+
+      expectNoValidationError(pubspecField);
+    });
+
     test('has an HTTPS documentation URL', () async {
       var pkg = packageMap('test_pkg', '1.0.0');
       pkg['documentation'] = 'https://pub.dartlang.org';
@@ -38,16 +47,19 @@ void main() {
     });
   });
 
-  group('should consider a package invalid if it', () {
-    setUp(d.validPackage.create);
-
-    test('is missing the "homepage" field', () async {
+  group('should warn if a package', () {
+    test('is missing both the "homepage" and the "description" field',
+        () async {
       var pkg = packageMap('test_pkg', '1.0.0');
       pkg.remove('homepage');
       await d.dir(appPath, [d.pubspec(pkg)]).create();
 
-      expectValidationError(pubspecField);
+      expectValidationWarning(pubspecField);
     });
+  });
+
+  group('should consider a package invalid if it', () {
+    setUp(d.validPackage.create);
 
     test('is missing the "description" field', () async {
       var pkg = packageMap('test_pkg', '1.0.0');
@@ -60,6 +72,14 @@ void main() {
     test('has a non-string "homepage" field', () async {
       var pkg = packageMap('test_pkg', '1.0.0');
       pkg['homepage'] = 12;
+      await d.dir(appPath, [d.pubspec(pkg)]).create();
+
+      expectValidationError(pubspecField);
+    });
+
+    test('has a non-string "repository" field', () async {
+      var pkg = packageMap('test_pkg', '1.0.0');
+      pkg['repository'] = 12;
       await d.dir(appPath, [d.pubspec(pkg)]).create();
 
       expectValidationError(pubspecField);
@@ -84,6 +104,14 @@ void main() {
     test('has a non-HTTP documentation URL', () async {
       var pkg = packageMap('test_pkg', '1.0.0');
       pkg['documentation'] = 'file:///foo/bar';
+      await d.dir(appPath, [d.pubspec(pkg)]).create();
+
+      expectValidationError(pubspecField);
+    });
+
+    test('has a non-HTTP repository URL', () async {
+      var pkg = packageMap('test_pkg', '1.0.0');
+      pkg['repository'] = 'file:///foo/bar';
       await d.dir(appPath, [d.pubspec(pkg)]).create();
 
       expectValidationError(pubspecField);


### PR DESCRIPTION
Also validate the repository field.

This is intended to fix https://github.com/dart-lang/pub/issues/2312