### PR TITLE
Fixed license headers

### DIFF
--- a/test/get/path/absolute_path_test.dart
+++ b/test/get/path/absolute_path_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/get/path/absolute_symlink_test.dart
+++ b/test/get/path/absolute_symlink_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/get/path/empty_pubspec_test.dart
+++ b/test/get/path/empty_pubspec_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/get/path/no_pubspec_test.dart
+++ b/test/get/path/no_pubspec_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/get/path/nonexistent_dir_test.dart
+++ b/test/get/path/nonexistent_dir_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/get/path/path_is_file_test.dart
+++ b/test/get/path/path_is_file_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/get/path/relative_path_test.dart
+++ b/test/get/path/relative_path_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';

--- a/test/get/path/relative_symlink_test.dart
+++ b/test/get/path/relative_symlink_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 // Pub uses NTFS junction points to create links in the packages directory.
 // These (unlike the symlinks that are supported in Vista and later) do not

--- a/test/get/path/shared_dependency_symlink_test.dart
+++ b/test/get/path/shared_dependency_symlink_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/get/path/shared_dependency_test.dart
+++ b/test/get/path/shared_dependency_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/get/switch_source_test.dart
+++ b/test/get/switch_source_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/list_package_dirs/ignores_updated_pubspec_test.dart
+++ b/test/list_package_dirs/ignores_updated_pubspec_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/list_package_dirs/includes_dev_dependencies_test.dart
+++ b/test/list_package_dirs/includes_dev_dependencies_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/list_package_dirs/lists_dependency_directories_test.dart
+++ b/test/list_package_dirs/lists_dependency_directories_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/list_package_dirs/lockfile_error_test.dart
+++ b/test/list_package_dirs/lockfile_error_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';

--- a/test/list_package_dirs/missing_pubspec_test.dart
+++ b/test/list_package_dirs/missing_pubspec_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 

--- a/test/list_package_dirs/no_lockfile_test.dart
+++ b/test/list_package_dirs/no_lockfile_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/list_package_dirs/pubspec_error_test.dart
+++ b/test/list_package_dirs/pubspec_error_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';

--- a/test/package_config_file_test.dart
+++ b/test/package_config_file_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/packages_file_test.dart
+++ b/test/packages_file_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:test/test.dart';
 

--- a/test/sdk_test.dart
+++ b/test/sdk_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'package:path/path.dart' as p;
 

--- a/test/unknown_source_test.dart
+++ b/test/unknown_source_test.dart
@@ -1,6 +1,6 @@
-// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS d.file
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE d.file.
+// BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
 


### PR DESCRIPTION
Minor fixes to license headers which had 'd.file' instead of 'file'