### PR TITLE
Small UI tweak

### DIFF
--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -243,13 +243,11 @@ Future<void> _outputHuman(List<_PackageDetails> rows,
       rows.where((row) => row.kind == _DependencyKind.transitive);
 
   final formattedRows = <List<_FormattedString>>[
-    ['Package', 'Current', 'Upgradable', 'Resolvable', 'Latest']
+    ['Dependencies', 'Current', 'Upgradable', 'Resolvable', 'Latest']
         .map((s) => _format(s, log.bold))
         .toList(),
     [
-      directRows.isEmpty
-          ? _raw('dependencies: all up-to-date')
-          : _format('dependencies', log.bold),
+      if (directRows.isEmpty) _raw('all up-to-date')
     ],
     ...await Future.wait(directRows.map(marker)),
     if (includeDevDependencies)

--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -246,9 +246,7 @@ Future<void> _outputHuman(List<_PackageDetails> rows,
     ['Dependencies', 'Current', 'Upgradable', 'Resolvable', 'Latest']
         .map((s) => _format(s, log.bold))
         .toList(),
-    [
-      if (directRows.isEmpty) _raw('all up-to-date')
-    ],
+    [if (directRows.isEmpty) _raw('all up-to-date')],
     ...await Future.wait(directRows.map(marker)),
     if (includeDevDependencies)
       [

--- a/test/outdated/goldens/circular_dependencies.txt
+++ b/test/outdated/goldens/circular_dependencies.txt
@@ -14,9 +14,8 @@ Resolving...
 
 $ pub outdated --no-color
 Resolving...
-Package  Current  Upgradable  Resolvable  Latest  
-dependencies
-foo      *1.2.3   1.3.0       1.3.0       1.3.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+foo           *1.2.3   1.3.0       1.3.0       1.3.0   
 
 dev_dependencies: all up-to-date
 
@@ -26,9 +25,8 @@ To update it, use `pub upgrade`.
 
 $ pub outdated --no-color --mark=none
 Resolving...
-Package  Current  Upgradable  Resolvable  Latest  
-dependencies
-foo      1.2.3    1.3.0       1.3.0       1.3.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+foo           1.2.3    1.3.0       1.3.0       1.3.0   
 
 dev_dependencies: all up-to-date
 
@@ -38,9 +36,8 @@ To update it, use `pub upgrade`.
 
 $ pub outdated --no-color --up-to-date
 Resolving...
-Package  Current  Upgradable  Resolvable  Latest  
-dependencies
-foo      *1.2.3   1.3.0       1.3.0       1.3.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+foo           *1.2.3   1.3.0       1.3.0       1.3.0   
 
 dev_dependencies: all up-to-date
 
@@ -50,9 +47,8 @@ To update it, use `pub upgrade`.
 
 $ pub outdated --no-color --pre-releases
 Resolving...
-Package  Current  Upgradable  Resolvable  Latest  
-dependencies
-foo      *1.2.3   1.3.0       1.3.0       1.3.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+foo           *1.2.3   1.3.0       1.3.0       1.3.0   
 
 dev_dependencies: all up-to-date
 
@@ -62,9 +58,8 @@ To update it, use `pub upgrade`.
 
 $ pub outdated --no-color --no-dev-dependencies
 Resolving...
-Package  Current  Upgradable  Resolvable  Latest  
-dependencies
-foo      *1.2.3   1.3.0       1.3.0       1.3.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+foo           *1.2.3   1.3.0       1.3.0       1.3.0   
 
 transitive dependencies: all up-to-date
 1 upgradable dependency is locked (in pubspec.lock) to an older version.

--- a/test/outdated/goldens/mutually_incompatible.txt
+++ b/test/outdated/goldens/mutually_incompatible.txt
@@ -21,10 +21,9 @@ Resolving...
 
 $ pub outdated --no-color
 Resolving...
-Package  Current  Upgradable  Resolvable  Latest  
-dependencies
-bar      *1.0.0   *1.0.0      *1.0.0      2.0.0   
-foo      *1.0.0   *1.0.0      *1.0.0      2.0.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+bar           *1.0.0   *1.0.0      *1.0.0      2.0.0   
+foo           *1.0.0   *1.0.0      *1.0.0      2.0.0   
 
 dev_dependencies: all up-to-date
 
@@ -35,10 +34,9 @@ Newer versions, while available, are not mutually compatible.
 
 $ pub outdated --no-color --mark=none
 Resolving...
-Package  Current  Upgradable  Resolvable  Latest  
-dependencies
-bar      1.0.0    1.0.0       1.0.0       2.0.0   
-foo      1.0.0    1.0.0       1.0.0       2.0.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+bar           1.0.0    1.0.0       1.0.0       2.0.0   
+foo           1.0.0    1.0.0       1.0.0       2.0.0   
 
 dev_dependencies: all up-to-date
 
@@ -49,10 +47,9 @@ Newer versions, while available, are not mutually compatible.
 
 $ pub outdated --no-color --up-to-date
 Resolving...
-Package  Current  Upgradable  Resolvable  Latest  
-dependencies
-bar      *1.0.0   *1.0.0      *1.0.0      2.0.0   
-foo      *1.0.0   *1.0.0      *1.0.0      2.0.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+bar           *1.0.0   *1.0.0      *1.0.0      2.0.0   
+foo           *1.0.0   *1.0.0      *1.0.0      2.0.0   
 
 dev_dependencies: all up-to-date
 
@@ -63,10 +60,9 @@ Newer versions, while available, are not mutually compatible.
 
 $ pub outdated --no-color --pre-releases
 Resolving...
-Package  Current  Upgradable  Resolvable  Latest  
-dependencies
-bar      *1.0.0   *1.0.0      *1.0.0      2.0.0   
-foo      *1.0.0   *1.0.0      *1.0.0      2.0.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+bar           *1.0.0   *1.0.0      *1.0.0      2.0.0   
+foo           *1.0.0   *1.0.0      *1.0.0      2.0.0   
 
 dev_dependencies: all up-to-date
 
@@ -77,10 +73,9 @@ Newer versions, while available, are not mutually compatible.
 
 $ pub outdated --no-color --no-dev-dependencies
 Resolving...
-Package  Current  Upgradable  Resolvable  Latest  
-dependencies
-bar      *1.0.0   *1.0.0      *1.0.0      2.0.0   
-foo      *1.0.0   *1.0.0      *1.0.0      2.0.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+bar           *1.0.0   *1.0.0      *1.0.0      2.0.0   
+foo           *1.0.0   *1.0.0      *1.0.0      2.0.0   
 
 transitive dependencies: all up-to-date
 

--- a/test/outdated/goldens/newer_versions.txt
+++ b/test/outdated/goldens/newer_versions.txt
@@ -42,17 +42,16 @@ Resolving...
 
 $ pub outdated --no-color
 Resolving...
-Package      Current  Upgradable  Resolvable  Latest  
-dependencies 
-foo          *1.2.3   *1.3.0      *2.0.0      3.0.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+foo           *1.2.3   *1.3.0      *2.0.0      3.0.0   
 
 dev_dependencies
-builder      *1.2.3   *1.3.0      2.0.0       2.0.0   
+builder       *1.2.3   *1.3.0      2.0.0       2.0.0   
 
 transitive dependencies
-transitive   *1.2.3   *1.3.0      *1.3.0      2.0.0   
-transitive2  -        -           1.0.0       1.0.0   
-transitive3  -        -           1.0.0       1.0.0   
+transitive    *1.2.3   *1.3.0      *1.3.0      2.0.0   
+transitive2   -        -           1.0.0       1.0.0   
+transitive3   -        -           1.0.0       1.0.0   
 
 3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `pub upgrade`.
@@ -62,17 +61,16 @@ To update these dependencies, edit pubspec.yaml.
 
 $ pub outdated --no-color --mark=none
 Resolving...
-Package      Current  Upgradable  Resolvable  Latest  
-dependencies 
-foo          1.2.3    1.3.0       2.0.0       3.0.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+foo           1.2.3    1.3.0       2.0.0       3.0.0   
 
 dev_dependencies
-builder      1.2.3    1.3.0       2.0.0       2.0.0   
+builder       1.2.3    1.3.0       2.0.0       2.0.0   
 
 transitive dependencies
-transitive   1.2.3    1.3.0       1.3.0       2.0.0   
-transitive2  -        -           1.0.0       1.0.0   
-transitive3  -        -           1.0.0       1.0.0   
+transitive    1.2.3    1.3.0       1.3.0       2.0.0   
+transitive2   -        -           1.0.0       1.0.0   
+transitive3   -        -           1.0.0       1.0.0   
 
 3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `pub upgrade`.
@@ -82,8 +80,7 @@ To update these dependencies, edit pubspec.yaml.
 
 $ pub outdated --no-color --up-to-date
 Resolving...
-Package        Current  Upgradable  Resolvable  Latest  
-dependencies   
+Dependencies   Current  Upgradable  Resolvable  Latest  
 bar            1.0.0    1.0.0       1.0.0       1.0.0   
 foo            *1.2.3   *1.3.0      *2.0.0      3.0.0   
 local_package  0.0.1    0.0.1       0.0.1       0.0.1   
@@ -104,17 +101,16 @@ To update these dependencies, edit pubspec.yaml.
 
 $ pub outdated --no-color --pre-releases
 Resolving...
-Package      Current  Upgradable  Resolvable  Latest       
-dependencies 
-foo          *1.2.3   *1.3.0      *2.0.0      3.0.0        
+Dependencies  Current  Upgradable  Resolvable  Latest       
+foo           *1.2.3   *1.3.0      *2.0.0      3.0.0        
 
 dev_dependencies
-builder      *1.2.3   *1.3.0      *2.0.0      3.0.0-alpha  
+builder       *1.2.3   *1.3.0      *2.0.0      3.0.0-alpha  
 
 transitive dependencies
-transitive   *1.2.3   *1.3.0      *1.3.0      2.0.0        
-transitive2  -        -           1.0.0       1.0.0        
-transitive3  -        -           1.0.0       1.0.0        
+transitive    *1.2.3   *1.3.0      *1.3.0      2.0.0        
+transitive2   -        -           1.0.0       1.0.0        
+transitive3   -        -           1.0.0       1.0.0        
 
 3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `pub upgrade`.
@@ -124,12 +120,11 @@ To update these dependencies, edit pubspec.yaml.
 
 $ pub outdated --no-color --no-dev-dependencies
 Resolving...
-Package     Current  Upgradable  Resolvable  Latest  
-dependencies
-foo         *1.2.3   *1.3.0      3.0.0       3.0.0   
+Dependencies  Current  Upgradable  Resolvable  Latest  
+foo           *1.2.3   *1.3.0      3.0.0       3.0.0   
 
 transitive dependencies
-transitive  *1.2.3   2.0.0       2.0.0       2.0.0   
+transitive    *1.2.3   2.0.0       2.0.0       2.0.0   
 
 2 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `pub upgrade`.


### PR DESCRIPTION
Small tweak to the heading/status for direct dependencies. WDYT @sigurdm ?

## Before this change:

<img width="479" alt="Screenshot 2020-03-27 at 17 28 20" src="https://user-images.githubusercontent.com/13644170/77777877-77556080-7050-11ea-929a-34f6dbf19de5.png">
<img width="473" alt="Screenshot 2020-03-27 at 17 28 25" src="https://user-images.githubusercontent.com/13644170/77777861-73c1d980-7050-11ea-95b3-c6c5bb7a7853.png">

## After this change:

<img width="477" alt="Screenshot 2020-03-27 at 17 28 32" src="https://user-images.githubusercontent.com/13644170/77777856-71f81600-7050-11ea-9ed3-4589fcd6a734.png">
<img width="480" alt="Screenshot 2020-03-27 at 17 28 36" src="https://user-images.githubusercontent.com/13644170/77777848-6efd2580-7050-11ea-9a9d-51b66b8f6682.png">
