### PR TITLE
Configure GitHub move app

### DIFF
--- a/.github/move.yml
+++ b/.github/move.yml
@@ -1,0 +1,21 @@
+# Configuration for move-issues - https://github.com/dessant/move-issues
+
+# Delete the command comment when it contains no other content
+deleteCommand: true
+
+# Close the source issue after moving
+closeSourceIssue: true
+
+# Lock the source issue after moving
+lockSourceIssue: false
+
+# Mention issue and comment authors
+mentionAuthors: true
+
+# Preserve mentions in the issue content
+keepContentMentions: true
+
+# Set custom aliases for targets
+aliases:
+  flutter: flutter/flutter
+  flutter-intellij: flutter/flutter-intellij


### PR DESCRIPTION
Configure the [GitHub move app](https://github.com/apps/move) so issues can be moved from the Flutter repo issue tracker (or any repo) to this repo.

Users with write access to the source repo and this repo will be able to use the Transfer Issue button:
<img width="207" alt="88121110-95a01880-cb79-11ea-8f3a-ea770196fd83" src="https://user-images.githubusercontent.com/682784/88121202-e0219500-cb79-11ea-9386-1ce3a5213895.png">

Preferences copied from [dart-lang/sdk](https://github.com/dart-lang/sdk/blob/master/.github/move.yml).