### PR TITLE
Fix NPE during language version analysis

### DIFF
--- a/lib/src/validator/language_version.dart
+++ b/lib/src/validator/language_version.dart
@@ -42,6 +42,7 @@ class LanguageVersionValidator extends Validator {
     for (final path in ['lib', 'bin']
         .map((path) => entrypoint.root.listFiles(beneath: path))
         .expand((files) => files)
+        .map(p.normalize)
         .map(p.absolute)
         .where((String file) => p.extension(file) == '.dart')) {
       CompilationUnit unit;


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/2397

During debugging, I noticed paths like this were flowing to getParsedUnit

```
/Users/kevmoo/github/json_serializable/json_serializable/./lib/builder.dart
/Users/kevmoo/github/json_serializable/json_serializable/./lib/type_helper.dart
/Users/kevmoo/github/json_serializable/json_serializable/./lib/json_serializable.dart
/Users/kevmoo/github/json_serializable/json_serializable/./lib/src/json_part_builder.dart
```

Adding `normalize` fixed this