### PR TITLE
Improve test.sh and testing in non-English setup

### DIFF
--- a/lib/src/git.dart
+++ b/lib/src/git.dart
@@ -57,7 +57,7 @@ Future<List<String>> run(List<String> args,
   log.muteProgress();
   try {
     var result = await runProcess(command, args,
-        workingDir: workingDir, environment: environment);
+        environment: {...?environment, 'LANG': 'en_GB'});
     if (!result.success) {
       throw GitException(args, result.stdout.join('\n'),
           result.stderr.join('\n'), result.exitCode);
@@ -77,7 +77,7 @@ List<String> runSync(List<String> args,
   }
 
   var result = runProcessSync(command, args,
-      workingDir: workingDir, environment: environment);
+      workingDir: workingDir, environment: {...?environment, 'LANG': 'en_GB'});
   if (!result.success) {
     throw GitException(args, result.stdout.join('\n'), result.stderr.join('\n'),
         result.exitCode);

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -3,7 +3,7 @@
 ### Test wrapper script.
 # Many of the integration tests runs the `pub` command, this is slow if every
 # invocation requires the dart compiler to load all the sources. This script
-# will create a `pub.XXX.dart.snapshot.dart2` which the tests can utilize.
+# will create a `pub.XXXXXX.dart.snapshot.dart2` which the tests can utilize.
 # After creating the snapshot this script will forward arguments to
 # `pub run test`, and ensure that the snapshot is deleted after tests have been
 # run.
@@ -12,8 +12,9 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT="$DIR/.."
 
+
 # PATH to a snapshot file.
-PUB_SNAPSHOT_FILE=`tempfile -p 'pub.' -s '.dart.snapshot.dart2'`;
+PUB_SNAPSHOT_FILE=`mktemp -t pub.XXXXXX.dart.snapshot.dart2`;
 
 # Always remove the snapshot
 function cleanup {
@@ -32,4 +33,4 @@ echo 'Building snapshot'
 # Run tests
 echo 'Running tests'
 export _PUB_TEST_SNAPSHOT="$PUB_SNAPSHOT_FILE"
-pub run test -r expanded "$@"
+pub run test --reporter expanded "$@"


### PR DESCRIPTION
Currently there are multiple issues with testing on non-Debian, non-English systems which are addressed by this PR:

1. There is one test (test/global/active/missing_git_repo_test.dart) which evaluates git output. This fails on a non-English system because the output is in the user's locale. This is solved by setting the `LANG` environment variable in the `environment` map in `runProcess()` .

2. `tool/test.sh` used `tempfile` to generate a filename for the pub snapshot. This command is debian-specific and was replaced by `mktemp` which is generally present in all Linux distos I have tested (including Debian/Ubuntu).

3. (general): At least for myself, often tests fail just because I forgot to run `dartfmt -w . && dartanalyzer .`. I have added a new tool `lint.sh` which basically does that for you.