### PR TITLE
Implementation of a `bump` command that bumps the current package version

### DIFF
--- a/lib/src/command/bump.dart
+++ b/lib/src/command/bump.dart
@@ -1,0 +1,123 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml_edit/yaml_edit.dart';
+
+import '../command.dart';
+import '../io.dart';
+import '../log.dart' as log;
+
+/// Handles the `bump` pub command.
+///
+/// Updates the version of the current package in `pubspec.yaml`. By default,
+/// it bumps the version up to the nearest stable patch number. Users may pass
+/// in the `--major|--minor|--patch`, which bumps the version up to the nearest
+/// stable major/minor/patch numbers accordingly. Users may also pass in a
+/// version number as an argument, and the version number will be bumped to the
+/// argument accordingly
+///
+/// **Examples**
+/// 1. `pub bump` 1.2.3 -> 1.2.4
+/// 2. `pub bump` 1.2.3-dev -> 1.2.3
+/// 3. `pub bump --major` 1.2.3 -> 2.0.0
+/// 4. `pub bump --minor` 1.2.3 -> 1.3.0
+/// 5. `pub bump 3.0.0` 1.2.3 -> 3.0.0
+class BumpCommand extends PubCommand {
+  @override
+  String get name => 'bump';
+  @override
+  String get description =>
+      'Updates the version of the current package in pubspec.yaml.';
+  @override
+  String get invocation => 'pub bump [--major|--minor|--patch]';
+
+  bool get isMajor => argResults['major'];
+  bool get isMinor => argResults['minor'];
+  bool get isPatch => argResults['patch'];
+
+  BumpCommand() {
+    argParser.addFlag('major',
+        negatable: false,
+        help: 'Bumps the major version number, while resetting the minor and '
+            'patch numbers, as well as build/pre-release information. '
+            'e.g. 1.2.3 -> 2.0.0');
+    argParser.addFlag('minor',
+        negatable: false,
+        help:
+            'Bumps the minor version number, while resetting the patch number, '
+            'as well as build/pre-release information. e.g. 1.2.3 -> 1.3.0');
+    argParser.addFlag('patch',
+        negatable: false,
+        help: 'Bumps the patch number. e.g. 1.2.3 -> 1.2.4. If it is '
+            'originally a pre-release version, it simply removes the '
+            'pre-release tag instead. e.g. 1.2.3-dev -> 1.2.3');
+  }
+
+  @override
+  void run() {
+    if ((isMajor && isMinor) || (isMajor && isPatch) || (isMinor && isPatch)) {
+      usageException('Only one flag should be specified at most');
+    }
+
+    if (argResults.rest.isNotEmpty && (isMajor || isMinor || isPatch)) {
+      usageException('Must not specify a version to bump to along with flags');
+    }
+
+    final initialVersion = entrypoint.root.version;
+    Version finalVersion;
+
+    if (argResults.rest.isNotEmpty) {
+      if (argResults.rest.length > 1) {
+        usageException('Please specify only one version to bump to');
+      }
+
+      try {
+        finalVersion = Version.parse(argResults.rest.first);
+      } on FormatException {
+        usageException('Invalid version ${argResults.rest.first} found. '
+            'Please ensure that it is correctly formatted according to pub '
+            'semver requirements');
+      }
+    } else {
+      final initialMajor = initialVersion.major;
+      final initialMinor = initialVersion.minor;
+      final initialPatch = initialVersion.patch;
+
+      /// We have already previously ensured that at most one of `isMajor`,
+      /// `isMinor`, or `isPatch` is true.
+      if (isMajor) {
+        finalVersion = Version(initialMajor + 1, 0, 0);
+      } else if (isMinor) {
+        finalVersion = Version(initialMajor, initialMinor + 1, 0);
+      } else {
+        /// Both the `--patch` flag and the default options have the same
+        /// behavior.
+
+        if (initialVersion.isPreRelease) {
+          finalVersion = Version(initialMajor, initialMinor, initialPatch);
+        } else {
+          finalVersion = Version(initialMajor, initialMinor, initialPatch + 1);
+        }
+      }
+    }
+    _updatePubspecVersion(initialVersion, finalVersion);
+  }
+
+  /// Writes [finalVersion] to pubspec and report the change.
+  void _updatePubspecVersion(Version initialVersion, Version finalVersion) {
+    final yamlEditor = YamlEditor(readTextFile(entrypoint.pubspecPath));
+
+    /// No need to check if the version is not declared in the pubspec
+    /// since this update function will add it in if that's the case.
+    yamlEditor.update(['version'], finalVersion.toString());
+
+    /// Windows line endings are already handled by [yamlEditor]
+    writeTextFile(entrypoint.pubspecPath, yamlEditor.toString());
+
+    /// Print the result of the update.
+    log.message(
+        'Successfully updated version from $initialVersion to $finalVersion');
+  }
+}

--- a/lib/src/command/bump.dart
+++ b/lib/src/command/bump.dart
@@ -31,7 +31,7 @@ class BumpCommand extends PubCommand {
   String get description =>
       'Updates the version of the current package in pubspec.yaml.';
   @override
-  String get invocation => 'pub bump [--major|--minor|--patch]';
+  String get invocation => 'pub bump [version|--major|--minor|--patch]';
 
   bool get isMajor => argResults['major'];
   bool get isMinor => argResults['minor'];

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -12,6 +12,7 @@ import 'package:path/path.dart' as p;
 
 import 'command.dart' show pubCommandAliases, lineLength;
 import 'command/build.dart';
+import 'command/bump.dart';
 import 'command/cache.dart';
 import 'command/deps.dart';
 import 'command/downgrade.dart';
@@ -105,6 +106,7 @@ class PubCommandRunner extends CommandRunner {
         abbr: 'v', negatable: false, help: 'Shortcut for "--verbosity=all".');
 
     addCommand(BuildCommand());
+    addCommand(BumpCommand());
     addCommand(CacheCommand());
     addCommand(DepsCommand());
     addCommand(DowngradeCommand());

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   source_span: ^1.4.0
   stack_trace: ^1.0.0
   yaml: ^2.2.0
+  yaml_edit: ^1.0.0
 
 dev_dependencies:
   shelf_test_handler: ^1.0.0

--- a/test/bump/bump_test.dart
+++ b/test/bump/bump_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
@@ -22,6 +23,44 @@ void main() {
       d.pubspec({
         'name': 'myapp',
         'version': '1.2.4',
+      })
+    ]).validate();
+  });
+
+  test('bump to version', () async {
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.3',
+      })
+    ]).create();
+
+    await pubBump(args: ['4.5.6'], output: contains('1.2.3 to 4.5.6'));
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '4.5.6',
+      })
+    ]).validate();
+  });
+
+  test('bump to version with pre-release and build', () async {
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.3',
+      })
+    ]).create();
+
+    await pubBump(
+        args: ['4.5.6-alpha+build.1'],
+        output: contains('1.2.3 to 4.5.6-alpha+build.1'));
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '4.5.6-alpha+build.1',
       })
     ]).validate();
   });
@@ -132,5 +171,64 @@ void main() {
         'version': '1.2.4',
       })
     ]).validate();
+  });
+
+  group('fails if', () {
+    test('more than one flag is provided', () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'version': '1.2.3',
+        })
+      ]).create();
+
+      await pubBump(
+          args: ['--major', '--patch'],
+          error: contains('Only one flag should be specified at most'),
+          exitCode: exit_codes.USAGE);
+    });
+
+    test('a flag is provided along with an argument', () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'version': '1.2.3',
+        })
+      ]).create();
+
+      await pubBump(
+          args: ['--major', '4.5.6'],
+          error: contains(
+              'Must not specify a version to bump to along with flags'),
+          exitCode: exit_codes.USAGE);
+    });
+
+    test('more than one argument is provided', () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'version': '1.2.3',
+        })
+      ]).create();
+
+      await pubBump(
+          args: ['4.5.6', '4.5.7'],
+          error: contains('Please specify only one version to bump to'),
+          exitCode: exit_codes.USAGE);
+    });
+
+    test('invalid version to bump to is provided', () async {
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'version': '1.2.3',
+        })
+      ]).create();
+
+      await pubBump(
+          args: ['a.b.c'],
+          error: contains('Invalid version a.b.c found.'),
+          exitCode: exit_codes.USAGE);
+    });
   });
 }

--- a/test/bump/bump_test.dart
+++ b/test/bump/bump_test.dart
@@ -1,0 +1,136 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+void main() {
+  test('default bump', () async {
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.3',
+      })
+    ]).create();
+
+    await pubBump(output: contains('1.2.3 to 1.2.4'));
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.4',
+      })
+    ]).validate();
+  });
+
+  test('bump with pre-release', () async {
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.3-dev',
+      })
+    ]).create();
+
+    await pubBump(output: contains('1.2.3-dev to 1.2.3'));
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.3',
+      })
+    ]).validate();
+  });
+
+  test('bump with build', () async {
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.3+build.1',
+      })
+    ]).create();
+
+    await pubBump(output: contains('1.2.3+build.1 to 1.2.4'));
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.4',
+      })
+    ]).validate();
+  });
+
+  test('bump with build and pre-release', () async {
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.3-alpha+build.1',
+      })
+    ]).create();
+
+    await pubBump(output: contains('1.2.3-alpha+build.1 to 1.2.3'));
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.3',
+      })
+    ]).validate();
+  });
+
+  test('bump major', () async {
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.3',
+      })
+    ]).create();
+
+    await pubBump(args: ['--major'], output: contains('1.2.3 to 2.0.0'));
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '2.0.0',
+      })
+    ]).validate();
+  });
+
+  test('bump minor', () async {
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.3',
+      })
+    ]).create();
+
+    await pubBump(args: ['--minor'], output: contains('1.2.3 to 1.3.0'));
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.3.0',
+      })
+    ]).validate();
+  });
+
+  test('bump patch', () async {
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.3',
+      })
+    ]).create();
+
+    await pubBump(output: contains('1.2.3 to 1.2.4'));
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'version': '1.2.4',
+      })
+    ]).validate();
+  });
+}

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -12,6 +12,7 @@ import 'package:path/path.dart' as p;
 
 import 'descriptor/git.dart';
 import 'descriptor/packages.dart';
+import 'descriptor/pubspec.dart';
 import 'descriptor/tar.dart';
 import 'test_pub.dart';
 
@@ -48,8 +49,8 @@ FileDescriptor outOfDateSnapshot(String name) =>
 ///
 /// [contents] may contain [Future]s that resolve to serializable objects,
 /// which may in turn contain [Future]s recursively.
-Descriptor pubspec(Map<String, Object> contents) =>
-    file('pubspec.yaml', yaml(contents));
+PubspecDescriptor pubspec(Map<String, Object> contents) =>
+    PubspecDescriptor('pubspec.yaml', yaml(contents));
 
 /// Describes a file named `pubspec.yaml` for an application package with the
 /// given [dependencies].

--- a/test/descriptor/pubspec.dart
+++ b/test/descriptor/pubspec.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async' show Future;
+import 'dart:convert' show utf8;
+import 'dart:io';
+
+import 'package:collection/collection.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart';
+import 'package:yaml_edit/yaml_edit.dart';
+
+import '../descriptor.dart';
+
+class PubspecDescriptor extends FileDescriptor {
+  final String _contents;
+
+  PubspecDescriptor(String name, this._contents) : super.protected(name);
+
+  @override
+  Future<String> read() async => _contents;
+
+  @override
+  Stream<List<int>> readAsBytes() =>
+      Stream.fromIterable([utf8.encode(_contents)]);
+
+  @override
+  Future validate([String parent]) async {
+    var fullPath = p.join(parent ?? sandbox, name);
+    if (!await File(fullPath).exists()) {
+      fail("File not found: '$fullPath'.");
+    }
+
+    var bytes = await File(fullPath).readAsBytes();
+
+    final actualContentsText = utf8.decode(bytes);
+    final actualYaml = YamlEditor(actualContentsText);
+    final expectedYaml = YamlEditor(_contents);
+
+    final actual = actualYaml.parseAt([]);
+    final expected = expectedYaml.parseAt([]);
+
+    if (!MapEquality().equals(expected.value, actual.value)) {
+      fail('Expected $expected, found: $actual');
+    }
+  }
+}

--- a/test/pub_test.dart
+++ b/test/pub_test.dart
@@ -29,6 +29,7 @@ void main() {
         -v, --verbose          Shortcut for "--verbosity=all".
 
         Available commands:
+          bump        Updates the version of the current package in pubspec.yaml.
           cache       Work with the system cache.
           deps        Print package dependencies.
           downgrade   Downgrade the current package's dependencies to oldest versions.

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -83,6 +83,8 @@ final versionSuffix = testVersion ?? sdk.version;
 /// Enum identifying a pub command that can be run with a well-defined success
 /// output.
 class RunCommand {
+  static final bump =
+      RunCommand('bump', RegExp(r'Successfully updated version from'));
   static final get = RunCommand(
       'get', RegExp(r'Got dependencies!|Changed \d+ dependenc(y|ies)!'));
   static final upgrade = RunCommand('upgrade', RegExp(r'''
@@ -151,6 +153,21 @@ Future pubCommand(RunCommand command,
       exitCode: exitCode,
       environment: environment);
 }
+
+Future pubBump(
+        {Iterable<String> args,
+        output,
+        error,
+        warning,
+        int exitCode,
+        Map<String, String> environment}) =>
+    pubCommand(RunCommand.bump,
+        args: args,
+        output: output,
+        error: error,
+        warning: warning,
+        exitCode: exitCode,
+        environment: environment);
 
 Future pubGet(
         {Iterable<String> args,


### PR DESCRIPTION
Updates the version of the current package in `pubspec.yaml`. By default, it bumps the version up to the nearest stable patch number. Users may pass in the `--major|--minor|--patch`, which bumps the version up to the nearest stable major/minor/patch numbers accordingly. Users may also pass in a version number as an argument, and the version number will be bumped to the argument accordingly.

**Examples**
1. `pub bump` 1.2.3 -> 1.2.4
2. `pub bump` 1.2.3-dev -> 1.2.3
3. `pub bump --major` 1.2.3 -> 2.0.0
4. `pub bump --minor` 1.2.3 -> 1.3.0
5. `pub bump 3.0.0` 1.2.3 -> 3.0.0