### PR TITLE
Rename arguments from checked to enableAsserts

### DIFF
--- a/lib/src/command/global_run.dart
+++ b/lib/src/command/global_run.dart
@@ -58,7 +58,7 @@ class GlobalRunCommand extends PubCommand {
     }
 
     var exitCode = await globals.runExecutable(package, executable, args,
-        checked: argResults['enable-asserts'] || argResults['checked']);
+        enableAsserts: argResults['enable-asserts'] || argResults['checked']);
     await flushThenExit(exitCode);
   }
 }

--- a/lib/src/command/run.dart
+++ b/lib/src/command/run.dart
@@ -76,7 +76,7 @@ class RunCommand extends PubCommand {
             !entrypoint.packageGraph.isPackageMutable(package));
 
     var exitCode = await runExecutable(entrypoint, package, executable, args,
-        checked: argResults['enable-asserts'] || argResults['checked'],
+        enableAsserts: argResults['enable-asserts'] || argResults['checked'],
         snapshotPath: useSnapshot ? snapshotPath : null, recompile: () {
       final pkg = entrypoint.packageGraph.packages[package];
       // The recompile function will only be called when [package] exists.

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -123,7 +123,7 @@ Future<String> _executablePath(
 Future<int> _runOrCompileSnapshot(String path, Iterable<String> args,
     {Future<void> Function() recompile,
     String packagesFile,
-    bool enableAsserts: false}) async {
+    bool enableAsserts = false}) async {
   if (!fileExists(path)) {
     if (recompile == null) return null;
     await recompile();
@@ -151,7 +151,7 @@ Future<int> _runOrCompileSnapshot(String path, Iterable<String> args,
 Future<int> _runSnapshot(String path, Iterable<String> args,
     {Future<void> Function() recompile,
     String packagesFile,
-    bool enableAsserts: false}) async {
+    bool enableAsserts = false}) async {
   Uri packageConfig;
   if (packagesFile != null) {
     // We use an absolute path here not because the VM insists but because it's

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -69,7 +69,9 @@ Future<int> runExecutable(Entrypoint entrypoint, String package,
       entrypoint.assertUpToDate();
 
       var result = await _runOrCompileSnapshot(snapshotPath, args,
-          packagesFile: packagesFile, checked: checked, recompile: recompile);
+          packagesFile: packagesFile,
+          enableAsserts: enableAsserts,
+          recompile: recompile);
       if (result != null) return result;
     }
 
@@ -130,7 +132,7 @@ Future<int> _runOrCompileSnapshot(String path, Iterable<String> args,
     if (!fileExists(path)) return null;
   }
 
-  return await runSnapshot(path, args,
+  return await _runSnapshot(path, args,
       recompile: recompile,
       packagesFile: packagesFile,
       enableAsserts: enableAsserts);

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -400,7 +400,7 @@ class GlobalPackages {
   /// Returns the exit code from the executable.
   Future<int> runExecutable(
       String package, String executable, Iterable<String> args,
-      {bool enableAsserts: false}) {
+      {bool enableAsserts = false}) {
     var entrypoint = find(package);
     return exe.runExecutable(
         entrypoint, package, p.join('bin', '$executable.dart'), args,

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -395,16 +395,16 @@ class GlobalPackages {
   /// recompiled if the SDK has been upgraded since it was first compiled and
   /// then run. Otherwise, it will be run from source.
   ///
-  /// If [checked] is true, the program is run with assertions enabled.
+  /// If [enableAsserts] is true, the program is run with assertions enabled.
   ///
   /// Returns the exit code from the executable.
   Future<int> runExecutable(
       String package, String executable, Iterable<String> args,
-      {bool checked = false}) {
+      {bool enableAsserts: false}) {
     var entrypoint = find(package);
     return exe.runExecutable(
         entrypoint, package, p.join('bin', '$executable.dart'), args,
-        checked: checked,
+        enableAsserts: enableAsserts,
         packagesFile:
             entrypoint.isCached ? _getPackagesFilePath(package) : null,
         // Don't use snapshots for executables activated from paths.

--- a/lib/src/isolate.dart
+++ b/lib/src/isolate.dart
@@ -16,14 +16,14 @@ import 'dart:isolate';
 /// If [buffered] is `true`, this uses [spawnBufferedUri] to spawn the isolate.
 Future runUri(Uri url, List<String> args, Object message,
     {bool buffered = false,
-    bool checked,
+    bool enableAsserts,
     bool automaticPackageResolution = false,
     Uri packageConfig}) async {
   var errorPort = ReceivePort();
   var exitPort = ReceivePort();
 
   await Isolate.spawnUri(url, args, message,
-      checked: checked,
+      checked: enableAsserts,
       automaticPackageResolution: automaticPackageResolution,
       packageConfig: packageConfig,
       onError: errorPort.sendPort,


### PR DESCRIPTION
For fewer references to the legacy name and to match the option that
users would pass.