### PR TITLE
Don't look for external package foo during testing

### DIFF
--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -84,6 +84,8 @@ void main() {
 
     test('has a git path dependency with an appropriate SDK constraint',
         () async {
+      // Ensure we don't report anything from the real pub.dev.
+      await setUpDependency({});
       await d.dir(appPath, [
         d.libPubspec('test_pkg', '1.0.0',
             deps: {
@@ -503,6 +505,8 @@ void main() {
 
     group('has a git path dependency', () {
       test('without an SDK constraint', () async {
+        // Ensure we don't report anything from the real pub.dev.
+        await setUpDependency({});
         await d.dir(appPath, [
           d.libPubspec('integration_pkg', '1.0.0', deps: {
             'foo': {
@@ -517,6 +521,8 @@ void main() {
       });
 
       test('with a too-broad SDK constraint', () async {
+        // Ensure we don't report anything from the real pub.dev.
+        await setUpDependency({});
         await d.dir(appPath, [
           d.libPubspec('integration_pkg', '1.0.0',
               deps: {

--- a/test/validator/utils.dart
+++ b/test/validator/utils.dart
@@ -6,6 +6,9 @@ import 'package:test/test.dart';
 
 import '../test_pub.dart';
 
+// TODO(sigurdm) consider rewriting all validator tests as integration tests.
+// That would make them more robust, and test actual end2end behaviour.
+
 Future<void> expectValidation(ValidatorCreator fn,
     {hints, warnings, errors}) async {
   final validator = await validatePackage(fn);


### PR DESCRIPTION
Package foo was published and broke our tests.

Took quite some time to figure out :)