### PR TITLE
Drop redundant stream utils

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -569,7 +569,7 @@ final String dartRepoRoot = (() {
 
 /// A line-by-line stream of standard input.
 final Stream<String> _stdinLines =
-    streamToLines(ByteStream(stdin).toStringStream());
+    ByteStream(stdin).toStringStream().transform(const LineSplitter());
 
 /// Displays a message and reads a yes/no confirmation from the user.
 ///
@@ -585,7 +585,7 @@ Future<bool> confirm(String message) {
   } else {
     stdout.write(log.format('$message (y/n)? '));
   }
-  return streamFirst(_stdinLines).then(RegExp(r'^[yY]').hasMatch);
+  return _stdinLines.first.then(RegExp(r'^[yY]').hasMatch);
 }
 
 /// Flushes the stdout and stderr streams, then exits the program with the given


### PR DESCRIPTION
- `streamFirst` does not behave differently from `stream.first`. The
  comment about being able to use it with single-subscription streams is
  a lie.
- `streamLines` is redundant against `LineSplitter`.