### PR TITLE
Use different language version API.

### DIFF
--- a/lib/src/validator/language_version.dart
+++ b/lib/src/validator/language_version.dart
@@ -55,7 +55,7 @@ class LanguageVersionValidator extends Validator {
         continue;
       }
 
-      final unitLanguageVersion = unit.languageVersion;
+      final unitLanguageVersion = unit.languageVersionToken;
       if (unitLanguageVersion != null) {
         if (Version(unitLanguageVersion.major, unitLanguageVersion.minor, 0) >
             packageSdkMinVersion) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,10 +39,10 @@ dependency_overrides:
   analyzer:
     git:
       url: https://github.com/dart-lang/sdk.git
-      ref: bbb449dfa44ff40d3192959731b5893cbf66b205
+      ref: 3095a082cd1d747e090581e244d0a731544c3a0c
       path: pkg/analyzer
   _fe_analyzer_shared:
     git:
       url: https://github.com/dart-lang/sdk.git
-      ref: bbb449dfa44ff40d3192959731b5893cbf66b205
+      ref: 3095a082cd1d747e090581e244d0a731544c3a0c
       path: pkg/_fe_analyzer_shared


### PR DESCRIPTION
We want to change this API before we publish. The `languageVersion` API is deprecated in favor of this one as of https://dart-review.googlesource.com/c/sdk/+/140768