### PR TITLE
Capitalize the default in y/N prompt

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -576,14 +576,16 @@ final Stream<String> _stdinLines =
 /// Returns a [Future] that completes to `true` if the user confirms or `false`
 /// if they do not.
 ///
-/// This will automatically append " (y/n)?" to the message, so [message]
-/// should just be a fragment like, "Are you sure you want to proceed".
+/// This will automatically append " (y/N)?" to the message, so [message]
+/// should just be a fragment like, "Are you sure you want to proceed". The
+/// default for an empty response, or any response not starting with `y` or `Y`
+/// is false.
 Future<bool> confirm(String message) {
   log.fine('Showing confirm message: $message');
   if (runningFromTest) {
-    log.message('$message (y/n)?');
+    log.message('$message (y/N)?');
   } else {
-    stdout.write(log.format('$message (y/n)? '));
+    stdout.write(log.format('$message (y/N)? '));
   }
   return streamFirst(_stdinLines).then(RegExp(r'^[yY]').hasMatch);
 }

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -293,7 +293,7 @@ Future confirmPublish(TestProcess pub) async {
   await expectLater(
       pub.stdout,
       emitsThrough(matches(
-        r'^Do you want to publish [^ ]+ [^ ]+ (y/n)?',
+        r'^Do you want to publish [^ ]+ [^ ]+ (y/N)?',
       )));
   pub.stdin.writeln('y');
 }


### PR DESCRIPTION
This makes it more clear that `N` is the default if enter is pressed
with no value.