### PR TITLE
Improve the `pub outdated --help` text

### DIFF
--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -32,9 +32,7 @@ class OutdatedCommand extends PubCommand {
 
   OutdatedCommand() {
     argParser.addFlag('json',
-        help: 'Outputs the results in a json formatted\n'
-            'report.',
-        negatable: false);
+        help: 'Outputs the results using a json format.', negatable: false);
 
     argParser.addFlag('color',
         help: 'Whether to color the output.\n'
@@ -47,9 +45,7 @@ class OutdatedCommand extends PubCommand {
             'latest version.');
 
     argParser.addFlag('prereleases',
-        defaultsTo: false,
-        help: 'Include prereleases when reporting latest\n'
-            'version.');
+        defaultsTo: false, help: 'Include prereleases in latest version.');
 
     // Preserve for backwards compatibility.
     argParser.addFlag('pre-releases',

--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -31,32 +31,40 @@ class OutdatedCommand extends PubCommand {
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-outdated';
 
   OutdatedCommand() {
-    argParser.addFlag('color',
-        help: 'Whether to color the output. Defaults to color '
-            'when connected to a terminal, and no-color otherwise.');
-
     argParser.addFlag('json',
-        help: 'Outputs the results in a json formatted report',
+        help: 'Outputs the results in a json formatted\n'
+            'report.',
         negatable: false);
+
+    argParser.addFlag('color',
+        help: 'Whether to color the output.\n'
+            'Defaults to color when connected to a\n'
+            'terminal, and no-color otherwise.');
 
     argParser.addFlag('up-to-date',
         defaultsTo: false,
-        help: 'Include dependencies that are already at the latest version.');
+        help: 'Include dependencies that are already at the\n'
+            'latest version.');
 
-    argParser.addFlag('pre-releases',
+    argParser.addFlag('prereleases',
         defaultsTo: false,
-        help: 'Include pre-releases when reporting latest version.');
+        help: 'Include prereleases when reporting latest\n'
+            'version.');
+
+    // Preserve for backwards compatibility.
+    argParser.addFlag('pre-releases',
+        defaultsTo: false, help: 'Alias of prereleases.', hide: true);
 
     argParser.addFlag(
       'dev-dependencies',
       defaultsTo: true,
-      help: 'When true take dev-dependencies into account when resolving.',
+      help: 'Take dev dependencies into account.',
     );
 
     argParser.addFlag(
       'dependency-overrides',
       defaultsTo: true,
-      help: 'Show resolutions with `dependency_override`',
+      help: 'Show resolutions with `dependency_overrides`.',
     );
 
     argParser.addOption('mark',
@@ -222,7 +230,10 @@ class OutdatedCommand extends PubCommand {
     if (available.isEmpty) {
       return null;
     }
-    available.sort(argResults['pre-releases']
+    final prereleases = argResults.wasParsed('prereleases')
+        ? argResults['prereleases']
+        : argResults['pre-releases'];
+    available.sort(prereleases
         ? (x, y) => x.version.compareTo(y.version)
         : (x, y) => Version.prioritize(x.version, y.version));
     return available.last;

--- a/test/outdated/goldens/circular_dependencies.txt
+++ b/test/outdated/goldens/circular_dependencies.txt
@@ -58,7 +58,7 @@ transitive dev_dependencies: all up-to-date
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `pub upgrade`.
 
-$ pub outdated --no-color --pre-releases
+$ pub outdated --no-color --prereleases
 Dependencies  Current  Upgradable  Resolvable  Latest  
 foo           *1.2.3   1.3.0       1.3.0       1.3.0   
 

--- a/test/outdated/goldens/dependency_overrides.txt
+++ b/test/outdated/goldens/dependency_overrides.txt
@@ -103,7 +103,7 @@ transitive dev_dependencies: all up-to-date
 Dependencies are all on the latest resolvable versions.
 Newer versions, while available, are not mutually compatible.
 
-$ pub outdated --no-color --pre-releases
+$ pub outdated --no-color --prereleases
 Dependencies  Current              Upgradable           Resolvable           Latest  
 bar           *1.0.1 (overridden)  *1.0.1 (overridden)  *1.0.1 (overridden)  2.0.0   
 baz           *2.0.0 (overridden)  *2.0.0 (overridden)  *2.0.0 (overridden)  2.0.0   

--- a/test/outdated/goldens/dependency_overrides_no_solution.txt
+++ b/test/outdated/goldens/dependency_overrides_no_solution.txt
@@ -82,7 +82,7 @@ transitive dev_dependencies: all up-to-date
 Dependencies are all on the latest resolvable versions.
 Newer versions, while available, are not mutually compatible.
 
-$ pub outdated --no-color --pre-releases
+$ pub outdated --no-color --prereleases
 Dependencies  Current              Upgradable           Resolvable           Latest  
 bar           *1.0.0 (overridden)  *1.0.0 (overridden)  *1.0.0 (overridden)  2.0.0   
 foo           *1.0.0 (overridden)  *1.0.0 (overridden)  *1.0.0 (overridden)  2.0.0   

--- a/test/outdated/goldens/helptext.txt
+++ b/test/outdated/goldens/helptext.txt
@@ -1,0 +1,22 @@
+$ pub outdated --help
+Analyze your dependencies to find which ones can be upgraded.
+
+Usage: pub outdated [options]
+-h, --help                         Print this usage information.
+    --json                         Outputs the results in a json formatted
+                                   report.
+    --[no-]color                   Whether to color the output.
+                                   Defaults to color when connected to a
+                                   terminal, and no-color otherwise.
+    --[no-]up-to-date              Include dependencies that are already at the
+                                   latest version.
+    --[no-]prereleases             Include prereleases when reporting latest
+                                   version.
+    --[no-]dev-dependencies        Take dev dependencies into account.
+                                   (defaults to on)
+    --[no-]dependency-overrides    Show resolutions with `dependency_overrides`.
+                                   (defaults to on)
+
+Run "pub help" to see global options.
+See https://dart.dev/tools/pub/cmd/pub-outdated for detailed documentation.
+

--- a/test/outdated/goldens/helptext.txt
+++ b/test/outdated/goldens/helptext.txt
@@ -3,15 +3,13 @@ Analyze your dependencies to find which ones can be upgraded.
 
 Usage: pub outdated [options]
 -h, --help                         Print this usage information.
-    --json                         Outputs the results in a json formatted
-                                   report.
+    --json                         Outputs the results using a json format.
     --[no-]color                   Whether to color the output.
                                    Defaults to color when connected to a
                                    terminal, and no-color otherwise.
     --[no-]up-to-date              Include dependencies that are already at the
                                    latest version.
-    --[no-]prereleases             Include prereleases when reporting latest
-                                   version.
+    --[no-]prereleases             Include prereleases in latest version.
     --[no-]dev-dependencies        Take dev dependencies into account.
                                    (defaults to on)
     --[no-]dependency-overrides    Show resolutions with `dependency_overrides`.

--- a/test/outdated/goldens/mutually_incompatible.txt
+++ b/test/outdated/goldens/mutually_incompatible.txt
@@ -76,7 +76,7 @@ transitive dev_dependencies: all up-to-date
 Dependencies are all on the latest resolvable versions.
 Newer versions, while available, are not mutually compatible.
 
-$ pub outdated --no-color --pre-releases
+$ pub outdated --no-color --prereleases
 Dependencies  Current  Upgradable  Resolvable  Latest  
 bar           *1.0.0   *1.0.0      *1.0.0      2.0.0   
 foo           *1.0.0   *1.0.0      *1.0.0      2.0.0   

--- a/test/outdated/goldens/newer_versions.txt
+++ b/test/outdated/goldens/newer_versions.txt
@@ -149,7 +149,7 @@ To update these dependencies, use `pub upgrade`.
 3  dependencies are constrained to versions that are older than a resolvable version.
 To update these dependencies, edit pubspec.yaml.
 
-$ pub outdated --no-color --pre-releases
+$ pub outdated --no-color --prereleases
 Dependencies  Current  Upgradable  Resolvable  Latest       
 foo           *1.2.3   *1.3.0      *2.0.0      3.0.0        
 

--- a/test/outdated/goldens/no_dependencies.txt
+++ b/test/outdated/goldens/no_dependencies.txt
@@ -12,7 +12,7 @@ Found no outdated packages.
 $ pub outdated --no-color --up-to-date
 Found no outdated packages.
 
-$ pub outdated --no-color --pre-releases
+$ pub outdated --no-color --prereleases
 Found no outdated packages.
 
 $ pub outdated --no-color --no-dev-dependencies


### PR DESCRIPTION
Fix of https://github.com/dart-lang/pub/issues/2428

I have made the --help text be 80 columns.

@kwalrath The text and arguments has already changed quite a bit since the version you reviewed.
Could you look it through again?

I made a golden-file test of the help text, so we will notice changes.

The golden file (test/outdated/golden/helptext.txt) in this pr can be used for reviewing this.,

I have not changed how the defaults are printed as suggested in the issue.

The (default is on) comes from package:args. And if we want to change them, we should probably change them there. The 'default default' is off, so I guess that is why package:args doesn't print anything in that case.
