### PR TITLE
pub run --v2 for use in dartdev

### DIFF
--- a/lib/src/command/run.dart
+++ b/lib/src/command/run.dart
@@ -101,16 +101,17 @@ class RunCommand extends PubCommand {
   /// If neither `package` or `command` is given and `command` with name of
   /// the current package doesn't exist we fallback to `'main'`.
   ///
-  /// Runs `bin/<command>.dart` from package `<package>`, with snapshot stored
-  /// in `.dart_tool/pub/bin/<package>/<command>.dart.snapshot.dart2`.
+  /// Runs `bin/<command>.dart` from package `<package>`. If `<package>` is not
+  /// mutable (local root package or path-dependency) a source snapshot will be
+  /// cached in `.dart_tool/pub/bin/<package>/<command>.dart.snapshot.dart2`.
   Future _runV2() async {
     var package = entrypoint.root.name;
     var command = package;
     var args = <String>[];
 
     if (argResults.rest.isNotEmpty) {
-      if (argResults.rest[0].contains('/')) {
-        usageException('[<package>[:command]] cannot contain "/"');
+      if (argResults.rest[0].contains(RegExp(r'[/\\]'))) {
+        usageException('[<package>[:command]] cannot contain "/" or "\\"');
       }
 
       package = argResults.rest[0];

--- a/lib/src/command/run.dart
+++ b/lib/src/command/run.dart
@@ -29,10 +29,15 @@ class RunCommand extends PubCommand {
     argParser.addFlag('enable-asserts', help: 'Enable assert statements.');
     argParser.addFlag('checked', abbr: 'c', hide: true);
     argParser.addOption('mode', help: 'Deprecated option', hide: true);
+    // mode exposed for `dartdev run` to use as subprocess.
+    argParser.addFlag('v2', hide: true);
   }
 
   @override
   Future run() async {
+    if (argResults['v2']) {
+      return await _runV2();
+    }
     if (argResults.rest.isEmpty) {
       usageException('Must specify an executable to run.');
     }
@@ -85,5 +90,99 @@ class RunCommand extends PubCommand {
       return entrypoint.precompileExecutable(package, executablePath);
     });
     await flushThenExit(exitCode);
+  }
+
+  /// Implement a v2 mode for use in `dartdev run`.
+  ///
+  /// Usage: `dartdev run [package[:command]]`
+  ///
+  /// If `package` is not given, defaults to current root package.
+  /// If `command` is not given, defaults to name of `package`.
+  /// If neither `package` or `command` is given and `command` with name of
+  /// the current package doesn't exist we fallback to `'main'`.
+  ///
+  /// Runs `bin/<command>.dart` from package `<package>`, with snapshot stored
+  /// in `.dart_tool/pub/bin/<package>/<command>.dart.snapshot.dart2`.
+  Future _runV2() async {
+    var package = entrypoint.root.name;
+    var command = package;
+    var args = <String>[];
+
+    if (argResults.rest.isNotEmpty) {
+      if (argResults.rest[0].contains('/')) {
+        usageException('[<package>[:command]] cannot contain "/"');
+      }
+
+      package = argResults.rest[0];
+      if (package.contains(':')) {
+        final parts = package.split(':');
+        if (parts.length > 2) {
+          usageException('[<package>[:command]] cannot contain multiple ":"');
+        }
+        package = parts[0];
+        command = parts[1];
+      } else {
+        command = package;
+      }
+      args = argResults.rest.skip(1).toList();
+    }
+
+    String snapshotPath(String command) => p.join(
+          entrypoint.cachePath,
+          'bin',
+          package,
+          '$command.dart.snapshot.dart2',
+        );
+
+    // If snapshot exists, we strive to avoid using [entrypoint.packageGraph]
+    // because this will load additional files. Instead we just run with the
+    // snapshot. Note. that `pub get|upgrade` will purge snapshots.
+    var snapshotExists = fileExists(snapshotPath(command));
+
+    // Don't ever compile snapshots for mutable packages, since their code may
+    // change later on. Don't check if this the case if a snapshot already
+    // exists.
+    var useSnapshot = snapshotExists ||
+        (package != entrypoint.root.name &&
+            !entrypoint.packageGraph.isPackageMutable(package));
+
+    // If argResults.rest.isEmpty, package == command, and 'bin/$command.dart'
+    // doesn't exist we use command = 'main' (if it exists).
+    // We don't need to check this if a snapshot already exists.
+    // This is a hack around the fact that we want 'dartdev run' to run either
+    // `bin/<packageName>.dart` or `bin/main.dart`, because `bin/main.dart` is
+    // a historical convention we've done in templates for a long time.
+    if (!snapshotExists && argResults.rest.isEmpty && package == command) {
+      final pkg = entrypoint.packageGraph.packages[package];
+      if (pkg == null) {
+        usageException('No such package "$package"');
+      }
+      if (!fileExists(pkg.path('bin', '$command.dart')) &&
+          fileExists(pkg.path('bin', 'main.dart'))) {
+        command = 'main';
+        snapshotExists = fileExists(snapshotPath(command));
+        useSnapshot = snapshotExists ||
+            (package != entrypoint.root.name &&
+                !entrypoint.packageGraph.isPackageMutable(package));
+      }
+    }
+
+    return await flushThenExit(await runExecutable(
+      entrypoint,
+      package,
+      '$command.dart',
+      args,
+      enableAsserts: argResults['enable-asserts'] || argResults['checked'],
+      snapshotPath: useSnapshot ? snapshotPath(command) : null,
+      recompile: () {
+        final pkg = entrypoint.packageGraph.packages[package];
+        // The recompile function will only be called when [package] exists.
+        assert(pkg != null);
+        return entrypoint.precompileExecutable(
+          package,
+          pkg.path('bin', '$command.dart'),
+        );
+      },
+    ));
   }
 }

--- a/test/run/v2/app_can_read_from_stdin_test.dart
+++ b/test/run/v2/app_can_read_from_stdin_test.dart
@@ -1,0 +1,70 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('the spawned application can read line-by-line from stdin', () async {
+    await d.dir(appPath, [
+      d.appPubspec(),
+      d.dir('bin', [
+        d.file('script.dart', """
+          import 'dart:io';
+
+          main() {
+            print("started");
+            var line1 = stdin.readLineSync();
+            print("between");
+            var line2 = stdin.readLineSync();
+            print(line1);
+            print(line2);
+          }
+        """)
+      ])
+    ]).create();
+
+    await pubGet();
+    var pub = await pubRunV2(args: ['myapp:script']);
+
+    await expectLater(pub.stdout, emits('started'));
+    pub.stdin.writeln('first');
+    await expectLater(pub.stdout, emits('between'));
+    pub.stdin.writeln('second');
+    expect(pub.stdout, emits('first'));
+    expect(pub.stdout, emits('second'));
+    await pub.shouldExit(0);
+  });
+
+  test('the spawned application can read streamed from stdin', () async {
+    await d.dir(appPath, [
+      d.appPubspec(),
+      d.dir('bin', [
+        d.file('script.dart', """
+          import 'dart:io';
+
+          main() {
+            print("started");
+            stdin.listen(stdout.add);
+          }
+        """)
+      ])
+    ]).create();
+
+    await pubGet();
+    var pub = await pubRunV2(args: ['myapp:script']);
+
+    await expectLater(pub.stdout, emits('started'));
+    pub.stdin.writeln('first');
+    await expectLater(pub.stdout, emits('first'));
+    pub.stdin.writeln('second');
+    await expectLater(pub.stdout, emits('second'));
+    pub.stdin.writeln('third');
+    await expectLater(pub.stdout, emits('third'));
+    await pub.stdin.close();
+    await pub.shouldExit(0);
+  });
+}

--- a/test/run/v2/app_can_read_from_stdin_test.dart
+++ b/test/run/v2/app_can_read_from_stdin_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/errors_if_only_transitive_dependency_test.dart
+++ b/test/run/v2/errors_if_only_transitive_dependency_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/errors_if_only_transitive_dependency_test.dart
+++ b/test/run/v2/errors_if_only_transitive_dependency_test.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('Errors if the script is in a non-immediate dependency.', () async {
+    await d.dir('foo', [
+      d.libPubspec('foo', '1.0.0'),
+      d.dir('bin', [d.file('bar.dart', "main() => print('foobar');")])
+    ]).create();
+
+    await d.dir('bar', [
+      d.libPubspec('bar', '1.0.0', deps: {
+        'foo': {'path': '../foo'}
+      })
+    ]).create();
+
+    await d.dir(appPath, [
+      d.appPubspec({
+        'bar': {'path': '../bar'}
+      })
+    ]).create();
+
+    await pubGet();
+
+    var pub = await pubRunV2(args: ['foo:script']);
+    expect(pub.stderr, emits('Package "foo" is not an immediate dependency.'));
+    expect(pub.stderr,
+        emits('Cannot run executables in transitive dependencies.'));
+    await pub.shouldExit(exit_codes.DATA);
+  });
+}

--- a/test/run/v2/errors_if_path_in_dependency_test.dart
+++ b/test/run/v2/errors_if_path_in_dependency_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/errors_if_path_in_dependency_test.dart
+++ b/test/run/v2/errors_if_path_in_dependency_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test(
+      'Errors if the executable is in a subdirectory in a '
+      'dependency.', () async {
+    await d.dir('foo', [d.libPubspec('foo', '1.0.0')]).create();
+
+    await d.dir(appPath, [
+      d.appPubspec({
+        'foo': {'path': '../foo'}
+      })
+    ]).create();
+
+    await runPub(args: ['run', 'foo:sub/dir'], error: '''
+Cannot run an executable in a subdirectory of a dependency.
+
+Usage: pub run <executable> [args...]
+-h, --help                   Print this usage information.
+    --[no-]enable-asserts    Enable assert statements.
+
+Run "pub help" to see global options.
+See https://dart.dev/tools/pub/cmd/pub-run for detailed documentation.
+''', exitCode: exit_codes.USAGE);
+  });
+}

--- a/test/run/v2/forwards_signal_posix_test.dart
+++ b/test/run/v2/forwards_signal_posix_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/forwards_signal_posix_test.dart
+++ b/test/run/v2/forwards_signal_posix_test.dart
@@ -1,0 +1,54 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Windows doesn't support sending signals.
+@TestOn('!windows')
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+const _catchableSignals = [
+  ProcessSignal.sighup,
+  ProcessSignal.sigterm,
+  ProcessSignal.sigusr1,
+  ProcessSignal.sigusr2,
+  ProcessSignal.sigwinch,
+];
+
+const SCRIPT = """
+import 'dart:io';
+
+main() {
+  ProcessSignal.SIGHUP.watch().first.then(print);
+  ProcessSignal.SIGTERM.watch().first.then(print);
+  ProcessSignal.SIGUSR1.watch().first.then(print);
+  ProcessSignal.SIGUSR2.watch().first.then(print);
+  ProcessSignal.SIGWINCH.watch().first.then(print);
+
+  print("ready");
+}
+""";
+
+void main() {
+  test('forwards signals to the inner script', () async {
+    await d.dir(appPath, [
+      d.appPubspec(),
+      d.dir('bin', [d.file('script.dart', SCRIPT)])
+    ]).create();
+
+    await pubGet();
+    var pub = await pubRunV2(args: ['myapp:script']);
+
+    await expectLater(pub.stdout, emits('ready'));
+    for (var signal in _catchableSignals) {
+      pub.signal(signal);
+      await expectLater(pub.stdout, emits(signal.toString()));
+    }
+
+    await pub.kill();
+  });
+}

--- a/test/run/v2/loads_package_imports_in_a_dependency_test.dart
+++ b/test/run/v2/loads_package_imports_in_a_dependency_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/loads_package_imports_in_a_dependency_test.dart
+++ b/test/run/v2/loads_package_imports_in_a_dependency_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('loads package imports in a dependency', () async {
+    await d.dir('foo', [
+      d.libPubspec('foo', '1.0.0'),
+      d.dir('lib', [d.file('foo.dart', "final value = 'foobar';")]),
+      d.dir('bin', [
+        d.file('bar.dart', '''
+import "package:foo/foo.dart";
+
+main() => print(value);
+''')
+      ])
+    ]).create();
+
+    await d.dir(appPath, [
+      d.appPubspec({
+        'foo': {'path': '../foo'}
+      })
+    ]).create();
+
+    await pubGet();
+    var pub = await pubRunV2(args: ['foo:bar']);
+    expect(pub.stdout, emits('foobar'));
+    await pub.shouldExit();
+  });
+}

--- a/test/run/v2/nonexistent_dependency_test.dart
+++ b/test/run/v2/nonexistent_dependency_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/nonexistent_dependency_test.dart
+++ b/test/run/v2/nonexistent_dependency_test.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('Errors if the script is in an unknown package.', () async {
+    await d.dir(appPath, [d.appPubspec()]).create();
+
+    await pubGet();
+    var pub = await pubRunV2(args: ['foo:script']);
+    expect(
+        pub.stderr,
+        emits('Could not find package "foo". Did you forget to add a '
+            'dependency?'));
+    await pub.shouldExit(exit_codes.DATA);
+  });
+}

--- a/test/run/v2/nonexistent_script_in_dependency_test.dart
+++ b/test/run/v2/nonexistent_script_in_dependency_test.dart
@@ -1,0 +1,32 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:path/path.dart' as p;
+import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('Errors if the script in a dependency does not exist.', () async {
+    await d.dir('foo', [d.libPubspec('foo', '1.0.0')]).create();
+
+    await d.dir(appPath, [
+      d.appPubspec({
+        'foo': {'path': '../foo'}
+      })
+    ]).create();
+
+    await pubGet();
+
+    var pub = await pubRunV2(args: ['foo:script']);
+    expect(
+        pub.stderr,
+        emits(
+            "Could not find ${p.join("bin", "script.dart")} in package foo."));
+    await pub.shouldExit(exit_codes.NO_INPUT);
+  });
+}

--- a/test/run/v2/nonexistent_script_in_dependency_test.dart
+++ b/test/run/v2/nonexistent_script_in_dependency_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/package_api_test.dart
+++ b/test/run/v2/package_api_test.dart
@@ -1,0 +1,75 @@
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+const _script = """
+  import 'dart:isolate';
+
+  main() async {
+    print(await Isolate.packageRoot);
+    print(await Isolate.packageConfig);
+    print(await Isolate.resolvePackageUri(
+        Uri.parse('package:myapp/resource.txt')));
+    print(await Isolate.resolvePackageUri(
+        Uri.parse('package:foo/resource.txt')));
+  }
+""";
+
+void main() {
+  test('an untransformed application sees a file: package config', () async {
+    await d.dir('foo', [d.libPubspec('foo', '1.0.0')]).create();
+
+    await d.dir(appPath, [
+      d.appPubspec({
+        'foo': {'path': '../foo'}
+      }),
+      d.dir('bin', [d.file('script.dart', _script)])
+    ]).create();
+
+    await pubGet();
+    var pub = await pubRunV2(args: ['myapp:script']);
+
+    expect(pub.stdout, emits('null'));
+    expect(pub.stdout,
+        emits(p.toUri(p.join(d.sandbox, 'myapp/.packages')).toString()));
+    expect(pub.stdout,
+        emits(p.toUri(p.join(d.sandbox, 'myapp/lib/resource.txt')).toString()));
+    expect(pub.stdout,
+        emits(p.toUri(p.join(d.sandbox, 'foo/lib/resource.txt')).toString()));
+    await pub.shouldExit(0);
+  });
+
+  test('a snapshotted application sees a file: package root', () async {
+    await servePackages((builder) {
+      builder.serve('foo', '1.0.0', contents: [
+        d.dir('bin', [d.file('script.dart', _script)])
+      ]);
+    });
+
+    await d.dir(appPath, [
+      d.appPubspec({'foo': 'any'})
+    ]).create();
+
+    await pubGet();
+
+    var pub = await pubRunV2(args: ['foo:script']);
+
+    expect(pub.stdout, emits('Precompiling executable...'));
+    expect(pub.stdout, emits('Precompiled foo:script.'));
+    expect(pub.stdout, emits('null'));
+    expect(pub.stdout,
+        emits(p.toUri(p.join(d.sandbox, 'myapp/.packages')).toString()));
+    expect(pub.stdout,
+        emits(p.toUri(p.join(d.sandbox, 'myapp/lib/resource.txt')).toString()));
+    var fooResourcePath = p.join(
+        globalPackageServer.pathInCache('foo', '1.0.0'), 'lib/resource.txt');
+    expect(pub.stdout, emits(p.toUri(fooResourcePath).toString()));
+    await pub.shouldExit(0);
+  });
+}

--- a/test/run/v2/package_api_test.dart
+++ b/test/run/v2/package_api_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/passes_along_arguments_test.dart
+++ b/test/run/v2/passes_along_arguments_test.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+const SCRIPT = '''
+main(List<String> args) {
+  print(args.join(" "));
+}
+''';
+
+void main() {
+  test('passes arguments to the spawned script', () async {
+    await d.dir(appPath, [
+      d.appPubspec(),
+      d.dir('bin', [d.file('args.dart', SCRIPT)])
+    ]).create();
+
+    await pubGet();
+
+    // Use some args that would trip up pub's arg parser to ensure that it
+    // isn't trying to look at them.
+    var pub =
+        await pubRunV2(args: ['myapp:args', '--verbose', '-m', '--', 'help']);
+
+    expect(pub.stdout, emits('--verbose -m -- help'));
+    await pub.shouldExit();
+  });
+}

--- a/test/run/v2/passes_along_arguments_test.dart
+++ b/test/run/v2/passes_along_arguments_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/runs_default_app_without_arguments.dart
+++ b/test/run/v2/runs_default_app_without_arguments.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('runs default Dart application without arguments', () async {
+    await d.dir(appPath, [
+      d.appPubspec(),
+      d.dir('bin', [d.file('myapp.dart', "main() => print('foobar');")])
+    ]).create();
+
+    await pubGet();
+    var pub = await pubRunV2(args: []);
+    expect(pub.stdout, emits('foobar'));
+    await pub.shouldExit();
+  });
+
+  test('runs main.dart Dart application without arguments', () async {
+    await d.dir(appPath, [
+      d.appPubspec(),
+      d.dir('bin', [d.file('main.dart', "main() => print('foobar');")])
+    ]).create();
+
+    await pubGet();
+    var pub = await pubRunV2(args: []);
+    expect(pub.stdout, emits('foobar'));
+    await pub.shouldExit();
+  });
+
+  test('prefers default Dart application without arguments', () async {
+    await d.dir(appPath, [
+      d.appPubspec(),
+      d.dir('bin', [
+        d.file('myapp.dart', "main() => print('foobar');"),
+        d.file('main.dart', "main() => print('-');"),
+      ])
+    ]).create();
+
+    await pubGet();
+    var pub = await pubRunV2(args: []);
+    expect(pub.stdout, emits('foobar'));
+    await pub.shouldExit();
+  });
+}

--- a/test/run/v2/runs_from_a_dependency_override_after_dependency_test.dart
+++ b/test/run/v2/runs_from_a_dependency_override_after_dependency_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/runs_from_a_dependency_override_after_dependency_test.dart
+++ b/test/run/v2/runs_from_a_dependency_override_after_dependency_test.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  // Regression test for issue 23113
+  test('runs a named Dart application in a dependency', () async {
+    await servePackages((builder) {
+      builder.serve('foo', '1.0.0', pubspec: {
+        'name': 'foo',
+        'version': '1.0.0'
+      }, contents: [
+        d.dir('bin', [d.file('bar.dart', "main() => print('foobar');")])
+      ]);
+    });
+
+    await d.dir(appPath, [
+      d.appPubspec({'foo': null})
+    ]).create();
+
+    await pubGet(args: ['--precompile']);
+
+    var pub = await pubRunV2(args: ['foo:bar']);
+    expect(pub.stdout, emits('foobar'));
+    await pub.shouldExit();
+
+    await d.dir('foo', [
+      d.libPubspec('foo', '2.0.0'),
+      d.dir('bin', [d.file('bar.dart', "main() => print('different');")])
+    ]).create();
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'dependencies': {
+          'foo': {'path': '../foo'}
+        }
+      })
+    ]).create();
+
+    await pubGet();
+
+    pub = await pubRunV2(args: ['foo:bar']);
+    expect(pub.stdout, emits('different'));
+    await pub.shouldExit();
+  });
+}

--- a/test/run/v2/runs_named_app_in_dependency_test.dart
+++ b/test/run/v2/runs_named_app_in_dependency_test.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('runs a named Dart application in a dependency', () async {
+    await d.dir('foo', [
+      d.libPubspec('foo', '1.0.0'),
+      d.dir('bin', [d.file('bar.dart', "main() => print('foobar');")])
+    ]).create();
+
+    await d.dir(appPath, [
+      d.appPubspec({
+        'foo': {'path': '../foo'}
+      })
+    ]).create();
+
+    await pubGet();
+    var pub = await pubRunV2(args: ['foo:bar']);
+    expect(pub.stdout, emits('foobar'));
+    await pub.shouldExit();
+  });
+}

--- a/test/run/v2/runs_named_app_in_dependency_test.dart
+++ b/test/run/v2/runs_named_app_in_dependency_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/runs_named_app_in_dev_dependency_test.dart
+++ b/test/run/v2/runs_named_app_in_dev_dependency_test.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('runs a named Dart application in a dev dependency', () async {
+    await d.dir('foo', [
+      d.libPubspec('foo', '1.0.0'),
+      d.dir('bin', [d.file('bar.dart', "main() => print('foobar');")])
+    ]).create();
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'dev_dependencies': {
+          'foo': {'path': '../foo'}
+        }
+      })
+    ]).create();
+
+    await pubGet();
+    var pub = await pubRunV2(args: ['foo:bar']);
+    expect(pub.stdout, emits('foobar'));
+    await pub.shouldExit();
+  });
+}

--- a/test/run/v2/runs_named_app_in_dev_dependency_test.dart
+++ b/test/run/v2/runs_named_app_in_dev_dependency_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/runs_shorthand_app_in_dependency_test.dart
+++ b/test/run/v2/runs_shorthand_app_in_dependency_test.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('runs a shorthand Dart application in a dependency', () async {
+    await d.dir('foo', [
+      d.libPubspec('foo', '1.0.0'),
+      d.dir('bin', [d.file('foo.dart', "main() => print('foo');")])
+    ]).create();
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'dependencies': {
+          'foo': {'path': '../foo'}
+        }
+      })
+    ]).create();
+
+    await pubGet();
+    var pub = await pubRunV2(args: ['foo']);
+    expect(pub.stdout, emits('foo'));
+    await pub.shouldExit();
+  });
+}

--- a/test/run/v2/runs_shorthand_app_in_dependency_test.dart
+++ b/test/run/v2/runs_shorthand_app_in_dependency_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/runs_the_script_in_checked_mode_test.dart
+++ b/test/run/v2/runs_the_script_in_checked_mode_test.dart
@@ -1,0 +1,23 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('runs the script with assertions enabled', () async {
+    await d.dir(appPath, [
+      d.appPubspec(),
+      d.dir('bin', [d.file('script.dart', 'main() { assert(false); }')])
+    ]).create();
+
+    await pubGet();
+    await runPub(
+        args: ['run', '--enable-asserts', 'myapp:script'],
+        error: contains('Failed assertion'),
+        exitCode: 255);
+  });
+}

--- a/test/run/v2/runs_the_script_in_checked_mode_test.dart
+++ b/test/run/v2/runs_the_script_in_checked_mode_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/run/v2/runs_the_script_in_unchecked_mode_test.dart
+++ b/test/run/v2/runs_the_script_in_unchecked_mode_test.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+const SCRIPT = '''
+main() {
+  assert(false);
+  print("no checks");
+}
+''';
+
+void main() {
+  test('runs the script without assertions by default', () async {
+    await d.dir(appPath, [
+      d.appPubspec(),
+      d.dir('bin', [d.file('script.dart', SCRIPT)])
+    ]).create();
+
+    await pubGet();
+    await runPub(args: ['run', 'myapp:script'], output: contains('no checks'));
+  });
+}

--- a/test/run/v2/runs_the_script_in_unchecked_mode_test.dart
+++ b/test/run/v2/runs_the_script_in_unchecked_mode_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -210,6 +210,20 @@ Future<PubProcess> pubRun({bool global = false, Iterable<String> args}) async {
   return pub;
 }
 
+/// Schedules starting the "pub run --v2" process and validates the
+/// expected startup output.
+///
+/// Returns the `pub run` process.
+Future<PubProcess> pubRunV2({Iterable<String> args}) async {
+  final pub = await startPub(args: ['run', '--v2', ...args]);
+
+  // Loading sources and transformers isn't normally printed, but the pub test
+  // infrastructure runs pub in verbose mode, which enables this.
+  expect(pub.stdout, mayEmitMultiple(startsWith('Loading')));
+
+  return pub;
+}
+
 /// Schedules renaming (moving) the directory at [from] to [to], both of which
 /// are assumed to be relative to [d.sandbox].
 void renameInSandbox(String from, String to) {


### PR DESCRIPTION
@jwren, if the first argument given to `dartdev run` matches `[<package>[:<command>]]` where `<package>` is `[a-z_][a-z0-9_]*` and `<command>` is `[^/]+` then we forward to `pub run --v2` (as introduced here).

Long term, we have to find a way to embed this properly and move the entire _run_ related logic into a single place. Maybe `pub` just exports some functions for asserting that `pubspec.yaml` is installed, and what packages are installed, and whether they are immutable.. I don't think we have to clean this up for an MVP.