### PR TITLE
Update usage output for latest args

### DIFF
--- a/test/pub_test.dart
+++ b/test/pub_test.dart
@@ -34,7 +34,6 @@ void main() {
           downgrade   Downgrade the current package's dependencies to oldest versions.
           get         Get the current package's dependencies.
           global      Work with global packages.
-          help        Display help information for pub.
           logout      Log out of pub.dartlang.org.
           outdated    Analyze your dependencies to find which ones can be upgraded.
           publish     Publish the current package to pub.dartlang.org.

--- a/test/pub_uploader_test.dart
+++ b/test/pub_uploader_test.dart
@@ -22,7 +22,6 @@ Usage: pub uploader [options] {add/remove} <email>
 -h, --help       Print this usage information.
     --server     The package server on which the package is hosted.
                  (defaults to "https://pub.dartlang.org")
-
     --package    The package whose uploaders will be modified.
                  (defaults to the current package)
 


### PR DESCRIPTION
The `help` command i now hidden since it is redundant against the last
line which also explains how to use help.