### PR TITLE
Remove unused dev_deps

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,9 +29,6 @@ dependencies:
   yaml: ^2.2.0
 
 dev_dependencies:
-  build_runner: ^1.0.0
-  build_test: ^0.10.0
-  build_vm_compilers: ^1.0.0
   shelf_test_handler: ^1.0.0
   test: ^1.3.0
   test_descriptor: ^1.0.0


### PR DESCRIPTION
These were used for building pub when testing.
This is now done by tool/test.sh instead.