### PR TITLE
Proposal with implementation: pub add

### DIFF
--- a/lib/src/command/add.dart
+++ b/lib/src/command/add.dart
@@ -1,0 +1,86 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../command.dart';
+import '../http.dart';
+import '../log.dart' as log;
+import '../pubspec.dart';
+import '../solver.dart';
+import '../source_registry.dart';
+
+class AddCommand extends PubCommand {
+  @override
+  String get name => 'add';
+  @override
+  String get description =>
+      'Retrieve a specific package and add it to pubspec.yaml';
+  @override
+  String get invocation => 'pub add <package> [--location=<URL>]';
+
+  AddCommand() {
+    argParser.addOption('location',
+        abbr: 'l',
+        help:
+            'Specify the location from where the package will be downloaded from.');
+  }
+
+  @override
+  Future run() async {
+    if (argResults.rest.isEmpty) {
+      printUsage();
+      return;
+    }
+    final name = argResults.rest[0];
+    final requestUrl =
+        '${_hasExternalUrl() ? _getExternalUrl() : 'https://pub.dartlang.org'}/api/packages/$name';
+    String latestVersion;
+
+    if (!argResults.wasParsed('location')) {
+      latestVersion = await _getLatestVersion(requestUrl);
+      if (latestVersion == null) return;
+    }
+
+    var pubspecPath = Directory.current.path;
+    if (Platform.isWindows) {
+      pubspecPath = pubspecPath.substring(
+          1,
+          pubspecPath.indexOf('\:') > 0
+              ? pubspecPath.indexOf('\:')
+              : pubspecPath.length - 1);
+    }
+    final pubspec = Pubspec.load(pubspecPath, SourceRegistry());
+    log.message('Found $name $latestVersion');
+    if (pubspec.addDependency(name, latestVersion,
+        url: argResults['location'])) {
+      // url can be null
+      await entrypoint.acquireDependencies(SolveType.GET);
+    }
+  }
+
+  String _getExternalUrl() {
+    if (argResults.wasParsed('location')) {
+      return argResults['location'];
+    } else if (Platform.environment.containsKey('PUB_HOSTED_URL')) {
+      return Platform.environment['PUB_HOSTED_URL'];
+    }
+    return null;
+  }
+
+  Future<String> _getLatestVersion(String url) async {
+    String latestVersion;
+    try {
+      latestVersion =
+          json.decode((await httpClient.get(url)).body)['latest']['version'];
+    } catch (e) {
+      log.error(e.toString());
+      log.error(
+          'Could not find package ${url.split('/')[url.split('/').length - 1]} at $url');
+      return null;
+    }
+    return latestVersion;
+  }
+
+  bool _hasExternalUrl() =>
+      Platform.environment.containsKey('PUB_HOSTED_URL') ||
+      argResults.wasParsed('location');
+}

--- a/lib/src/command/cache_repair.dart
+++ b/lib/src/command/cache_repair.dart
@@ -36,10 +36,12 @@ class CacheRepairCommand extends PubCommand {
         .expand((x) => x);
 
     final successes = [
-      for (final result in repairResults) if (result.success) result.package
+      for (final result in repairResults)
+        if (result.success) result.package
     ];
     final failures = [
-      for (final result in repairResults) if (!result.success) result.package
+      for (final result in repairResults)
+        if (!result.success) result.package
     ];
 
     if (successes.isNotEmpty) {

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -11,6 +11,7 @@ import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
 import 'command.dart' show pubCommandAliases, lineLength;
+import 'command/add.dart';
 import 'command/build.dart';
 import 'command/cache.dart';
 import 'command/deps.dart';
@@ -112,6 +113,7 @@ class PubCommandRunner extends CommandRunner {
         negatable: false,
         help: 'A more sparkly experience.');
 
+    addCommand(AddCommand());
     addCommand(BuildCommand());
     addCommand(CacheCommand());
     addCommand(DepsCommand());

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -609,3 +609,8 @@ bool equalsIgnoringPreRelease(Version version1, Version version2) =>
     version1.major == version2.major &&
     version1.minor == version2.minor &&
     version1.patch == version2.patch;
+
+String escapeBackslashes(String input) {
+  return input.replaceAllMapped(RegExp(r'(?<!\\)\\(?!\\)'),
+      (match) => r'\\'); //match backslashes but not double slashes
+}

--- a/test/add/externally_hosted_dep_test.dart
+++ b/test/add/externally_hosted_dep_test.dart
@@ -1,0 +1,17 @@
+import 'package:test/test.dart';
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+void main() {
+  test('It is possible to add an externally hosted package', () async {
+    final port = await servePackages((builder) {
+      builder.serve('foo', '1.2.3');
+      builder.serve('foo', '0.0.1');
+      builder.serve('baz', '1.0.0');
+    });
+    await d.appDir({'baz': '1.0.0'}).create();
+    await pubCommand(RunCommand('add', RegExp('')),
+        args: ['foo', '--location=http://localhost:$port']);
+    await d.cacheDir({'baz': '1.0.0', 'foo': '1.2.3'}).validate();
+  });
+}

--- a/test/add/pubdev_dep_test.dart
+++ b/test/add/pubdev_dep_test.dart
@@ -1,0 +1,30 @@
+import 'package:test/test.dart';
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+void main() {
+  final addCommand = RunCommand('add', RegExp(''));
+
+  test('A package from pub server can be added', () async {
+    await servePackages((builder) {
+      builder.serve('foo', '1.2.3');
+      builder.serve('foo', '0.0.1');
+      builder.serve('baz', '1.0.0');
+    });
+    await d.appDir({'baz': '1.0.0'}).create();
+    await pubCommand(addCommand, args: ['foo']);
+    await pubGet();
+    await d.cacheDir({'baz': '1.0.0', 'foo': '1.2.3'}).validate();
+  });
+
+  test('Refuses to add package if it already exists in pubspec', () async {
+    await servePackages((builder) {
+      builder.serve('foo', '1.2.3');
+    });
+    await d.appDir({'foo': '0.0.1'}).create();
+    const expectedError =
+        'pubspec.yaml already contains foo. Refusing to alter it.';
+    await pubCommand(addCommand,
+        args: ['foo'], error: expectedError, exitCode: 0);
+  });
+}

--- a/test/deps/executables_test.dart
+++ b/test/deps/executables_test.dart
@@ -163,13 +163,15 @@ void main() {
     });
 
     test('all dependencies', _testAllDepsOutput('''
-        myapp
-        foo: foo, baz
-        bar:qux'''));
+myapp
+bar:qux
+foo: foo, baz
+'''));
     test('non-dev dependencies', _testNonDevDepsOutput('''
         myapp
+        bar:qux
         foo: foo, baz
-        bar:qux'''));
+        '''));
   });
 
   group('dev dependencies', () {

--- a/test/deps_test.dart
+++ b/test/deps_test.dart
@@ -47,29 +47,29 @@ void main() {
     test('in compact form', () async {
       await pubGet();
       await runPub(args: ['deps', '-s', 'compact'], output: '''
-          Dart SDK 0.1.2+3
-          myapp 0.0.0
+Dart SDK 0.1.2+3
+myapp 0.0.0
 
-          dependencies:
-          - from_path 1.2.3
-          - normal 1.2.3 [transitive circular_a]
-          - overridden 2.0.0
+dependencies:
+- from_path 1.2.3
+- normal 1.2.3 [circular_a transitive]
+- overridden 2.0.0
 
-          dev dependencies:
-          - unittest 1.2.3 [shared dev_only]
+dev dependencies:
+- unittest 1.2.3 [dev_only shared]
 
-          dependency overrides:
-          - overridden 2.0.0
-          - override_only 1.2.3
+dependency overrides:
+- overridden 2.0.0
+- override_only 1.2.3
 
-          transitive dependencies:
-          - circular_a 1.2.3 [circular_b]
-          - circular_b 1.2.3 [circular_a]
-          - dev_only 1.2.3
-          - other 1.0.0 [myapp]
-          - shared 1.2.3 [other]
-          - transitive 1.2.3 [shared]
-          ''');
+transitive dependencies:
+- circular_a 1.2.3 [circular_b]
+- circular_b 1.2.3 [circular_a]
+- dev_only 1.2.3
+- other 1.0.0 [myapp]
+- shared 1.2.3 [other]
+- transitive 1.2.3 [shared]
+''');
     });
 
     test('in list form', () async {
@@ -79,16 +79,16 @@ void main() {
           myapp 0.0.0
 
           dependencies:
-          - normal 1.2.3
-            - transitive any
-            - circular_a any
-          - overridden 2.0.0
           - from_path 1.2.3
+          - normal 1.2.3
+            - circular_a any
+            - transitive any
+          - overridden 2.0.0
 
           dev dependencies:
           - unittest 1.2.3
-            - shared any
             - dev_only any
+            - shared any
 
           dependency overrides:
           - overridden 2.0.0
@@ -161,7 +161,7 @@ void main() {
 
           dependencies:
           - from_path 1.2.3
-          - normal 1.2.3 [transitive circular_a]
+          - normal 1.2.3 [circular_a transitive]
           - overridden 2.0.0
 
           dependency overrides:
@@ -184,11 +184,11 @@ void main() {
           myapp 0.0.0
 
           dependencies:
-          - normal 1.2.3
-            - transitive any
-            - circular_a any
-          - overridden 2.0.0
           - from_path 1.2.3
+          - normal 1.2.3
+            - circular_a any
+            - transitive any
+          - overridden 2.0.0
 
           dependency overrides:
           - overridden 2.0.0

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -354,10 +354,9 @@ void testExistencePredicate(String name, bool Function(String path) predicate,
             Stream.fromIterable(
               [
                 base64Decode(
-                    'H4sIAP2weF4AA+3S0QqCMBiG4V2KeAE1nfuF7maViNBqzDyQ6N4z6yCIogOtg97ncAz2wTvfuxCW'
-                    'alZ6UFqttIiUYpXObWlzM57fqcyIkcxoU2ZKZyYvtErsvLNuuvboYpKotqm7uPUv74XYeBf7Oh66'
-                    '8I1dX+LH/qFbt6HaLHrnd9O/cQ0sxZv++UP/Qob+1srQX08/5dmf9z+le+erdJWOHyE9/3oPAAAA'
-                    'AAAAAAAAAAAAgM9dALkoaRMAKAAA')
+                    'H4sIAF08q14AA+3SSwrCMBSF4SwlK9AkzQPcTdTOmja0dtDd21YEUYoILSL+3+QOciEHzk1DzHkv'
+                    'NqVGwblp6uDU47wTuvDO+MIrNe5pY5UR0m0b66bvLrGVUlRlU8f23CztvXv/UWnuP/fHLpen3RBT'
+                    'tf4fU8He2uX+dfHUvw1GC6nWj/Lqz/uvYyoPcr6Cb0cBAAAAAAAAAAAAAAAA8KEr192SOwAoAAA=')
               ],
             ),
             tempDir);

--- a/test/outdated/goldens/dependency_overrides.txt
+++ b/test/outdated/goldens/dependency_overrides.txt
@@ -131,9 +131,9 @@ Newer versions, while available, are not mutually compatible.
 
 $ pub outdated --no-color --no-dependency-overrides
 Dependencies  Current              Upgradable  Resolvable  Latest  
-bar           *1.0.1 (overridden)  2.0.0       2.0.0       2.0.0   
+bar           *1.0.1 (overridden)  2.0.0       *1.0.0      2.0.0   
 baz           *2.0.0 (overridden)  *1.0.0      2.0.0       2.0.0   
-foo           *1.0.1 (overridden)  *1.0.0      *1.0.0      2.0.0   
+foo           *1.0.1 (overridden)  *1.0.0      2.0.0       2.0.0   
 
 dev_dependencies: all up-to-date
 
@@ -144,6 +144,6 @@ transitive dev_dependencies: all up-to-date
 3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `pub upgrade`.
 
-1 dependency is constrained to a version that is older than a resolvable version.
-To update it, edit pubspec.yaml.
+3  dependencies are constrained to versions that are older than a resolvable version.
+To update these dependencies, edit pubspec.yaml.
 

--- a/test/package_server.dart
+++ b/test/package_server.dart
@@ -28,6 +28,7 @@ Future servePackages(void Function(PackageServerBuilder) callback) async {
   addTearDown(() {
     _globalPackageServer = null;
   });
+  return _globalPackageServer.port;
 }
 
 /// Like [servePackages], but instead creates an empty server with no packages
@@ -93,11 +94,17 @@ class PackageServer {
     _servedPackageDir.contents.clear();
 
     _builder._packages.forEach((name, versions) {
+      var sortedVersions = List.from(versions);
+      sortedVersions
+        ..sort((a, b) => a.version.toString().compareTo(b.version.toString()));
+      final latestVersion = sortedVersions[sortedVersions.length - 1];
+
       _servedApiPackageDir.contents.addAll([
         d.file(
             name,
             jsonEncode({
               'name': name,
+              'latest': packageVersionApiMap(url, latestVersion.pubspec),
               'uploaders': ['nweiz@google.com'],
               'versions': versions
                   .map((version) => packageVersionApiMap(url, version.pubspec))

--- a/test/pub_get_and_upgrade_test.dart
+++ b/test/pub_get_and_upgrade_test.dart
@@ -81,7 +81,7 @@ void main() {
       ]).create();
 
       await pubCommand(command,
-          error: RegExp(r'bar from path is incompatible with foo from path'));
+          error: RegExp(r'foo from path is incompatible with bar from path'));
     });
 
     test('does not allow a dependency on itself', () async {

--- a/test/pub_test.dart
+++ b/test/pub_test.dart
@@ -29,6 +29,7 @@ void main() {
         -v, --verbose          Shortcut for "--verbosity=all".
 
         Available commands:
+          add         Retrieve a specific package and add it to pubspec.yaml
           cache       Work with the system cache.
           deps        Print package dependencies.
           downgrade   Downgrade the current package's dependencies to oldest versions.

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -57,7 +57,7 @@ Matcher isUnminifiedDart2JSOutput =
 final _entrypoint = Entrypoint(pubRoot, SystemCache(isOffline: true));
 
 /// Converts [value] into a YAML string.
-String yaml(value) => jsonEncode(value);
+String yaml(value) => yamlToString(value);
 
 /// The path of the package cache directory used for tests, relative to the
 /// sandbox directory.

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -163,4 +163,9 @@ b: {}'''));
       }
     });
   });
+
+  test('Escape backslashes', () {
+    expect(escapeBackslashes(r'C:\Users\Foo\\Bar'),
+        equals(r'C:\\Users\\Foo\\Bar'));
+  });
 }

--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -11,6 +11,7 @@ import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 import 'package:pub/src/entrypoint.dart';
+import 'package:pub/src/utils.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/dependency.dart';
 
@@ -205,7 +206,8 @@ void main() {
     group('has a path dependency', () {
       group('where a hosted version exists', () {
         test('and should suggest the hosted primary version', () async {
-          await setUpDependency({'path': path.join(d.sandbox, 'foo')},
+          await setUpDependency(
+              {'path': escapeBackslashes(path.join(d.sandbox, 'foo'))},
               hostedVersions: ['3.0.0-pre', '2.0.0', '1.0.0']);
           expectDependencyValidationError('  foo: ^2.0.0');
         });
@@ -213,7 +215,8 @@ void main() {
         test(
             'and should suggest the hosted prerelease version if '
             "it's the only version available", () async {
-          await setUpDependency({'path': path.join(d.sandbox, 'foo')},
+          await setUpDependency(
+              {'path': escapeBackslashes(path.join(d.sandbox, 'foo'))},
               hostedVersions: ['3.0.0-pre', '2.0.0-pre']);
           expectDependencyValidationError('  foo: ^3.0.0-pre');
         });
@@ -221,7 +224,8 @@ void main() {
         test(
             'and should suggest a tighter constraint if primary is '
             'pre-1.0.0', () async {
-          await setUpDependency({'path': path.join(d.sandbox, 'foo')},
+          await setUpDependency(
+              {'path': escapeBackslashes(path.join(d.sandbox, 'foo'))},
               hostedVersions: ['0.0.1', '0.0.2']);
           expectDependencyValidationError('  foo: ^0.0.2');
         });
@@ -230,7 +234,7 @@ void main() {
       group('where no hosted version exists', () {
         test("and should use the other source's version", () async {
           await setUpDependency({
-            'path': path.join(d.sandbox, 'foo'),
+            'path': escapeBackslashes(path.join(d.sandbox, 'foo')),
             'version': '>=1.0.0 <2.0.0'
           });
           expectDependencyValidationError('  foo: ">=1.0.0 <2.0.0"');
@@ -239,8 +243,10 @@ void main() {
         test(
             "and should use the other source's unquoted version if "
             'concrete', () async {
-          await setUpDependency(
-              {'path': path.join(d.sandbox, 'foo'), 'version': '0.2.3'});
+          await setUpDependency({
+            'path': escapeBackslashes(path.join(d.sandbox, 'foo')),
+            'version': '0.2.3'
+          });
           expectDependencyValidationError('  foo: 0.2.3');
         });
       });

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -219,9 +219,9 @@ void withLockFile() {
 
     await d.appDir({'foo': 'any', 'bar': '<2.0.0'}).create();
     await expectResolves(error: equalsIgnoringWhitespace('''
-      Because myapp depends on foo any which depends on bar >=2.0.0,
-        bar >=2.0.0 is required.
-      So, because myapp depends on bar <2.0.0, version solving failed.
+      Because every version of foo depends on bar >=2.0.0 and myapp depends on
+      bar <2.0.0, foo is forbidden. So, because myapp depends on foo any,
+      version solving failed.
     '''));
   });
 }
@@ -256,8 +256,8 @@ void rootDependency() {
     await d.appDir({'foo': '1.0.0'}).create();
     await expectResolves(error: equalsIgnoringWhitespace('''
       Because myapp depends on foo 1.0.0 which depends on myapp >0.0.0,
-        myapp >0.0.0 is required.
-      So, because myapp is 0.0.0, version solving failed.
+      myapp >0.0.0 is required. So, because myapp is 0.0.0,
+      version solving failed.
     '''));
   });
 }
@@ -454,13 +454,11 @@ void unsolvable() {
 
     await d.appDir({'foo': '1.0.0', 'bar': '1.0.0'}).create();
     await expectResolves(error: equalsIgnoringWhitespace('''
-      Because every version of foo depends on shared ^2.0.0 and no versions of
-        shared match ^2.9.0, every version of foo requires
-        shared >=2.0.0 <2.9.0.
-      And because every version of bar depends on shared >=2.9.0 <4.0.0, bar is
-        incompatible with foo.
-      So, because myapp depends on both foo 1.0.0 and bar 1.0.0, version
-        solving failed.
+      Because every version of bar depends on shared >=2.9.0 <4.0.0
+      and no versions of shared match ^2.9.0, every version of bar requires
+      shared ^3.0.0. And because every version of foo depends on shared ^2.0.0,
+      foo is incompatible with bar. So, because myapp depends on both bar 1.0.0
+      and foo 1.0.0, version solving failed.
     '''));
   });
 
@@ -474,10 +472,9 @@ void unsolvable() {
 
     await d.appDir({'foo': '1.0.0', 'bar': '1.0.0'}).create();
     await expectResolves(error: equalsIgnoringWhitespace('''
-      Because every version of bar depends on shared >3.0.0 and every version
-        of foo depends on shared <=2.0.0, bar is incompatible with foo.
-      So, because myapp depends on both foo 1.0.0 and bar 1.0.0, version
-        solving failed.
+        Because every version of foo depends on shared <=2.0.0 and every version
+        of bar depends on shared >3.0.0, foo is incompatible with bar.
+        So, because myapp depends on both bar 1.0.0 and foo 1.0.0, version solving failed.
     '''));
   });
 
@@ -501,13 +498,13 @@ void unsolvable() {
 
     await expectResolves(
         error: allOf([
-      contains('Because every version of bar depends on shared from hosted on '
+      contains('Because every version of foo depends on shared from hosted on '
           'http://localhost:'),
-      contains(' and every version of foo depends on shared from hosted on '
+      contains(' and every version of bar depends on shared from hosted on '
           'http://localhost:'),
-      contains(', bar is incompatible with foo.'),
-      contains('So, because myapp depends on both foo 1.0.0 and bar 1.0.0, '
-          'version solving failed.')
+      contains(', foo is incompatible with bar.'),
+      contains(
+          'So, because myapp depends on both bar 1.0.0 and foo 1.0.0, version solving failed.')
     ]));
   });
 
@@ -524,11 +521,9 @@ void unsolvable() {
 
     await d.appDir({'foo': '1.0.0', 'bar': '1.0.0'}).create();
     await expectResolves(error: equalsIgnoringWhitespace('''
-      Because every version of bar depends on shared from path and every
-        version of foo depends on shared from hosted, bar is incompatible with
-        foo.
-      So, because myapp depends on both foo 1.0.0 and bar 1.0.0, version
-        solving failed.
+      Because every version of foo depends on shared from hosted and every
+      version of bar depends on shared from path, foo is incompatible with bar.
+      So, because myapp depends on both bar 1.0.0 and foo 1.0.0, version solving failed.
     '''));
   });
 
@@ -675,9 +670,8 @@ void badSource() {
     }).create();
     await expectResolves(error: equalsIgnoringWhitespace('''
       Because every version of foo depends on bar any which depends on baz any,
-        every version of foo requires baz from hosted.
-      So, because myapp depends on both foo any and baz from path, version
-        solving failed.
+      every version of foo requires baz from hosted. So, because myapp depends
+      on both baz from path and foo any, version solving failed.
     '''));
   });
 }


### PR DESCRIPTION
Hello folks,

I propose a new command for pub: `pub add <package> [--location=<src>]`.

The add command behaves like `npm install <package>` such that it resolves the latest version of `<package>`, adds the dependency to `pubspec.yaml` and runs `pub get`. An optional `--location` can be added to pull from a custom pub server. The [`PUB_HOSTED_URL`](https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md) environment variable is respected too, but `--location ` shadows it.

If the dependency already exists in `pubspec.yaml` the command terminates.