### PR TITLE
Remove unused dependency from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,4 +34,3 @@ dev_dependencies:
   test: ^1.3.0
   test_descriptor: ^1.0.0
   test_process: ^1.0.0
-  protoc_plugin: <19.0.0


### PR DESCRIPTION
That line sneaked in in https://github.com/dart-lang/pub/commit/04e0601eec2539156bfec7a74a2cc3828067c014