### PR TITLE
Don't precompile dependencies of global activate from path

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -143,7 +143,7 @@ class GlobalPackages {
     var entrypoint = Entrypoint(path, cache);
 
     // Get the package's dependencies.
-    await entrypoint.acquireDependencies(SolveType.GET, precompile: true);
+    await entrypoint.acquireDependencies(SolveType.GET);
     var name = entrypoint.root.name;
 
     // Call this just to log what the current active package is, if any.

--- a/test/global/activate/path_package_test.dart
+++ b/test/global/activate/path_package_test.dart
@@ -54,4 +54,28 @@ void main() {
         output: 'ok',
         workingDirectory: p.current);
   });
+
+  test("Doesn't precompile binaries when activating from path", () async {
+    await servePackages(
+      (builder) => builder.serve(
+        'bar',
+        '1.0.0',
+        contents: [
+          d.dir('bin', [d.file('bar.dart', "main() => print('bar');")])
+        ],
+      ),
+    );
+
+    await d.dir('foo', [
+      d.libPubspec('foo', '1.0.0', deps: {'bar': '^1.0.0'}),
+      d.dir('bin', [d.file('foo.dart', "main() => print('ok');")])
+    ]).create();
+
+    await runPub(
+        args: ['global', 'activate', '--source', 'path', '../foo'],
+        output: allOf([
+          contains('Activated foo 1.0.0 at path'),
+          isNot(contains('Precompiled'))
+        ]));
+  });
 }


### PR DESCRIPTION
We should never precompile dependencies of the activated package.
For path packages we also don't precompile the package itself

Fixes: https://github.com/dart-lang/pub/issues/2526