### PR TITLE
Fix `pub outdated` for circular dependency on root.

### DIFF
--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -183,8 +183,11 @@ class OutdatedCommand extends PubCommand {
 Pubspec _stripDevDependencies(Pubspec original) {
   return Pubspec(
     original.name,
+    version: original.version,
     sdkConstraints: original.sdkConstraints,
     dependencies: original.dependencies.values,
+    devDependencies: [], // explicitly give empty list, to prevent lazy parsing
+    // TODO(sigurdm): consider dependency overrides.
   );
 }
 
@@ -211,6 +214,7 @@ Pubspec _stripVersionConstraints(Pubspec original) {
 
   return Pubspec(
     original.name,
+    version: original.version,
     sdkConstraints: original.sdkConstraints,
     dependencies: _unconstrained(original.dependencies),
     devDependencies: _unconstrained(original.devDependencies),

--- a/test/outdated/goldens/circular_dependencies.txt
+++ b/test/outdated/goldens/circular_dependencies.txt
@@ -1,0 +1,72 @@
+$ pub outdated --format=json
+Resolving...
+{
+  "packages": [
+    {
+      "package": "foo",
+      "current": "1.2.3",
+      "upgradable": "1.3.0",
+      "resolvable": "1.3.0",
+      "latest": "1.3.0"
+    }
+  ]
+}
+
+$ pub outdated --format=no-color
+Resolving...
+Package  Current  Upgradable  Resolvable  Latest  
+dependencies
+foo      *1.2.3   1.3.0       1.3.0       1.3.0   
+
+dev_dependencies: all up-to-date
+
+transitive dependencies: all up-to-date
+1 upgradable dependency is locked (in pubspec.lock) to an older version.
+To update it, use `pub upgrade`.
+
+$ pub outdated --format=no-color --mark=none
+Resolving...
+Package  Current  Upgradable  Resolvable  Latest  
+dependencies
+foo      1.2.3    1.3.0       1.3.0       1.3.0   
+
+dev_dependencies: all up-to-date
+
+transitive dependencies: all up-to-date
+1 upgradable dependency is locked (in pubspec.lock) to an older version.
+To update it, use `pub upgrade`.
+
+$ pub outdated --format=no-color --up-to-date
+Resolving...
+Package  Current  Upgradable  Resolvable  Latest  
+dependencies
+foo      *1.2.3   1.3.0       1.3.0       1.3.0   
+
+dev_dependencies: all up-to-date
+
+transitive dependencies: all up-to-date
+1 upgradable dependency is locked (in pubspec.lock) to an older version.
+To update it, use `pub upgrade`.
+
+$ pub outdated --format=no-color --pre-releases
+Resolving...
+Package  Current  Upgradable  Resolvable  Latest  
+dependencies
+foo      *1.2.3   1.3.0       1.3.0       1.3.0   
+
+dev_dependencies: all up-to-date
+
+transitive dependencies: all up-to-date
+1 upgradable dependency is locked (in pubspec.lock) to an older version.
+To update it, use `pub upgrade`.
+
+$ pub outdated --format=no-color --no-dev-dependencies
+Resolving...
+Package  Current  Upgradable  Resolvable  Latest  
+dependencies
+foo      *1.2.3   1.3.0       1.3.0       1.3.0   
+
+transitive dependencies: all up-to-date
+1 upgradable dependency is locked (in pubspec.lock) to an older version.
+To update it, use `pub upgrade`.
+

--- a/test/outdated/outdated_test.dart
+++ b/test/outdated/outdated_test.dart
@@ -80,4 +80,27 @@ Future<void> main() async {
       ..serve('transitive3', '1.0.0'));
     await variations('newer_versions');
   });
+
+  test('circular dependency on root', () async {
+    await servePackages(
+      (builder) => builder..serve('foo', '1.2.3', deps: {'app': '^1.0.0'}),
+    );
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'app',
+        'version': '1.0.1',
+        'dependencies': {
+          'foo': '^1.0.0',
+        },
+      })
+    ]).create();
+
+    await pubGet();
+
+    globalPackageServer.add(
+      (builder) => builder..serve('foo', '1.3.0', deps: {'app': '^1.0.1'}),
+    );
+    await variations('circular_dependencies');
+  });
 }


### PR DESCRIPTION
When root package is required by one of its dependencies, resolution
fails as the stripped `PubSpec` didn't retain the verion number.
This addresses this issue, and adds a test case covering circular
dependency on the root package.