### PR TITLE
Rely on terminal telling if we can use colors

### DIFF
--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -18,6 +18,7 @@ import '../package_name.dart';
 import '../pubspec.dart';
 import '../solver.dart';
 import '../source/hosted.dart';
+import '../utils.dart';
 
 class OutdatedCommand extends PubCommand {
   @override
@@ -200,7 +201,7 @@ class OutdatedCommand extends PubCommand {
       await _outputJson(rows);
     } else {
       final useColors = argResults['color'] ||
-          (!argResults.wasParsed('color') && stdin.hasTerminal);
+          (!argResults.wasParsed('color') && canUseSpecialChars);
       final marker = {
         'outdated': oudatedMarker,
         'none': noneMarker,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -408,8 +408,8 @@ String _urlDecode(String encoded) =>
 bool get canUseSpecialChars =>
     !runningFromTest &&
     !runningAsTest &&
-    !Platform.isWindows &&
-    stdioType(stdout) == StdioType.terminal;
+    stdioType(stdout) == StdioType.terminal &&
+    stdout.supportsAnsiEscapes;
 
 /// Gets a "special" string (ANSI escape or Unicode).
 ///


### PR DESCRIPTION
This should enable colors on common windows terminals.

Tested with cmd and powershell.