### PR TITLE
Force colors in `pub outdated --color`

### DIFF
--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -200,8 +200,10 @@ class OutdatedCommand extends PubCommand {
     if (argResults['json']) {
       await _outputJson(rows);
     } else {
-      final useColors = argResults['color'] ||
-          (!argResults.wasParsed('color') && canUseSpecialChars);
+      if (argResults.wasParsed('color') && argResults['color']) {
+        forceColors = true;
+      }
+      final useColors = argResults['color'] || canUseSpecialChars;
       final marker = {
         'outdated': oudatedMarker,
         'none': noneMarker,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -400,16 +400,20 @@ String niceDuration(Duration duration) {
 String _urlDecode(String encoded) =>
     Uri.decodeComponent(encoded.replaceAll('+', ' '));
 
+/// Set to `true` if ANSI colors should be output regardless of terminalD
+bool forceColors = false;
+
 /// Whether "special" strings such as Unicode characters or color escapes are
 /// safe to use.
 ///
 /// On Windows or when not printing to a terminal, only printable ASCII
 /// characters should be used.
 bool get canUseSpecialChars =>
-    !runningFromTest &&
-    !runningAsTest &&
-    stdioType(stdout) == StdioType.terminal &&
-    stdout.supportsAnsiEscapes;
+    forceColors ||
+    (!runningFromTest &&
+        !runningAsTest &&
+        stdioType(stdout) == StdioType.terminal &&
+        stdout.supportsAnsiEscapes);
 
 /// Gets a "special" string (ANSI escape or Unicode).
 ///


### PR DESCRIPTION
Before colors would not be shown because they only get applied with a second level of terminal detection