### PR TITLE
Use line length to wrap usage

### DIFF
--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 
@@ -20,6 +22,8 @@ const pubCommandAliases = {
   'publish': ['lish', 'lush'],
   'upgrade': ['update'],
 };
+
+final lineLength = stdout.hasTerminal ? stdout.terminalColumns : 80;
 
 /// The base class for commands for the pub executable.
 ///
@@ -53,8 +57,8 @@ abstract class PubCommand extends Command {
   // Lazily initialize the parser because the superclass constructor requires
   // it but we want to initialize it based on [allowTrailingOptions].
   @override
-  ArgParser get argParser =>
-      _argParser ??= ArgParser(allowTrailingOptions: allowTrailingOptions);
+  ArgParser get argParser => _argParser ??= ArgParser(
+      allowTrailingOptions: allowTrailingOptions, usageLineLength: lineLength);
 
   ArgParser _argParser;
 

--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -67,7 +67,7 @@ class OutdatedCommand extends PubCommand {
 
     argParser.addFlag('up-to-date',
         defaultsTo: false,
-        help: 'Include dependencies that are already at the\n'
+        help: 'Include dependencies that are already at the '
             'latest version.');
   }
 

--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -33,7 +33,7 @@ class OutdatedCommand extends PubCommand {
   OutdatedCommand() {
     argParser.addFlag('color',
         help: 'Whether to color the output.\n'
-            'Defaults to color when connected to a\n'
+            'Defaults to color when connected to a '
             'terminal, and no-color otherwise.');
 
     argParser.addFlag(

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -10,7 +10,7 @@ import 'package:args/command_runner.dart';
 import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
-import 'command.dart' show pubCommandAliases;
+import 'command.dart' show pubCommandAliases, lineLength;
 import 'command/build.dart';
 import 'command/cache.dart';
 import 'command/deps.dart';
@@ -79,7 +79,9 @@ class PubCommandRunner extends CommandRunner {
   String get usageFooter =>
       'See https://dart.dev/tools/pub/cmd for detailed documentation.';
 
-  PubCommandRunner() : super('pub', 'Pub is a package manager for Dart.') {
+  PubCommandRunner()
+      : super('pub', 'Pub is a package manager for Dart.',
+            usageLineLength: lineLength) {
     argParser.addFlag('version', negatable: false, help: 'Print pub version.');
     argParser.addFlag('trace',
         help: 'Print debugging information when an error occurs.');


### PR DESCRIPTION
Specify the `usageLineLength` in our command and command runner. Use the
terminal width or default to 80 if it is unknown.

Remove a manually placed newline in a help string with a space so that
it can wrap based on terminal width. For a width of 80 the wrapping
matches the manual newline.