### PR TITLE
Use gzip decoder from dart:io.

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -847,7 +847,7 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
     final tarFile = path.join(tempDir, 'archive.tar');
     await _createFileFromStream(decompressed, tarFile);
     return (Platform.isWindows)
-        ? runProcess(_pathTo7zip, ['x', '$tarFile', '-o$destination'])
+        ? runProcess(_pathTo7zip, ['x', '$tarFile'], workingDir: destination)
         : runProcess(_tarPath, [
             if (_noUnknownKeyword) '--warning=no-unknown-keyword',
             '--extract',

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -844,7 +844,7 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
   // We used to stream directly to `tar`,  but that was fragile in certain
   // settings.
   final processResult = await withTempDir((tempDir) async {
-    final tarFile = path.join(tempDir, '${path.basename(destination)}.tar');
+    final tarFile = path.join(tempDir, 'archive.tar');
     await _createFileFromStream(decompressed, tarFile);
     return (Platform.isWindows)
         ? runProcess(_pathTo7zip, ['x', '"$tarFile"', '-o"$destination"'])

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -226,8 +226,8 @@ String createTempDir(String base, String prefix) {
 /// 'pub_' with characters appended to it to make a unique name.
 ///
 /// Returns the path of the created directory.
-String _createSystemTempDir() {
-  var tempDir = Directory.systemTemp.createTempSync('pub_');
+Future<String> _createSystemTempDir() async {
+  var tempDir = await Directory.systemTemp.createTemp('pub_');
   log.io('Created temp directory ${tempDir.path}');
   return tempDir.resolveSymbolicLinksSync();
 }
@@ -797,7 +797,7 @@ void touch(String path) => File(path).setLastModifiedSync(DateTime.now());
 /// Returns a future that completes to the value that the future returned from
 /// [fn] completes to.
 Future<T> withTempDir<T>(FutureOr<T> Function(String path) fn) async {
-  var tempDir = _createSystemTempDir();
+  var tempDir = await _createSystemTempDir();
   try {
     return await fn(tempDir);
   } finally {
@@ -980,7 +980,7 @@ ByteStream createTarGz(List<String> contents, {String baseDir}) {
 
     // Don't use [withTempDir] here because we don't want to delete the temp
     // directory until the returned stream has closed.
-    var tempDir = _createSystemTempDir();
+    var tempDir = await _createSystemTempDir();
 
     try {
       // Create the file containing the list of files to compress.

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -847,7 +847,7 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
     final tarFile = path.join(tempDir, 'archive.tar');
     await _createFileFromStream(decompressed, tarFile);
     return (Platform.isWindows)
-        ? runProcess(_pathTo7zip, ['x', '$tarFile'], workingDir: destination)
+        ? runProcess(_pathTo7zip, ['x', tarFile], workingDir: destination)
         : runProcess(_tarPath, [
             if (_noUnknownKeyword) '--warning=no-unknown-keyword',
             '--extract',

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -610,33 +610,6 @@ Pair<EventSink<T>, Future> _consumerToSink<T>(StreamConsumer<T> consumer) {
   return Pair(controller.sink, done);
 }
 
-// TODO(nweiz): remove this when issue 7786 is fixed.
-/// Pipes all data and errors from [stream] into [sink].
-///
-/// When [stream] is done, the returned [Future] is completed and [sink] is
-/// closed if [closeSink] is true.
-///
-/// When an error occurs on [stream], that error is passed to [sink]. If
-/// [cancelOnError] is true, [Future] will be completed successfully and no
-/// more data or errors will be piped from [stream] to [sink]. If
-/// [cancelOnError] and [closeSink] are both true, [sink] will then be
-/// closed.
-Future _store(Stream stream, EventSink sink,
-    {bool cancelOnError = true, bool closeSink = true}) {
-  var completer = Completer();
-  stream.listen(sink.add, onError: (e, stackTrace) {
-    sink.addError(e, stackTrace);
-    if (cancelOnError) {
-      completer.complete();
-      if (closeSink) sink.close();
-    }
-  }, onDone: () {
-    if (closeSink) sink.close();
-    completer.complete();
-  }, cancelOnError: cancelOnError);
-  return completer.future;
-}
-
 /// Spawns and runs the process located at [executable], passing in [args].
 ///
 /// Returns a [Future] that will complete with the results of the process after
@@ -867,38 +840,38 @@ String _findTarPath() {
 /// Extracts a `.tar.gz` file from [stream] to [destination].
 Future extractTarGz(Stream<List<int>> stream, String destination) async {
   log.fine('Extracting .tar.gz stream to $destination.');
-  if (Platform.isWindows) {
-    return await _extractTarGzWindows(stream, destination);
+  final decompressed = stream.transform(GZipCodec().decoder);
+  // We used to stream directly to `tar`,  but that was fragile in certain
+  // settings.
+  PubProcessResult processResult;
+  await withTempDir((tempDir) async {
+    final tarFile =
+        path.join(tempDir, path.basenameWithoutExtension(destination));
+    await _createFileFromStream(decompressed, tarFile);
+
+    if (Platform.isWindows) {
+      processResult = await runProcess(_pathTo7zip, ['x', tarFile],
+          workingDir: destination);
+    } else {
+      processResult = await runProcess(_tarPath, [
+        if (_noUnknownKeyword) '--warning=no-unknown-keyword',
+        '--extract',
+        '--no-same-owner',
+        '--no-same-permissions',
+        '--directory',
+        destination,
+        '--file',
+        tarFile,
+      ]);
+    }
+  });
+  if (processResult.exitCode != exit_codes.SUCCESS) {
+    throw FileSystemException(
+        'Could not un-tar (exit code ${processResult.exitCode}). Error:\n'
+        '${processResult.stdout.join("\n")}\n'
+        '${processResult.stderr.join("\n")}');
   }
-
-  var args = [
-    if (_noUnknownKeyword) '--warning=no-unknown-keyword',
-    '--extract',
-    '--gunzip',
-    '--no-same-owner',
-    '--no-same-permissions',
-    '--directory',
-    destination
-  ];
-
-  var process = await _startProcess(_tarPath, args);
-
-  // Ignore errors on process.std{out,err}. They'll be passed to
-  // process.exitCode, and we don't want them being top-levelled by
-  // std{out,err}Sink.
-  unawaited(
-      _store(process.stdout.handleError((_) {}), stdout, closeSink: false));
-  unawaited(
-      _store(process.stderr.handleError((_) {}), stderr, closeSink: false));
-  var results =
-      await Future.wait([_store(stream, process.stdin), process.exitCode]);
-
-  var exitCode = results[1];
-  if (exitCode != exit_codes.SUCCESS) {
-    throw Exception('Failed to extract .tar.gz stream to $destination '
-        '(exit code $exitCode).');
-  }
-  log.fine('Extracted .tar.gz stream to $destination. Exit code $exitCode.');
+  log.fine('Extracted .tar.gz to $destination. Exit code $exitCode.');
 }
 
 /// Whether to include "--warning=no-unknown-keyword" when invoking tar.
@@ -929,51 +902,6 @@ final String _pathTo7zip = (() {
   if (!runningFromDartRepo) return _sdkAssetPath(path.join('7zip', '7za.exe'));
   return path.join(dartRepoRoot, 'third_party', '7zip', '7za.exe');
 })();
-
-Future _extractTarGzWindows(Stream<List<int>> stream, String destination) {
-  // TODO(rnystrom): In the repo's history, there is an older implementation of
-  // this that does everything in memory by piping streams directly together
-  // instead of writing out temp files. The code is simpler, but unfortunately,
-  // 7zip seems to periodically fail when we invoke it from Dart and tell it to
-  // read from stdin instead of a file. Consider resurrecting that version if
-  // we can figure out why it fails.
-
-  return withTempDir((tempDir) async {
-    // Write the archive to a temp file.
-    var dataFile = path.join(tempDir, 'data.tar.gz');
-    await _createFileFromStream(stream, dataFile);
-
-    // 7zip can't unarchive from gzip -> tar -> destination all in one step
-    // first we un-gzip it to a tar file.
-    // Note: Setting the working directory instead of passing in a full file
-    // path because 7zip says "A full path is not allowed here."
-    var unzipResult = await runProcess(_pathTo7zip, ['e', 'data.tar.gz'],
-        workingDir: tempDir);
-
-    if (unzipResult.exitCode != exit_codes.SUCCESS) {
-      throw Exception(
-          'Could not un-gzip (exit code ${unzipResult.exitCode}). Error:\n'
-          '${unzipResult.stdout.join("\n")}\n'
-          '${unzipResult.stderr.join("\n")}');
-    }
-
-    // Find the tar file we just created since we don't know its name.
-    var tarFile = listDir(tempDir)
-        .firstWhere((file) => path.extension(file) == '.tar', orElse: () {
-      throw FormatException('The gzip file did not contain a tar file.');
-    });
-
-    // Untar the archive into the destination directory.
-    var untarResult =
-        await runProcess(_pathTo7zip, ['x', tarFile], workingDir: destination);
-    if (untarResult.exitCode != exit_codes.SUCCESS) {
-      throw Exception(
-          'Could not un-tar (exit code ${untarResult.exitCode}). Error:\n'
-          '${untarResult.stdout.join("\n")}\n'
-          '${untarResult.stderr.join("\n")}');
-    }
-  });
-}
 
 /// Create a .tar.gz archive from a list of entries.
 ///

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -847,7 +847,7 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
     final tarFile = path.join(tempDir, 'archive.tar');
     await _createFileFromStream(decompressed, tarFile);
     return (Platform.isWindows)
-        ? runProcess(_pathTo7zip, ['x', '"$tarFile"', '-o"$destination"'])
+        ? runProcess(_pathTo7zip, ['x', '$tarFile', '-o$destination'])
         : runProcess(_tarPath, [
             if (_noUnknownKeyword) '--warning=no-unknown-keyword',
             '--extract',

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -840,20 +840,18 @@ String _findTarPath() {
 /// Extracts a `.tar.gz` file from [stream] to [destination].
 Future extractTarGz(Stream<List<int>> stream, String destination) async {
   log.fine('Extracting .tar.gz stream to $destination.');
-  final gzipErrorCompleter = Completer();
-  final decompressed = stream.transform(GZipCodec().decoder).handleError((e) {
-    // We don't know the error type here: https://dartbug.com/41270
-    gzipErrorCompleter.completeError(
-        FileSystemException('Could not decompress gz stream $e'));
-  });
+  final decompressed = stream.transform(GZipCodec().decoder);
+
   // We used to stream directly to `tar`,  but that was fragile in certain
   // settings.
   final processResult = await withTempDir((tempDir) async {
     final tarFile = path.join(tempDir, 'archive.tar');
-    await Future.any([
-      _createFileFromStream(decompressed, tarFile),
-      gzipErrorCompleter.future
-    ]);
+    try {
+      await _createFileFromStream(decompressed, tarFile);
+    } catch (e) {
+      // We don't know the error type here: https://dartbug.com/41270
+      throw FileSystemException('Could not decompress gz stream $e');
+    }
     return (Platform.isWindows)
         ? runProcess(_pathTo7zip, ['x', tarFile], workingDir: destination)
         : runProcess(_tarPath, [

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -384,15 +384,13 @@ void testExistencePredicate(String name, bool Function(String path) predicate,
       });
     });
 
-    test('throws on tar error', () async {
+    test('throws on gzip error', () async {
       await withTempDir((tempDir) async {
         expect(
             () async => await extractTarGz(
                 Stream.fromIterable(
                   [
-                    base64Decode(
-                        // Empty is not a gzip encoded file
-                        '')
+                    [10, 20, 30] // Not a good gz stream.
                   ],
                 ),
                 tempDir),

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
-import 'package:pub/src/exceptions.dart';
 import 'package:pub/src/io.dart';
 import 'package:test/test.dart';
 

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -367,7 +367,7 @@ void testExistencePredicate(String name, bool Function(String path) predicate,
 
     test('throws on tar error', () async {
       await withTempDir((tempDir) async {
-        expect(
+        await expectLater(
             () async => await extractTarGz(
                 Stream.fromIterable(
                   [
@@ -386,7 +386,7 @@ void testExistencePredicate(String name, bool Function(String path) predicate,
 
     test('throws on gzip error', () async {
       await withTempDir((tempDir) async {
-        expect(
+        await expectLater(
             () async => await extractTarGz(
                 Stream.fromIterable(
                   [

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -7,8 +7,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
-import 'package:pool/pool.dart';
-import 'package:pub/src/http.dart';
 import 'package:pub/src/io.dart';
 import 'package:test/test.dart';
 
@@ -401,38 +399,6 @@ void testExistencePredicate(String name, bool Function(String path) predicate,
             throwsA(isA<FileSystemException>()));
       });
     });
-
-    test('can untar all of pub.dev', () async {
-      Stream<String> allPackageNames() async* {
-        var nextUrl = 'https://pub.dev/api/packages';
-        do {
-          final result = json.decode(await httpClient.read(nextUrl));
-          for (final package in result['packages']) {
-            yield package['name'];
-          }
-          nextUrl = result['next_url'];
-        } while (nextUrl != null);
-      }
-
-      Future<List<String>> versionArchiveUrls(String packageName) async {
-        final result = json.decode(
-            await httpClient.read('https://pub.dev/api/package/$packageName'));
-        return result['versions'].map((v) => v['archive_urls']);
-      }
-
-      final pool = Pool(30);
-      withTempDir(fn)
-       allPackageNames().expand((packageName) async {
-        final versions = await versionArchiveUrls(packageName);
-        return versions.map((archiveUrl) async {
-return pool.withResource(() {
-
-});
-        });
-      });
-    },
-        // This test is extremely expensive.
-        skip: false);
   });
 }
 

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -7,6 +7,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
+import 'package:pool/pool.dart';
+import 'package:pub/src/http.dart';
 import 'package:pub/src/io.dart';
 import 'package:test/test.dart';
 
@@ -399,6 +401,38 @@ void testExistencePredicate(String name, bool Function(String path) predicate,
             throwsA(isA<FileSystemException>()));
       });
     });
+
+    test('can untar all of pub.dev', () async {
+      Stream<String> allPackageNames() async* {
+        var nextUrl = 'https://pub.dev/api/packages';
+        do {
+          final result = json.decode(await httpClient.read(nextUrl));
+          for (final package in result['packages']) {
+            yield package['name'];
+          }
+          nextUrl = result['next_url'];
+        } while (nextUrl != null);
+      }
+
+      Future<List<String>> versionArchiveUrls(String packageName) async {
+        final result = json.decode(
+            await httpClient.read('https://pub.dev/api/package/$packageName'));
+        return result['versions'].map((v) => v['archive_urls']);
+      }
+
+      final pool = Pool(30);
+      withTempDir(fn)
+       allPackageNames().expand((packageName) async {
+        final versions = await versionArchiveUrls(packageName);
+        return versions.map((archiveUrl) async {
+return pool.withResource(() {
+
+});
+        });
+      });
+    },
+        // This test is extremely expensive.
+        skip: false);
   });
 }
 

--- a/tool/extract_all_pub_dev.dart
+++ b/tool/extract_all_pub_dev.dart
@@ -36,14 +36,14 @@ Future<List<String>> versionArchiveUrls(String packageName) async {
 
 Future<void> main() async {
   var alreadyDonePackages = <String>{};
-  var failures = <String>[];
+  var failures = <Map<String, dynamic>>[];
   if (fileExists(statusFilename)) {
     final json = jsonDecode(readTextFile(statusFilename));
     for (final packageName in json['packages'] ?? []) {
       alreadyDonePackages.add(packageName);
     }
-    for (final packageName in json['failures'] ?? []) {
-      failures.add(packageName);
+    for (final failure in json['failures'] ?? []) {
+      failures.add(failure);
     }
   }
   print('Already processed ${alreadyDonePackages.length} packages');
@@ -90,8 +90,8 @@ Future<void> main() async {
                 await extractTarGz(response.stream, tempDir);
                 print('Extracted $archiveUrl');
               } catch (e, _) {
-                print('Failed to get and extract $archiveUrl');
-                failures.add(archiveUrl);
+                print('Failed to get and extract $archiveUrl $e');
+                failures.add({'archive': archiveUrl, 'error': e.toString()});
                 allVersionsGood = false;
                 return;
               }

--- a/tool/extract_all_pub_dev.dart
+++ b/tool/extract_all_pub_dev.dart
@@ -1,0 +1,109 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// This is a manual test that can be run to test the .tar.gz decoding.
+/// It will save progress in [statusFileName] such that it doesn't have to be
+/// finished in a single run.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:http/http.dart' as http;
+import 'package:pool/pool.dart';
+import 'package:pub/src/http.dart';
+import 'package:pub/src/io.dart';
+
+const statusFilename = 'extract_all_pub_status.json';
+
+Stream<String> allPackageNames() async* {
+  var nextUrl = 'https://pub.dev/api/packages';
+  do {
+    final result = json.decode(await httpClient.read(nextUrl));
+    for (final package in result['packages']) {
+      yield package['name'];
+    }
+    nextUrl = result['next_url'];
+  } while (nextUrl != null);
+}
+
+Future<List<String>> versionArchiveUrls(String packageName) async {
+  final url = 'https://pub.dev/api/packages/$packageName';
+  final result = json.decode(await httpClient.read(url));
+  return List<String>.from(result['versions'].map((v) => v['archive_url']));
+}
+
+Future<void> main() async {
+  var alreadyDonePackages = <String>{};
+  var failures = <String>[];
+  if (fileExists(statusFilename)) {
+    final json = jsonDecode(readTextFile(statusFilename));
+    for (final packageName in json['packages'] ?? []) {
+      alreadyDonePackages.add(packageName);
+    }
+    for (final packageName in json['failures'] ?? []) {
+      failures.add(packageName);
+    }
+  }
+  print('Already processed ${alreadyDonePackages.length} packages');
+  print('Already found ${alreadyDonePackages.length}');
+
+  void writeStatus() {
+    writeTextFile(
+      statusFilename,
+      JsonEncoder.withIndent('  ').convert({
+        'packages': [...alreadyDonePackages],
+        'failures': [...failures],
+      }),
+    );
+  }
+
+  ProcessSignal.sigint.watch().listen((_) {
+    writeStatus();
+    exit(1);
+  });
+
+  final pool = Pool(10); // Process 10 packages at a time.
+
+  try {
+    await for (final packageName in allPackageNames()) {
+      if (alreadyDonePackages.contains(packageName)) {
+        print('Skipping $packageName - already done');
+        continue;
+      } else {
+        print('Processing all versions of $packageName '
+            '[+${alreadyDonePackages.length}, - ${failures.length}]');
+      }
+      final resource = await pool.request();
+      scheduleMicrotask(() async {
+        try {
+          final versions = await versionArchiveUrls(packageName);
+          var allVersionsGood = true;
+          await Future.wait(versions.map((archiveUrl) async {
+            await withTempDir((tempDir) async {
+              print('downloading $archiveUrl');
+              http.StreamedResponse response;
+              try {
+                response = await httpClient
+                    .send(http.Request('GET', Uri.parse(archiveUrl)));
+                await extractTarGz(response.stream, tempDir);
+                print('Extracted $archiveUrl');
+              } catch (e, _) {
+                print('Failed to get and extract $archiveUrl');
+                failures.add(archiveUrl);
+                allVersionsGood = false;
+                return;
+              }
+            });
+          }));
+          if (allVersionsGood) alreadyDonePackages.add(packageName);
+        } finally {
+          resource.release();
+        }
+      });
+    }
+  } finally {
+    writeStatus();
+  }
+}

--- a/tool/extract_all_pub_dev.dart
+++ b/tool/extract_all_pub_dev.dart
@@ -70,10 +70,9 @@ Future<void> main() async {
       }
       print('Processing all versions of $packageName '
           '[+${alreadyDonePackages.length}, - ${failures.length}]');
+      final resource = await pool.request();
       scheduleMicrotask(() async {
-        PoolResource resource;
         try {
-          resource = await pool.request();
           final versions = await versionArchiveUrls(packageName);
           var allVersionsGood = true;
           await Future.wait(versions.map((archiveUrl) async {


### PR DESCRIPTION
And stop using `tar` in streaming mode. It seems to give us problems.
Instead the decompressed tar file is stored to disk (that was always the
case on windows).

Also streamline the tar.gz extraction logic between
windows/non-windows a bit.

Has been tested with the tool/extract_all_pub_dev.dart tool on linux, and partial runs with windows and mac os.

Fixes: #2186 , https://github.com/dart-lang/pub/issues/2308