### PR TITLE
Fix output of transitive dev_dependencies

### DIFF
--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -376,26 +376,28 @@ Future<void> _outputHuman(
         .toList(),
     [if (directRows.isEmpty) _raw('all up-to-date')],
     ...await Future.wait(directRows.map(marker)),
-    if (includeDevDependencies)
+    if (includeDevDependencies) ...[
       [
         devRows.isEmpty
             ? _raw('\ndev_dependencies: all up-to-date')
             : _format('\ndev_dependencies', log.bold),
       ],
-    ...await Future.wait(devRows.map(marker)),
+      ...await Future.wait(devRows.map(marker)),
+    ],
     [
       transitiveRows.isEmpty
           ? _raw('\ntransitive dependencies: all up-to-date')
           : _format('\ntransitive dependencies', log.bold)
     ],
     ...await Future.wait(transitiveRows.map(marker)),
-    if (includeDevDependencies)
+    if (includeDevDependencies) ...[
       [
         devTransitiveRows.isEmpty
             ? _raw('\ntransitive dev_dependencies: all up-to-date')
             : _format('\ntransitive dev_dependencies', log.bold)
       ],
-    ...await Future.wait(devTransitiveRows.map(marker)),
+      ...await Future.wait(devTransitiveRows.map(marker)),
+    ],
   ];
 
   final columnWidths = <int, int>{};

--- a/test/outdated/goldens/newer_versions.txt
+++ b/test/outdated/goldens/newer_versions.txt
@@ -58,6 +58,19 @@ $ pub outdated --json
       }
     },
     {
+      "package": "dev_trans",
+      "current": {
+        "version": "1.0.0"
+      },
+      "upgradable": null,
+      "resolvable": {
+        "version": "1.0.0"
+      },
+      "latest": {
+        "version": "2.0.0"
+      }
+    },
+    {
       "package": "transitive3",
       "current": null,
       "upgradable": null,
@@ -83,12 +96,13 @@ transitive    *1.2.3   *1.3.0      *1.3.0      2.0.0
 transitive2   -        -           1.0.0       1.0.0   
 
 transitive dev_dependencies
+dev_trans     *1.0.0   -           *1.0.0      2.0.0   
 transitive3   -        -           1.0.0       1.0.0   
 
 3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `pub upgrade`.
 
-2  dependencies are constrained to versions that are older than a resolvable version.
+3  dependencies are constrained to versions that are older than a resolvable version.
 To update these dependencies, edit pubspec.yaml.
 
 $ pub outdated --no-color --mark=none
@@ -103,12 +117,13 @@ transitive    1.2.3    1.3.0       1.3.0       2.0.0
 transitive2   -        -           1.0.0       1.0.0   
 
 transitive dev_dependencies
+dev_trans     1.0.0    -           1.0.0       2.0.0   
 transitive3   -        -           1.0.0       1.0.0   
 
 3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `pub upgrade`.
 
-2  dependencies are constrained to versions that are older than a resolvable version.
+3  dependencies are constrained to versions that are older than a resolvable version.
 To update these dependencies, edit pubspec.yaml.
 
 $ pub outdated --no-color --up-to-date
@@ -125,12 +140,13 @@ transitive     *1.2.3   *1.3.0      *1.3.0      2.0.0
 transitive2    -        -           1.0.0       1.0.0   
 
 transitive dev_dependencies
+dev_trans      *1.0.0   -           *1.0.0      2.0.0   
 transitive3    -        -           1.0.0       1.0.0   
 
 3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `pub upgrade`.
 
-2  dependencies are constrained to versions that are older than a resolvable version.
+3  dependencies are constrained to versions that are older than a resolvable version.
 To update these dependencies, edit pubspec.yaml.
 
 $ pub outdated --no-color --pre-releases
@@ -145,12 +161,13 @@ transitive    *1.2.3   *1.3.0      *1.3.0      2.0.0
 transitive2   -        -           1.0.0       1.0.0        
 
 transitive dev_dependencies
+dev_trans     *1.0.0   -           *1.0.0      2.0.0        
 transitive3   -        -           1.0.0       1.0.0        
 
 3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `pub upgrade`.
 
-2  dependencies are constrained to versions that are older than a resolvable version.
+3  dependencies are constrained to versions that are older than a resolvable version.
 To update these dependencies, edit pubspec.yaml.
 
 $ pub outdated --no-color --no-dev-dependencies
@@ -178,11 +195,12 @@ transitive    *1.2.3   *1.3.0      *1.3.0      2.0.0
 transitive2   -        -           1.0.0       1.0.0   
 
 transitive dev_dependencies
+dev_trans     *1.0.0   -           *1.0.0      2.0.0   
 transitive3   -        -           1.0.0       1.0.0   
 
 3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `pub upgrade`.
 
-2  dependencies are constrained to versions that are older than a resolvable version.
+3  dependencies are constrained to versions that are older than a resolvable version.
 To update these dependencies, edit pubspec.yaml.
 

--- a/test/outdated/outdated_test.dart
+++ b/test/outdated/outdated_test.dart
@@ -46,8 +46,12 @@ Future<void> main() async {
     await servePackages((builder) => builder
       ..serve('foo', '1.2.3', deps: {'transitive': '^1.0.0'})
       ..serve('bar', '1.0.0')
-      ..serve('builder', '1.2.3', deps: {'transitive': '^1.0.0'})
-      ..serve('transitive', '1.2.3'));
+      ..serve('builder', '1.2.3', deps: {
+        'transitive': '^1.0.0',
+        'dev_trans': '^1.0.0',
+      })
+      ..serve('transitive', '1.2.3')
+      ..serve('dev_trans', '1.0.0'));
 
     await d.dir('local_package', [
       d.libDir('local_package'),
@@ -72,13 +76,17 @@ Future<void> main() async {
           deps: {'transitive': '>=1.0.0<3.0.0', 'transitive2': '^1.0.0'})
       ..serve('foo', '3.0.0', deps: {'transitive': '^2.0.0'})
       ..serve('builder', '1.3.0', deps: {'transitive': '^1.0.0'})
-      ..serve('builder', '2.0.0',
-          deps: {'transitive': '^1.0.0', 'transitive3': '^1.0.0'})
+      ..serve('builder', '2.0.0', deps: {
+        'transitive': '^1.0.0',
+        'transitive3': '^1.0.0',
+        'dev_trans': '^1.0.0'
+      })
       ..serve('builder', '3.0.0-alpha', deps: {'transitive': '^1.0.0'})
       ..serve('transitive', '1.3.0')
       ..serve('transitive', '2.0.0')
       ..serve('transitive2', '1.0.0')
-      ..serve('transitive3', '1.0.0'));
+      ..serve('transitive3', '1.0.0')
+      ..serve('dev_trans', '2.0.0'));
     await variations('newer_versions');
   });
 


### PR DESCRIPTION
In the case we have a transitive dev_dependency in current, and a newer
exists it will have a 'latest' entry.

Fixes: https://github.com/dart-lang/pub/issues/2426