### PR TITLE
Normalize command names when invoked via alias

### DIFF
--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -10,6 +10,17 @@ import 'global_packages.dart';
 import 'log.dart' as log;
 import 'system_cache.dart';
 
+/// All of the aliases used for [PubCommand] subclasses.
+///
+/// Centralized so invocations with aliases can be normalized to the primary
+/// command name when sending telemetry.
+const pubCommandAliases = {
+  'deps': ['dependencies', 'tab'],
+  'get': ['install'],
+  'publish': ['lish', 'lush'],
+  'upgrade': ['update'],
+};
+
 /// The base class for commands for the pub executable.
 ///
 /// A command may either be a "leaf" command or it may be a parent for a set
@@ -58,6 +69,9 @@ abstract class PubCommand extends Command {
     if (docUrl == null) return null;
     return 'See $docUrl for detailed documentation.';
   }
+
+  @override
+  List<String> get aliases => pubCommandAliases[name] ?? const [];
 
   @override
   void printUsage() {

--- a/lib/src/command/deps.dart
+++ b/lib/src/command/deps.dart
@@ -23,9 +23,6 @@ class DepsCommand extends PubCommand {
   String get description => 'Print package dependencies.';
 
   @override
-  List<String> get aliases => const ['dependencies', 'tab'];
-
-  @override
   String get invocation => 'pub deps';
 
   @override

--- a/lib/src/command/get.dart
+++ b/lib/src/command/get.dart
@@ -19,8 +19,6 @@ class GetCommand extends PubCommand {
   @override
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-get';
   @override
-  List<String> get aliases => const ['install'];
-  @override
   bool get isOffline => argResults['offline'];
 
   GetCommand() {

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -27,8 +27,6 @@ class LishCommand extends PubCommand {
   @override
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-lish';
   @override
-  List<String> get aliases => const ['lish', 'lush'];
-  @override
   bool get takesArguments => false;
 
   /// The URL of the server to which to upload the package.

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -19,8 +19,6 @@ class UpgradeCommand extends PubCommand {
   String get invocation => 'pub upgrade [dependencies...]';
   @override
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-upgrade';
-  @override
-  List<String> get aliases => const ['update'];
 
   @override
   bool get isOffline => argResults['offline'];

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -10,6 +10,7 @@ import 'package:args/command_runner.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
+import 'command.dart' show pubCommandAliases;
 import 'command/build.dart';
 import 'command/cache.dart';
 import 'command/deps.dart';
@@ -45,6 +46,9 @@ class PubCommandRunner extends CommandRunner {
   /// Returns an empty string if no command is being run. (This is only
   /// expected to happen when unit tests invoke code inside pub without going
   /// through a command.)
+  ///
+  /// For top-level commands, if an alias is used, the primary command name is
+  /// returned. For instance `install` becomes `get`.
   static String get command {
     if (_options == null) return '';
 
@@ -52,7 +56,18 @@ class PubCommandRunner extends CommandRunner {
     for (var command = _options.command;
         command != null;
         command = command.command) {
-      list.add(command.name);
+      var commandName = command.name;
+
+      if (list.isEmpty) {
+        // this is a top-level command
+        final rootCommand = pubCommandAliases.entries.singleWhere(
+            (element) => element.value.contains(command.name),
+            orElse: () => null);
+        if (rootCommand != null) {
+          commandName = rootCommand.key;
+        }
+      }
+      list.add(commandName);
     }
     return list.join(' ');
   }


### PR DESCRIPTION
Since https://github.com/dart-lang/pub/commit/ab109723d9eb782c2ea4cce68c044da40403a652
we are seeing `install` and `update` in telemetry, which is weird. (These map to `get` and `upgrade` respectively.)

This commit ensures telemetry headers only see each command with its canonical name.