### PR TITLE
pub upgrade --major-versions

### DIFF
--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -98,7 +98,7 @@ class OutdatedCommand extends PubCommand {
         ? rootPubspec
         : stripDevDependencies(rootPubspec);
 
-    final resolvablePubspec = stripVersionConstraints(upgradablePubspec);
+    final resolvablePubspec = removeVersionUpperBounds(upgradablePubspec);
 
     List<PackageId> upgradablePackages;
     List<PackageId> resolvablePackages;

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -96,6 +96,12 @@ class UpgradeCommand extends PubCommand {
       for (final package in allDependencies) {
         final resolvedPackage = resolvablePackages[package.name];
 
+        /// If packages were specified on the command line, [dependencyChanges]
+        /// will only contain the changes made to those packages since we do
+        /// not modify the package constraints of other packages, so there is
+        /// never a case where
+        /// `!package.constraint.allows(resolvedPackage.version)` evaluates to
+        /// true.
         if (resolvedPackage != null &&
             !package.constraint.allows(resolvedPackage.version) &&
             package.source is HostedSource) {

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -3,10 +3,20 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
+
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml_edit/yaml_edit.dart';
 
 import '../command.dart';
+import '../entrypoint.dart';
+import '../io.dart';
 import '../log.dart' as log;
+import '../package.dart';
+import '../package_name.dart';
+import '../pubspec.dart';
 import '../solver.dart';
+import '../source/hosted.dart';
 
 /// Handles the `upgrade` pub command.
 class UpgradeCommand extends PubCommand {
@@ -23,6 +33,9 @@ class UpgradeCommand extends PubCommand {
   @override
   bool get isOffline => argResults['offline'];
 
+  /// Avoid showing spinning progress messages when not in a terminal.
+  bool get _shouldShowSpinner => stdout.hasTerminal;
+
   UpgradeCommand() {
     argParser.addFlag('offline',
         help: 'Use cached packages instead of accessing the network.');
@@ -36,6 +49,10 @@ class UpgradeCommand extends PubCommand {
         help: 'Precompile executables in immediate dependencies.');
 
     argParser.addFlag('packages-dir', hide: true);
+
+    argParser.addFlag('breaking',
+        help: 'Upgrades packages to their latest resolvable version, '
+            'and updates pubspec.yaml');
   }
 
   @override
@@ -44,14 +61,142 @@ class UpgradeCommand extends PubCommand {
       log.warning(log.yellow(
           'The --packages-dir flag is no longer used and does nothing.'));
     }
-    await entrypoint.acquireDependencies(SolveType.UPGRADE,
-        useLatest: argResults.rest,
-        dryRun: argResults['dry-run'],
-        precompile: argResults['precompile']);
+
+    if (argResults.wasParsed('breaking')) {
+      final rootPubspec = entrypoint.root.pubspec;
+      final resolvablePubspec = _stripVersionConstraints(rootPubspec);
+
+      Map<String, PackageId> resolvablePackages;
+      await log.spinner('Resolving', () async {
+        resolvablePackages = await _tryResolve(resolvablePubspec);
+      }, condition: _shouldShowSpinner);
+
+      final dependencyChanges = <PackageRange, PackageId>{};
+
+      for (var package in entrypoint.root.pubspec.dependencies.values) {
+        final resolvedPackage = resolvablePackages[package.name];
+
+        if (resolvedPackage != null &&
+            !package.constraint.allows(resolvedPackage.version) &&
+            package.source is HostedSource) {
+          dependencyChanges[package] = resolvedPackage;
+        }
+      }
+      if (!argResults['dry-run']) {
+        await _writeToPubspec(dependencyChanges);
+        await Entrypoint.current(cache).acquireDependencies(SolveType.UPGRADE);
+      }
+
+      _outputHuman(dependencyChanges, argResults['dry-run']);
+    } else {
+      await entrypoint.acquireDependencies(SolveType.UPGRADE,
+          useLatest: argResults.rest,
+          dryRun: argResults['dry-run'],
+          precompile: argResults['precompile']);
+    }
 
     if (isOffline) {
       log.warning('Warning: Upgrading when offline may not update you to the '
           'latest versions of your dependencies.');
     }
   }
+
+  /// Writes the differences between [resolvedPackages] and the current
+  /// dependencies to the pubspec file.
+  Future<void> _writeToPubspec(
+      Map<PackageRange, PackageId> dependencyChanges) async {
+    ArgumentError.checkNotNull(dependencyChanges, 'dependencyChanges');
+
+    if (dependencyChanges.isEmpty) return;
+
+    final yamlEditor = YamlEditor(readTextFile(entrypoint.pubspecPath));
+
+    for (final finalPackage in dependencyChanges.values) {
+      // TODO(walnut): handle changes in dev dependencies too
+      yamlEditor.update(
+          ['dependencies', finalPackage.name], '^${finalPackage.version}');
+    }
+
+    /// Windows line endings are already handled by [yamlEditor]
+    writeTextFile(entrypoint.pubspecPath, yamlEditor.toString());
+  }
+
+  /// Try to solve [pubspec] return [PackageId]'s in the resolution or `null`.
+  Future<Map<String, PackageId>> _tryResolve(Pubspec pubspec) async {
+    try {
+      final resolvedPackages = (await resolveVersions(
+        SolveType.UPGRADE,
+        cache,
+        Package.inMemory(pubspec),
+      ))
+          .packages;
+
+      final result = <String, PackageId>{};
+
+      for (final resolvedPackage in resolvedPackages) {
+        result[resolvedPackage.name] = resolvedPackage;
+      }
+
+      return result;
+    } on SolveFailure {
+      return <String, PackageId>{};
+    }
+  }
+}
+
+/// Outputs a summary of changes that will be made
+void _outputHuman(
+    Map<PackageRange, PackageId> dependencyChanges, bool isDryRun) {
+  ArgumentError.checkNotNull(dependencyChanges, 'dependencyChanges');
+
+  if (dependencyChanges.isEmpty) {
+    log.message('No breaking changes detected!');
+  } else {
+    if (isDryRun) {
+      log.message(
+          '${dependencyChanges.length} breaking change(s) would have been made:');
+    } else {
+      log.message(
+          '${dependencyChanges.length} breaking change(s) have been made:');
+    }
+
+    for (final change in dependencyChanges.entries) {
+      final initialPackage = change.key;
+      final finalPackage = change.value;
+
+      log.message('${initialPackage.name}: ${initialPackage.constraint} -> '
+          '^${finalPackage.version}');
+    }
+  }
+}
+
+/// Returns new pubspec with the same dependencies as [original] but with no
+/// version constraints on hosted packages.
+Pubspec _stripVersionConstraints(Pubspec original) {
+  List<PackageRange> _unconstrained(Map<String, PackageRange> constrained) {
+    final result = <PackageRange>[];
+    for (final name in constrained.keys) {
+      final packageRange = constrained[name];
+      var unconstrainedRange = packageRange;
+      if (packageRange.source is HostedSource) {
+        unconstrainedRange = PackageRange(
+            packageRange.name,
+            packageRange.source,
+            VersionConstraint.any,
+            packageRange.description,
+            features: packageRange.features);
+      }
+      result.add(unconstrainedRange);
+    }
+    return result;
+  }
+
+  return Pubspec(
+    original.name,
+    version: original.version,
+    sdkConstraints: original.sdkConstraints,
+    dependencies: _unconstrained(original.dependencies),
+    devDependencies: _unconstrained(original.devDependencies),
+    dependencyOverrides: original.dependencyOverrides.values,
+  );
 }

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -71,7 +71,7 @@ class UpgradeCommand extends PubCommand {
       ];
 
       final resolvablePubspec =
-          stripVersionConstraints(rootPubspec, upgradeOnly: upgradeOnly);
+          removeVersionUpperBounds(rootPubspec, upgradeOnly: upgradeOnly);
 
       /// Solve [resolvablePubspec] and consolidate the resolved versions of the
       /// packages into a map for quick searching.

--- a/lib/src/pubspec_utils.dart
+++ b/lib/src/pubspec_utils.dart
@@ -2,11 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:pub_semver/pub_semver.dart';
-
 import 'package_name.dart';
 import 'pubspec.dart';
 import 'source/hosted.dart';
+import 'utils.dart';
 
 /// Returns a new [Pubspec] without [original]'s dev_dependencies.
 Pubspec stripDevDependencies(Pubspec original) {
@@ -32,8 +31,11 @@ Pubspec stripDependencyOverrides(Pubspec original) {
   );
 }
 
-/// Returns new pubspec with the same dependencies as [original] but with no
-/// version constraints on hosted packages.
+/// Returns new pubspec with the same dependencies as [original] but with the
+/// upper bounds of the constraints removed.
+///
+/// If [upgradeOnly] is provided, only the packages whose names are in
+/// [upgradeOnly] will have their upper bounds removed.
 Pubspec stripVersionConstraints(Pubspec original, {List<String> upgradeOnly}) {
   upgradeOnly ??= [];
 
@@ -50,7 +52,7 @@ Pubspec stripVersionConstraints(Pubspec original, {List<String> upgradeOnly}) {
         unconstrainedRange = PackageRange(
             packageRange.name,
             packageRange.source,
-            VersionConstraint.any,
+            removeUpperBound(packageRange.constraint),
             packageRange.description,
             features: packageRange.features);
       }

--- a/lib/src/pubspec_utils.dart
+++ b/lib/src/pubspec_utils.dart
@@ -9,6 +9,8 @@ import 'utils.dart';
 
 /// Returns a new [Pubspec] without [original]'s dev_dependencies.
 Pubspec stripDevDependencies(Pubspec original) {
+  ArgumentError.checkNotNull(original, 'original pubspec');
+
   return Pubspec(
     original.name,
     version: original.version,
@@ -21,6 +23,8 @@ Pubspec stripDevDependencies(Pubspec original) {
 
 /// Returns a new [Pubspec] without [original]'s dependency_overrides.
 Pubspec stripDependencyOverrides(Pubspec original) {
+  ArgumentError.checkNotNull(original, 'original pubspec');
+
   return Pubspec(
     original.name,
     version: original.version,
@@ -37,9 +41,10 @@ Pubspec stripDependencyOverrides(Pubspec original) {
 /// If [upgradeOnly] is provided, only the packages whose names are in
 /// [upgradeOnly] will have their upper bounds removed.
 Pubspec removeVersionUpperBounds(Pubspec original, {List<String> upgradeOnly}) {
+  ArgumentError.checkNotNull(original, 'original pubspec');
   upgradeOnly ??= [];
 
-  List<PackageRange> _unconstrained(
+  List<PackageRange> _removeUpperConstraints(
     Map<String, PackageRange> constrained,
   ) {
     final result = <PackageRange>[];
@@ -47,6 +52,8 @@ Pubspec removeVersionUpperBounds(Pubspec original, {List<String> upgradeOnly}) {
     for (final name in constrained.keys) {
       final packageRange = constrained[name];
       var unconstrainedRange = packageRange;
+
+      /// We only need to remove the upper bound if it is a hosted package.
       if (packageRange.source is HostedSource &&
           (upgradeOnly.isEmpty || upgradeOnly.contains(packageRange.name))) {
         unconstrainedRange = PackageRange(
@@ -66,8 +73,8 @@ Pubspec removeVersionUpperBounds(Pubspec original, {List<String> upgradeOnly}) {
     original.name,
     version: original.version,
     sdkConstraints: original.sdkConstraints,
-    dependencies: _unconstrained(original.dependencies),
-    devDependencies: _unconstrained(original.devDependencies),
+    dependencies: _removeUpperConstraints(original.dependencies),
+    devDependencies: _removeUpperConstraints(original.devDependencies),
     dependencyOverrides: original.dependencyOverrides.values,
   );
 }

--- a/lib/src/pubspec_utils.dart
+++ b/lib/src/pubspec_utils.dart
@@ -1,0 +1,71 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_semver/pub_semver.dart';
+
+import 'package_name.dart';
+import 'pubspec.dart';
+import 'source/hosted.dart';
+
+/// Returns a new [Pubspec] without [original]'s dev_dependencies.
+Pubspec stripDevDependencies(Pubspec original) {
+  return Pubspec(
+    original.name,
+    version: original.version,
+    sdkConstraints: original.sdkConstraints,
+    dependencies: original.dependencies.values,
+    devDependencies: [], // explicitly give empty list, to prevent lazy parsing
+    dependencyOverrides: original.dependencyOverrides.values,
+  );
+}
+
+/// Returns a new [Pubspec] without [original]'s dependency_overrides.
+Pubspec stripDependencyOverrides(Pubspec original) {
+  return Pubspec(
+    original.name,
+    version: original.version,
+    sdkConstraints: original.sdkConstraints,
+    dependencies: original.dependencies.values,
+    devDependencies: original.devDependencies.values,
+    dependencyOverrides: [],
+  );
+}
+
+/// Returns new pubspec with the same dependencies as [original] but with no
+/// version constraints on hosted packages.
+Pubspec stripVersionConstraints(Pubspec original, {List<String> upgradeOnly}) {
+  upgradeOnly ??= [];
+
+  List<PackageRange> _unconstrained(
+    Map<String, PackageRange> constrained,
+  ) {
+    final result = <PackageRange>[];
+
+    for (final name in constrained.keys) {
+      final packageRange = constrained[name];
+      var unconstrainedRange = packageRange;
+      if (packageRange.source is HostedSource &&
+          (upgradeOnly.isEmpty || upgradeOnly.contains(packageRange.name))) {
+        unconstrainedRange = PackageRange(
+            packageRange.name,
+            packageRange.source,
+            VersionConstraint.any,
+            packageRange.description,
+            features: packageRange.features);
+      }
+      result.add(unconstrainedRange);
+    }
+
+    return result;
+  }
+
+  return Pubspec(
+    original.name,
+    version: original.version,
+    sdkConstraints: original.sdkConstraints,
+    dependencies: _unconstrained(original.dependencies),
+    devDependencies: _unconstrained(original.devDependencies),
+    dependencyOverrides: original.dependencyOverrides.values,
+  );
+}

--- a/lib/src/pubspec_utils.dart
+++ b/lib/src/pubspec_utils.dart
@@ -36,7 +36,7 @@ Pubspec stripDependencyOverrides(Pubspec original) {
 ///
 /// If [upgradeOnly] is provided, only the packages whose names are in
 /// [upgradeOnly] will have their upper bounds removed.
-Pubspec stripVersionConstraints(Pubspec original, {List<String> upgradeOnly}) {
+Pubspec removeVersionUpperBounds(Pubspec original, {List<String> upgradeOnly}) {
   upgradeOnly ??= [];
 
   List<PackageRange> _unconstrained(

--- a/lib/src/solver.dart
+++ b/lib/src/solver.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'lock_file.dart';
 import 'package.dart';
+import 'solver/failure.dart';
 import 'solver/result.dart';
 import 'solver/type.dart';
 import 'solver/version_solver.dart';
@@ -35,4 +36,28 @@ Future<SolveResult> resolveVersions(
     lockFile ?? LockFile.empty(),
     useLatest ?? const [],
   ).solve();
+}
+
+/// Attempts to select the best concrete versions for all of the transitive
+/// dependencies of [root] taking into account all of the [VersionConstraint]s
+/// that those dependencies place on each other and the requirements imposed by
+/// [lockFile].
+///
+/// Like [resolveVersions] except that this function returns `null` where a
+/// similar call to [resolveVersions] would throw a [SolveFailure].
+///
+/// If [useLatest] is given, then only the latest versions of the referenced
+/// packages will be used. This is for forcing an upgrade to one or more
+/// packages.
+///
+/// If [upgradeAll] is true, the contents of [lockFile] are ignored.
+Future<SolveResult> tryResolveVersions(
+    SolveType type, SystemCache cache, Package root,
+    {LockFile lockFile, Iterable<String> useLatest}) async {
+  try {
+    return await resolveVersions(type, cache, root,
+        lockFile: lockFile, useLatest: useLatest);
+  } on SolveFailure {
+    return null;
+  }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -637,6 +637,8 @@ Map<K2, V2> mapMap<K1, V1, K2, V2>(
 /// Removes the upper bound of [constraint]. [constraint] must not be the
 /// empty version constraint.
 VersionRange removeUpperBound(VersionConstraint constraint) {
+  ArgumentError.checkNotNull(constraint, 'constraint');
+
   /// A [VersionConstraint] has to either be a [VersionRange], [VersionUnion],
   /// or the empty [VersionConstraint].
   if (constraint is VersionRange) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -619,3 +619,20 @@ Map<K2, V2> mapMap<K1, V1, K2, V2>(
       key(entry.key, entry.value): value(entry.key, entry.value),
   };
 }
+
+/// Removes the upper bound of [constraint]. [constraint] must not be the
+/// empty version constraint.
+VersionRange removeUpperBound(VersionConstraint constraint) {
+  /// A [VersionConstraint] has to either be a [VersionRange], [VersionUnion],
+  /// or the empty [VersionConstraint].
+  if (constraint is VersionRange) {
+    return VersionRange(min: constraint.min, includeMin: constraint.includeMin);
+  }
+
+  if (constraint is VersionUnion && constraint.ranges.isNotEmpty) {
+    final firstRange = constraint.ranges.first;
+    return VersionRange(min: firstRange.min, includeMin: firstRange.includeMin);
+  }
+
+  throw UnsupportedError('Unable to remove upper bound of empty constraint!');
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,10 @@ dependencies:
   source_span: ^1.4.0
   stack_trace: ^1.0.0
   yaml: ^2.2.0
+  yaml_edit:
+    git:
+      url: https://github.com/walnutdust/yaml_edit/
+      ref: development
 
 dev_dependencies:
   shelf_test_handler: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,10 +28,7 @@ dependencies:
   source_span: ^1.4.0
   stack_trace: ^1.0.0
   yaml: ^2.2.0
-  yaml_edit:
-    git:
-      url: https://github.com/walnutdust/yaml_edit/
-      ref: development
+  yaml_edit: ^1.0.0
 
 dev_dependencies:
   shelf_test_handler: ^1.0.0

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -12,6 +12,7 @@ import 'package:path/path.dart' as p;
 
 import 'descriptor/git.dart';
 import 'descriptor/packages.dart';
+import 'descriptor/pubspec.dart';
 import 'descriptor/tar.dart';
 import 'test_pub.dart';
 
@@ -48,8 +49,8 @@ FileDescriptor outOfDateSnapshot(String name) =>
 ///
 /// [contents] may contain [Future]s that resolve to serializable objects,
 /// which may in turn contain [Future]s recursively.
-Descriptor pubspec(Map<String, Object> contents) =>
-    file('pubspec.yaml', yaml(contents));
+PubspecDescriptor pubspec(Map<String, Object> contents) =>
+    PubspecDescriptor('pubspec.yaml', yaml(contents));
 
 /// Describes a file named `pubspec.yaml` for an application package with the
 /// given [dependencies].

--- a/test/descriptor/pubspec.dart
+++ b/test/descriptor/pubspec.dart
@@ -42,7 +42,7 @@ class PubspecDescriptor extends FileDescriptor {
     final actual = actualYaml.parseAt([]);
     final expected = expectedYaml.parseAt([]);
 
-    if (!MapEquality().equals(expected.value, actual.value)) {
+    if (!DeepCollectionEquality().equals(expected.value, actual.value)) {
       fail('Expected $expected, found: $actual');
     }
   }

--- a/test/descriptor/pubspec.dart
+++ b/test/descriptor/pubspec.dart
@@ -6,6 +6,7 @@ import 'dart:async' show Future;
 import 'dart:convert' show utf8;
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart';
@@ -41,7 +42,7 @@ class PubspecDescriptor extends FileDescriptor {
     final actual = actualYaml.parseAt([]);
     final expected = expectedYaml.parseAt([]);
 
-    if (!deepEquals(expected, actual)) {
+    if (!MapEquality().equals(expected.value, actual.value)) {
       fail('Expected $expected, found: $actual');
     }
   }

--- a/test/descriptor/pubspec.dart
+++ b/test/descriptor/pubspec.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async' show Future;
+import 'dart:convert' show utf8;
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart';
+import 'package:yaml_edit/yaml_edit.dart';
+
+import '../descriptor.dart';
+
+class PubspecDescriptor extends FileDescriptor {
+  final String _contents;
+
+  PubspecDescriptor(String name, this._contents) : super.protected(name);
+
+  @override
+  Future<String> read() async => _contents;
+
+  @override
+  Stream<List<int>> readAsBytes() =>
+      Stream.fromIterable([utf8.encode(_contents)]);
+
+  @override
+  Future validate([String parent]) async {
+    var fullPath = p.join(parent ?? sandbox, name);
+    if (!await File(fullPath).exists()) {
+      fail("File not found: '$fullPath'.");
+    }
+
+    var bytes = await File(fullPath).readAsBytes();
+
+    final actualContentsText = utf8.decode(bytes);
+    final actualYaml = YamlEditor(actualContentsText);
+    final expectedYaml = YamlEditor(_contents);
+
+    final actual = actualYaml.parseAt([]);
+    final expected = expectedYaml.parseAt([]);
+
+    if (!deepEquals(expected, actual)) {
+      fail('Expected $expected, found: $actual');
+    }
+  }
+}

--- a/test/upgrade/breaking/applies_changes_test.dart
+++ b/test/upgrade/breaking/applies_changes_test.dart
@@ -34,7 +34,7 @@ void main() {
       await pubUpgrade(
           args: ['--breaking'],
           output: allOf([
-            contains('2 breaking change(s) have been made:'),
+            contains('Detected 2 potential breaking changes:'),
             contains('foo: ^1.0.0 -> ^2.0.0'),
             contains('bar: ^0.1.0 -> ^0.2.0')
           ]));
@@ -88,7 +88,7 @@ void main() {
       await pubUpgrade(
           args: ['--breaking'],
           output: allOf([
-            contains('2 breaking change(s) have been made:'),
+            contains('Detected 2 potential breaking changes:'),
             contains('foo: ^1.0.0 -> ^2.0.0'),
             contains('bar: ^0.1.0 -> ^0.2.0')
           ]));
@@ -126,11 +126,11 @@ void main() {
       // command.
       await d.appDir({'foo': '^1.0.0', 'bar': '^0.1.0'}).create();
 
-      // Only two breaking changes should be detected.
+      // Only one breaking changes should be detected.
       await pubUpgrade(
           args: ['--breaking', 'foo'],
           output: allOf([
-            contains('1 breaking change(s) have been made:'),
+            contains('Detected 1 potential breaking change:'),
             contains('foo: ^1.0.0 -> ^2.0.0'),
           ]));
 
@@ -164,7 +164,7 @@ void main() {
       await pubUpgrade(
           args: ['--breaking'],
           output: allOf([
-            contains('1 breaking change(s) have been made:'),
+            contains('Detected 1 potential breaking change:'),
             contains('foo: 1.0.0 -> ^3.0.0')
           ]));
 

--- a/test/upgrade/breaking/applies_changes_test.dart
+++ b/test/upgrade/breaking/applies_changes_test.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+import 'package:pub/src/io.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('--breaking applies breaking changes and shows summary report',
+      () async {
+    await servePackages((builder) {
+      builder.serve('foo', '1.0.0');
+      builder.serve('foo', '2.0.0');
+    });
+
+    // Create the lockfile.
+    await d.appDir({'foo': '1.0.0'}).create();
+
+    await pubGet();
+
+    // Recreating the appdir because the previous one only lasts for one
+    // command.
+    await d.appDir({'foo': '1.0.0'}).create();
+
+    // Also delete the "packages" directory.
+    deleteEntry(path.join(d.sandbox, appPath, 'packages'));
+
+    // Do the dry run.
+    await pubUpgrade(
+        args: ['--breaking'],
+        output: allOf([
+          contains('1 breaking change(s) have been made:'),
+          contains('foo: 1.0.0 -> ^2.0.0')
+        ]));
+
+    await d.dir(appPath, [
+      // The pubspec file should be modified.
+      d.pubspec({
+        'name': 'myapp',
+        'dependencies': {'foo': '^2.0.0'}
+      }),
+      // The lockfile should be modified.
+      d.file('pubspec.lock', contains('2.0.0')),
+      // The "packages" directory should not have been regenerated.
+      d.nothing('packages')
+    ]).validate();
+  });
+}

--- a/test/upgrade/breaking/applies_changes_test.dart
+++ b/test/upgrade/breaking/applies_changes_test.dart
@@ -263,21 +263,24 @@ void main() {
       });
 
       // Create the lockfile.
-      await d.appDir({'foo': '^1.0.0', 'bar': '2.0.0'}).create();
+      await d.appDir({'foo': '^1.0.0', 'bar': '^2.0.0'}).create();
 
       await pubGet();
 
       // Recreating the appdir because the previous one only lasts for one
       // command.
-      await d.appDir({'foo': '^1.0.0', 'bar': '2.0.0'}).create();
+      await d.appDir({'foo': '^1.0.0', 'bar': '^2.0.0'}).create();
 
-      // Only two breaking changes should be detected.
+      // Only one breaking change should be detected.
       await pubUpgrade(
-          args: ['--breaking'], output: contains('No breaking changes deasda'));
+          args: ['--breaking'],
+          output: allOf([
+            contains('Detected 1 potential breaking change:'),
+            contains('bar: ^2.0.0 -> ^4.0.0')
+          ]));
 
-      await d.appDir({'foo': '^1.0.0', 'bar': '^2.0.0'}).validate();
-
-      await d.appPackagesFile({'foo': '^1.0.0', 'bar': '^2.0.0'}).validate();
+      await d.appDir({'foo': '^1.0.0', 'bar': '^4.0.0'}).validate();
+      await d.appPackagesFile({'foo': '1.0.0', 'bar': '4.0.0'}).validate();
     });
   });
 }

--- a/test/upgrade/breaking/applies_changes_test.dart
+++ b/test/upgrade/breaking/applies_changes_test.dart
@@ -1,53 +1,250 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
-
-import 'package:pub/src/io.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
 
 void main() {
-  test('--breaking applies breaking changes and shows summary report',
-      () async {
-    await servePackages((builder) {
-      builder.serve('foo', '1.0.0');
-      builder.serve('foo', '2.0.0');
+  group('--breaking', () {
+    test('applies breaking changes and shows summary report', () async {
+      await servePackages((builder) {
+        builder.serve('foo', '1.0.0');
+        builder.serve('foo', '2.0.0');
+        builder.serve('bar', '0.1.0');
+        builder.serve('bar', '0.2.0');
+        builder.serve('baz', '1.0.0');
+        builder.serve('baz', '1.0.1');
+      });
+
+      // Create the lockfile.
+      await d
+          .appDir({'foo': '^1.0.0', 'bar': '^0.1.0', 'baz': '^1.0.0'}).create();
+
+      await pubGet();
+
+      // Recreating the appdir because the previous one only lasts for one
+      // command.
+      await d
+          .appDir({'foo': '^1.0.0', 'bar': '^0.1.0', 'baz': '^1.0.0'}).create();
+
+      // Only two breaking changes should be detected.
+      await pubUpgrade(
+          args: ['--breaking'],
+          output: allOf([
+            contains('2 breaking change(s) have been made:'),
+            contains('foo: ^1.0.0 -> ^2.0.0'),
+            contains('bar: ^0.1.0 -> ^0.2.0')
+          ]));
+
+      await d.appDir(
+          {'foo': '^2.0.0', 'bar': '^0.2.0', 'baz': '^1.0.0'}).validate();
+
+      await d.appPackagesFile(
+          {'foo': '2.0.0', 'bar': '0.2.0', 'baz': '1.0.1'}).validate();
+    });
+    test(
+        'applies breaking changes and shows summary report for dev dependencies',
+        () async {
+      await servePackages((builder) {
+        builder.serve('foo', '1.0.0');
+        builder.serve('foo', '2.0.0');
+        builder.serve('bar', '0.1.0');
+        builder.serve('bar', '0.2.0');
+        builder.serve('baz', '1.0.0');
+        builder.serve('baz', '1.0.1');
+      });
+
+      // Create the lockfile.
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'dev_dependencies': {
+            'foo': '^1.0.0',
+            'bar': '^0.1.0',
+            'baz': '^1.0.0'
+          }
+        })
+      ]).create();
+
+      await pubGet();
+
+      // Recreating the appdir because the previous one only lasts for one
+      // command.
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'dev_dependencies': {
+            'foo': '^1.0.0',
+            'bar': '^0.1.0',
+            'baz': '^1.0.0'
+          }
+        })
+      ]).create();
+
+      // Only two breaking changes should be detected.
+      await pubUpgrade(
+          args: ['--breaking'],
+          output: allOf([
+            contains('2 breaking change(s) have been made:'),
+            contains('foo: ^1.0.0 -> ^2.0.0'),
+            contains('bar: ^0.1.0 -> ^0.2.0')
+          ]));
+
+      await d.dir(appPath, [
+        // The pubspec file should be modified.
+        d.pubspec({
+          'name': 'myapp',
+          'dev_dependencies': {
+            'foo': '^2.0.0',
+            'bar': '^0.2.0',
+            'baz': '^1.0.0'
+          }
+        }),
+      ]).validate();
+
+      await d.appPackagesFile(
+          {'foo': '2.0.0', 'bar': '0.2.0', 'baz': '1.0.1'}).validate();
     });
 
-    // Create the lockfile.
-    await d.appDir({'foo': '1.0.0'}).create();
+    test('upgrades only a selected package', () async {
+      await servePackages((builder) {
+        builder.serve('foo', '1.0.0');
+        builder.serve('foo', '2.0.0');
+        builder.serve('bar', '0.1.0');
+        builder.serve('bar', '0.2.0');
+      });
 
-    await pubGet();
+      // Create the lockfile.
+      await d.appDir({'foo': '^1.0.0', 'bar': '^0.1.0'}).create();
 
-    // Recreating the appdir because the previous one only lasts for one
-    // command.
-    await d.appDir({'foo': '1.0.0'}).create();
+      await pubGet();
 
-    // Also delete the "packages" directory.
-    deleteEntry(path.join(d.sandbox, appPath, 'packages'));
+      // Recreating the appdir because the previous one only lasts for one
+      // command.
+      await d.appDir({'foo': '^1.0.0', 'bar': '^0.1.0'}).create();
 
-    // Do the dry run.
-    await pubUpgrade(
-        args: ['--breaking'],
-        output: allOf([
-          contains('1 breaking change(s) have been made:'),
-          contains('foo: 1.0.0 -> ^2.0.0')
-        ]));
+      // Only two breaking changes should be detected.
+      await pubUpgrade(
+          args: ['--breaking', 'foo'],
+          output: allOf([
+            contains('1 breaking change(s) have been made:'),
+            contains('foo: ^1.0.0 -> ^2.0.0'),
+          ]));
 
-    await d.dir(appPath, [
-      // The pubspec file should be modified.
-      d.pubspec({
-        'name': 'myapp',
-        'dependencies': {'foo': '^2.0.0'}
-      }),
-      // The lockfile should be modified.
-      d.file('pubspec.lock', contains('2.0.0')),
-      // The "packages" directory should not have been regenerated.
-      d.nothing('packages')
-    ]).validate();
+      await d.dir(appPath, [
+        // The pubspec file should be modified.
+        d.pubspec({
+          'name': 'myapp',
+          'dependencies': {'foo': '^2.0.0', 'bar': '^0.1.0'}
+        }),
+      ]).validate();
+
+      await d.appPackagesFile({'foo': '2.0.0', 'bar': '0.1.0'}).validate();
+    });
+
+    test('chooses the latest version where possible', () async {
+      await servePackages((builder) {
+        builder.serve('foo', '1.0.0');
+        builder.serve('foo', '2.0.0');
+        builder.serve('foo', '3.0.0');
+      });
+
+      // Create the lockfile.
+      await d.appDir({'foo': '1.0.0'}).create();
+
+      await pubGet();
+
+      // Recreating the appdir because the previous one only lasts for one
+      // command.
+      await d.appDir({'foo': '1.0.0'}).create();
+
+      await pubUpgrade(
+          args: ['--breaking'],
+          output: allOf([
+            contains('1 breaking change(s) have been made:'),
+            contains('foo: 1.0.0 -> ^3.0.0')
+          ]));
+
+      await d.dir(appPath, [
+        // The pubspec file should be modified.
+        d.pubspec({
+          'name': 'myapp',
+          'dependencies': {'foo': '^3.0.0'}
+        }),
+        // The lockfile should be modified.
+        d.file('pubspec.lock', contains('3.0.0'))
+      ]).validate();
+
+      await d.appPackagesFile({'foo': '3.0.0'}).validate();
+    });
+
+    test('overridden dependencies - no resolution', () async {
+      ensureGit();
+      await servePackages(
+        (builder) => builder
+          ..serve('foo', '1.0.0', deps: {'bar': '^2.0.0'})
+          ..serve('foo', '2.0.0', deps: {'bar': '^1.0.0'})
+          ..serve('bar', '1.0.0', deps: {'foo': '^1.0.0'})
+          ..serve('bar', '2.0.0', deps: {'foo': '^2.0.0'}),
+      );
+
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'app',
+          'version': '1.0.1',
+          'dependencies': {
+            'foo': 'any',
+            'bar': 'any',
+          },
+          'dependency_overrides': {
+            'foo': '1.0.0',
+            'bar': '1.0.0',
+          },
+        })
+      ]).create();
+
+      await pubGet();
+
+      // Recreating the appdir because the previous one only lasts for one
+      // command.
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'version': '1.0.1',
+          'dependencies': {
+            'foo': 'any',
+            'bar': 'any',
+          },
+          'dependency_overrides': {
+            'foo': '1.0.0',
+            'bar': '1.0.0',
+          },
+        })
+      ]).create();
+
+      await pubUpgrade(
+          args: ['--breaking'],
+          output: contains('No breaking changes detected!'));
+
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+          'version': '1.0.1',
+          'dependencies': {
+            'foo': 'any',
+            'bar': 'any',
+          },
+          'dependency_overrides': {
+            'foo': '1.0.0',
+            'bar': '1.0.0',
+          },
+        })
+      ]).validate();
+
+      await d.appPackagesFile({'foo': '1.0.0', 'bar': '1.0.0'}).validate();
+    });
   });
 }

--- a/test/upgrade/dry_run_does_not_apply_changes_test.dart
+++ b/test/upgrade/dry_run_does_not_apply_changes_test.dart
@@ -43,4 +43,40 @@ void main() {
       d.nothing('packages')
     ]).validate();
   });
+
+  test(
+      '--dry-run shows report but does not apply changes even with breaking flag',
+      () async {
+    await servePackages((builder) {
+      builder.serve('foo', '1.0.0');
+      builder.serve('foo', '2.0.0');
+    });
+
+    // Create the lockfile.
+    await d.appDir({'foo': '1.0.0'}).create();
+
+    await pubGet();
+
+    // Recreating the appdir because the previous one only lasts for one
+    // command.
+    await d.appDir({'foo': '1.0.0'}).create();
+
+    // Also delete the "packages" directory.
+    deleteEntry(path.join(d.sandbox, appPath, 'packages'));
+
+    // Do the dry run.
+    await pubUpgrade(
+        args: ['--dry-run', '--breaking'],
+        output: allOf([
+          contains('1 breaking change(s) would have been made:'),
+          contains('foo: 1.0.0 -> ^2.0.0')
+        ]));
+
+    await d.dir(appPath, [
+      // The lockfile should not be modified.
+      d.file('pubspec.lock', contains('2.0.0')),
+      // The "packages" directory should not have been regenerated.
+      d.nothing('packages')
+    ]).validate();
+  });
 }

--- a/test/upgrade/dry_run_does_not_apply_changes_test.dart
+++ b/test/upgrade/dry_run_does_not_apply_changes_test.dart
@@ -68,7 +68,7 @@ void main() {
     await pubUpgrade(
         args: ['--dry-run', '--breaking'],
         output: allOf([
-          contains('1 breaking change(s) would have been made:'),
+          contains('Detected 1 potential breaking change:'),
           contains('foo: 1.0.0 -> ^2.0.0')
         ]));
 

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:pub/src/utils.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -160,6 +161,67 @@ b: {}'''));
         completer('aa').complete();
         await w;
       }
+    });
+  });
+
+  group('removeUpperBound', () {
+    test('works on version range', () {
+      final constraint = VersionConstraint.parse('>=1.0.0 <3.0.0');
+      final removedUpperBound = removeUpperBound(constraint);
+
+      expect(removedUpperBound.min, equals(Version(1, 0, 0)));
+      expect(removedUpperBound.includeMin, isTrue);
+      expect(removedUpperBound.max, isNull);
+    });
+
+    test('works on version range exclude min', () {
+      final constraint = VersionConstraint.parse('>0.0.1 <5.0.0');
+      final removedUpperBound = removeUpperBound(constraint);
+
+      expect(removedUpperBound.min, equals(Version(0, 0, 1)));
+      expect(removedUpperBound.includeMin, isFalse);
+      expect(removedUpperBound.max, isNull);
+    });
+
+    test('works on specific version constraint', () {
+      final constraint = VersionConstraint.parse('1.2.3');
+      final removedUpperBound = removeUpperBound(constraint);
+
+      expect(removedUpperBound.min, equals(Version(1, 2, 3)));
+      expect(removedUpperBound.includeMin, isTrue);
+      expect(removedUpperBound.max, isNull);
+    });
+
+    test('works on compatible version constraint', () {
+      final constraint = VersionConstraint.parse('^1.2.3');
+      final removedUpperBound = removeUpperBound(constraint);
+
+      expect(removedUpperBound.min, equals(Version(1, 2, 3)));
+      expect(removedUpperBound.includeMin, isTrue);
+      expect(removedUpperBound.max, isNull);
+    });
+
+    test('works on compatible version union', () {
+      final constraint1 = VersionConstraint.parse('>=1.2.3 <2.0.0');
+      final constraint2 = VersionConstraint.parse('>2.2.3 <=4.0.0');
+      final constraint = VersionUnion.fromRanges([constraint1, constraint2]);
+
+      final removedUpperBound = removeUpperBound(constraint);
+
+      expect(removedUpperBound.min, equals(Version(1, 2, 3)));
+      expect(removedUpperBound.includeMin, isTrue);
+      expect(removedUpperBound.max, isNull);
+    });
+
+    test('fails when an empty version constraint is provided', () {
+      final constraint = VersionConstraint.empty;
+
+      expect(() => removeUpperBound(constraint), throwsUnsupportedError);
+    });
+
+    test('fails on empty version union', () {
+      final constraint = VersionUnion.fromRanges([]);
+      expect(() => removeUpperBound(constraint), throwsUnsupportedError);
     });
   });
 }


### PR DESCRIPTION
`pub upgrade --bump [<packages>...]`

Updates constraints in pubspec.yaml to allow the latest resolvable version of packages for `<packages>...` specified or all packages if no specific packages are given.

This is similar to removing the upper bound from all constraints, running pub upgrade and adjusting the constraints to have upper bounds again. The motivation for this is to allow for a quick and convenient method to upgrade all the package's dependencies to their latest resolvable version as given in `pub outdated`.

Currently implemented as a hidden flag, pending confirmation on the name.