### PR TITLE
Drop quoteRegExp util

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -845,7 +845,7 @@ pub global run ${package.name}:$script "\$@"
   /// Returns the value of the property named [name] in the bin stub script
   /// [source].
   String _binStubProperty(String source, String name) {
-    var pattern = RegExp(quoteRegExp(name) + r': ([a-zA-Z0-9_-]+)');
+    var pattern = RegExp(RegExp.escape(name) + r': ([a-zA-Z0-9_-]+)');
     var match = pattern.firstMatch(source);
     return match == null ? null : match[1];
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -212,21 +212,6 @@ String pluralize(String name, int number, {String plural}) {
 String capitalize(String text) =>
     text.substring(0, 1).toUpperCase() + text.substring(1);
 
-/// Escapes any regex metacharacters in [string] so that using as a [RegExp]
-/// pattern will match the string literally.
-// TODO(rnystrom): Remove when #4706 is fixed.
-String quoteRegExp(String string) {
-  // Note: make sure "\" is done first so that we don't escape the other
-  // escaped characters. We could do all of the replaces at once with a regexp
-  // but string literal for regex that matches all regex metacharacters would
-  // be a bit hard to read.
-  for (var metacharacter in r'\^$.*+?()[]{}|'.split('')) {
-    string = string.replaceAll(metacharacter, '\\$metacharacter');
-  }
-
-  return string;
-}
-
 /// Returns whether [host] is a host for a localhost or loopback URL.
 ///
 /// Unlike [InternetAddress.isLoopback], this hostnames from URLs as well as


### PR DESCRIPTION
This has been implemented in the SDK as `RegExp.escape`.