### PR TITLE
Differentiate between ansi and unicode support

### DIFF
--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -218,9 +218,8 @@ class OutdatedCommand extends PubCommand {
       if (argResults.wasParsed('color')) {
         forceColors = argResults['color'];
       }
-      final useColors = argResults.wasParsed('color')
-          ? argResults['color']
-          : canUseSpecialChars;
+      final useColors =
+          argResults.wasParsed('color') ? argResults['color'] : canUseAnsiCodes;
 
       await _outputHuman(rows, mode,
           useColors: useColors,
@@ -709,14 +708,14 @@ Showing packages where the current version doesn't fully support null safety.
                   break;
                 case NullSafetyCompliance.compliant:
                   color = log.green;
-                  prefix = '✓';
+                  prefix = emoji('✓', '+');
                   nullSafetyJson = true;
                   asDesired = true;
                   break;
                 case NullSafetyCompliance.notCompliant:
                 case NullSafetyCompliance.mixed:
                   color = log.red;
-                  prefix = '✗';
+                  prefix = emoji('✗', 'x');
                   nullSafetyJson = false;
                   break;
               }

--- a/lib/src/log.dart
+++ b/lib/src/log.dart
@@ -43,17 +43,17 @@ Transcript<_Entry> _transcript;
 /// This will also be in [_progresses].
 Progress _animatedProgress;
 
-final _cyan = getSpecial('\u001b[36m');
-final _green = getSpecial('\u001b[32m');
-final _magenta = getSpecial('\u001b[35m');
-final _red = getSpecial('\u001b[31m');
-final _yellow = getSpecial('\u001b[33m');
+final _cyan = getAnsi('\u001b[36m');
+final _green = getAnsi('\u001b[32m');
+final _magenta = getAnsi('\u001b[35m');
+final _red = getAnsi('\u001b[31m');
+final _yellow = getAnsi('\u001b[33m');
 //final _blue = getSpecial('\u001b[34m');
-final _gray = getSpecial('\u001b[38;5;245m');
+final _gray = getAnsi('\u001b[38;5;245m');
 
-final _none = getSpecial('\u001b[0m');
-final _noColor = getSpecial('\u001b[39m');
-final _bold = getSpecial('\u001b[1m');
+final _none = getAnsi('\u001b[0m');
+final _noColor = getAnsi('\u001b[39m');
+final _bold = getAnsi('\u001b[1m');
 
 /// An enum type for defining the different logging levels a given message can
 /// be associated with.
@@ -283,7 +283,7 @@ void exception(exception, [StackTrace trace]) {
   // This is basically the top-level exception handler so that we don't
   // spew a stack trace on our users.
   if (exception is SourceSpanException) {
-    error(exception.toString(color: canUseSpecialChars));
+    error(exception.toString(color: canUseAnsiCodes));
   } else {
     error(getErrorMessage(exception));
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -405,19 +405,27 @@ bool forceColors = false;
 ///
 /// On Windows or when not printing to a terminal, only printable ASCII
 /// characters should be used.
-bool get canUseSpecialChars =>
+bool get canUseAnsiCodes =>
     forceColors ||
     (!runningFromTest &&
         !runningAsTest &&
         stdioType(stdout) == StdioType.terminal &&
         stdout.supportsAnsiEscapes);
 
-/// Gets a "special" string (ANSI escape or Unicode).
-///
-/// On Windows or when not printing to a terminal, returns something else since
-/// those aren't supported.
-String getSpecial(String special, [String onWindows = '']) =>
-    canUseSpecialChars ? special : onWindows;
+/// Gets an ANSI escape if those are supported by stdout (or nothing).
+String getAnsi(String ansiCode) => canUseAnsiCodes ? ansiCode : '';
+
+/// Gets a emoji special character as unicode, or the [alternative] if unicode 
+/// charactors are not supported by stdout.
+String emoji(String unicode, String alternative) =>
+    canUseUnicode ? unicode : alternative;
+
+// Assume unicode emojis are supported when not on Windows.
+// If we are on Windows, unicode emojis are supported in Windows Terminal,
+// which sets the WT_SESSION environment variable. See:
+// https://github.com/microsoft/terminal/blob/master/doc/user-docs/index.md#tips-and-tricks
+bool get canUseUnicode =>
+    !Platform.isWindows || Platform.environment.containsKey('WT_SESSION');
 
 /// Prepends each line in [text] with [prefix].
 ///

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -415,7 +415,7 @@ bool get canUseAnsiCodes =>
 /// Gets an ANSI escape if those are supported by stdout (or nothing).
 String getAnsi(String ansiCode) => canUseAnsiCodes ? ansiCode : '';
 
-/// Gets a emoji special character as unicode, or the [alternative] if unicode 
+/// Gets a emoji special character as unicode, or the [alternative] if unicode
 /// charactors are not supported by stdout.
 String emoji(String unicode, String alternative) =>
     canUseUnicode ? unicode : alternative;
@@ -425,7 +425,13 @@ String emoji(String unicode, String alternative) =>
 // which sets the WT_SESSION environment variable. See:
 // https://github.com/microsoft/terminal/blob/master/doc/user-docs/index.md#tips-and-tricks
 bool get canUseUnicode =>
-    !Platform.isWindows || Platform.environment.containsKey('WT_SESSION');
+    // The tests support unicode also on windows.
+    runningFromTest ||
+    runningAsTest ||
+    // When not outputting to terminal we can also use unicode.
+    stdioType(stdout) != StdioType.terminal ||
+    !Platform.isWindows ||
+    Platform.environment.containsKey('WT_SESSION');
 
 /// Prepends each line in [text] with [prefix].
 ///


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub/issues/2607