### PR TITLE
Drop upper bound instead of using "any" while resolving in "pub outdated"

### DIFF
--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -19,8 +19,8 @@ import '../null_safety_analysis.dart';
 import '../package.dart';
 import '../package_name.dart';
 import '../pubspec.dart';
+import '../pubspec_utils.dart';
 import '../solver.dart';
-import '../source/hosted.dart';
 import '../system_cache.dart';
 import '../utils.dart';
 
@@ -94,13 +94,13 @@ class OutdatedCommand extends PubCommand {
 
     final rootPubspec = includeDependencyOverrides
         ? entrypoint.root.pubspec
-        : _stripDependencyOverrides(entrypoint.root.pubspec);
+        : stripDependencyOverrides(entrypoint.root.pubspec);
 
     final upgradablePubspec = includeDevDependencies
         ? rootPubspec
         : stripDevDependencies(rootPubspec);
 
-    final resolvablePubspec = _stripVersionConstraints(upgradablePubspec);
+    final resolvablePubspec = stripVersionUpperBounds(upgradablePubspec);
 
     List<PackageId> upgradablePackages;
     List<PackageId> resolvablePackages;
@@ -322,71 +322,15 @@ class OutdatedCommand extends PubCommand {
   }
 }
 
-/// Try to solve [pubspec] return [PackageId]'s in the resolution or `null`.
+/// Try to solve [pubspec] return [PackageId]s in the resolution or `[]`.
 Future<List<PackageId>> _tryResolve(Pubspec pubspec, SystemCache cache) async {
-  try {
-    return (await resolveVersions(
-      SolveType.UPGRADE,
-      cache,
-      Package.inMemory(pubspec),
-    ))
-        .packages;
-  } on SolveFailure {
+  final solveResult = await tryResolveVersions(
+      SolveType.UPGRADE, cache, Package.inMemory(pubspec));
+  if (solveResult == null) {
     return [];
   }
-}
 
-Pubspec stripDevDependencies(Pubspec original) {
-  return Pubspec(
-    original.name,
-    version: original.version,
-    sdkConstraints: original.sdkConstraints,
-    dependencies: original.dependencies.values,
-    devDependencies: [], // explicitly give empty list, to prevent lazy parsing
-    dependencyOverrides: original.dependencyOverrides.values,
-  );
-}
-
-Pubspec _stripDependencyOverrides(Pubspec original) {
-  return Pubspec(
-    original.name,
-    version: original.version,
-    sdkConstraints: original.sdkConstraints,
-    dependencies: original.dependencies.values,
-    devDependencies: original.devDependencies.values,
-    dependencyOverrides: [],
-  );
-}
-
-/// Returns new pubspec with the same dependencies as [original] but with no
-/// version constraints on hosted packages.
-Pubspec _stripVersionConstraints(Pubspec original) {
-  List<PackageRange> _unconstrained(Map<String, PackageRange> constrained) {
-    final result = <PackageRange>[];
-    for (final name in constrained.keys) {
-      final packageRange = constrained[name];
-      var unconstrainedRange = packageRange;
-      if (packageRange.source is HostedSource) {
-        unconstrainedRange = PackageRange(
-            packageRange.name,
-            packageRange.source,
-            VersionConstraint.any,
-            packageRange.description,
-            features: packageRange.features);
-      }
-      result.add(unconstrainedRange);
-    }
-    return result;
-  }
-
-  return Pubspec(
-    original.name,
-    version: original.version,
-    sdkConstraints: original.sdkConstraints,
-    dependencies: _unconstrained(original.dependencies),
-    devDependencies: _unconstrained(original.devDependencies),
-    dependencyOverrides: original.dependencyOverrides.values,
-  );
+  return solveResult.packages;
 }
 
 Future<void> _outputJson(

--- a/lib/src/pubspec_utils.dart
+++ b/lib/src/pubspec_utils.dart
@@ -1,0 +1,104 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+import 'package_name.dart';
+import 'pubspec.dart';
+import 'source/hosted.dart';
+
+/// Returns a new [Pubspec] without [original]'s dev_dependencies.
+Pubspec stripDevDependencies(Pubspec original) {
+  ArgumentError.checkNotNull(original, 'original pubspec');
+
+  return Pubspec(
+    original.name,
+    version: original.version,
+    sdkConstraints: original.sdkConstraints,
+    dependencies: original.dependencies.values,
+    devDependencies: [], // explicitly give empty list, to prevent lazy parsing
+    dependencyOverrides: original.dependencyOverrides.values,
+  );
+}
+
+/// Returns a new [Pubspec] without [original]'s dependency_overrides.
+Pubspec stripDependencyOverrides(Pubspec original) {
+  ArgumentError.checkNotNull(original, 'original pubspec');
+
+  return Pubspec(
+    original.name,
+    version: original.version,
+    sdkConstraints: original.sdkConstraints,
+    dependencies: original.dependencies.values,
+    devDependencies: original.devDependencies.values,
+    dependencyOverrides: [],
+  );
+}
+
+/// Returns new pubspec with the same dependencies as [original] but with the
+/// upper bounds of the constraints removed.
+///
+/// If [upgradeOnly] is provided, only the packages whose names are in
+/// [upgradeOnly] will have their upper bounds removed.
+Pubspec stripVersionUpperBounds(Pubspec original, {List<String> upgradeOnly}) {
+  ArgumentError.checkNotNull(original, 'original pubspec');
+  upgradeOnly ??= [];
+
+  List<PackageRange> _stripUpperBounds(
+    Map<String, PackageRange> constrained,
+  ) {
+    final result = <PackageRange>[];
+
+    for (final name in constrained.keys) {
+      final packageRange = constrained[name];
+      var unconstrainedRange = packageRange;
+
+      /// We only need to remove the upper bound if it is a hosted package.
+      if (packageRange.source is HostedSource &&
+          (upgradeOnly.isEmpty || upgradeOnly.contains(packageRange.name))) {
+        unconstrainedRange = PackageRange(
+            packageRange.name,
+            packageRange.source,
+            stripUpperBound(packageRange.constraint),
+            packageRange.description,
+            features: packageRange.features);
+      }
+      result.add(unconstrainedRange);
+    }
+
+    return result;
+  }
+
+  return Pubspec(
+    original.name,
+    version: original.version,
+    sdkConstraints: original.sdkConstraints,
+    dependencies: _stripUpperBounds(original.dependencies),
+    devDependencies: _stripUpperBounds(original.devDependencies),
+    dependencyOverrides: original.dependencyOverrides.values,
+  );
+}
+
+/// Removes the upper bound of [constraint]. If [constraint] is the
+/// empty version constraint, an empty version range will be returned.
+@visibleForTesting
+VersionRange stripUpperBound(VersionConstraint constraint) {
+  ArgumentError.checkNotNull(constraint, 'constraint');
+
+  /// A [VersionConstraint] has to either be a [VersionRange], [VersionUnion],
+  /// or the empty [VersionConstraint].
+  if (constraint is VersionRange) {
+    return VersionRange(min: constraint.min, includeMin: constraint.includeMin);
+  }
+
+  if (constraint is VersionUnion && constraint.ranges.isNotEmpty) {
+    final firstRange = constraint.ranges.first;
+    return VersionRange(min: firstRange.min, includeMin: firstRange.includeMin);
+  }
+
+  /// If it gets here, [constraint] is the empty version constraint, so we
+  /// just return an empty version range
+  return VersionRange(min: Version.none, max: Version.none);
+}

--- a/lib/src/solver.dart
+++ b/lib/src/solver.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'lock_file.dart';
 import 'package.dart';
+import 'solver/failure.dart';
 import 'solver/result.dart';
 import 'solver/type.dart';
 import 'solver/version_solver.dart';
@@ -35,4 +36,28 @@ Future<SolveResult> resolveVersions(
     lockFile ?? LockFile.empty(),
     useLatest ?? const [],
   ).solve();
+}
+
+/// Attempts to select the best concrete versions for all of the transitive
+/// dependencies of [root] taking into account all of the [VersionConstraint]s
+/// that those dependencies place on each other and the requirements imposed by
+/// [lockFile].
+///
+/// Like [resolveVersions] except that this function returns `null` where a
+/// similar call to [resolveVersions] would throw a [SolveFailure].
+///
+/// If [useLatest] is given, then only the latest versions of the referenced
+/// packages will be used. This is for forcing an upgrade to one or more
+/// packages.
+///
+/// If [upgradeAll] is true, the contents of [lockFile] are ignored.
+Future<SolveResult> tryResolveVersions(
+    SolveType type, SystemCache cache, Package root,
+    {LockFile lockFile, Iterable<String> useLatest}) async {
+  try {
+    return await resolveVersions(type, cache, root,
+        lockFile: lockFile, useLatest: useLatest);
+  } on SolveFailure {
+    return null;
+  }
 }

--- a/test/outdated/goldens/prereleases.txt
+++ b/test/outdated/goldens/prereleases.txt
@@ -10,7 +10,7 @@ $ pub outdated --json
         "version": "1.0.0-dev.1"
       },
       "resolvable": {
-        "version": "0.9.0"
+        "version": "1.0.0-dev.2"
       },
       "latest": {
         "version": "1.0.0-dev.2"
@@ -35,9 +35,9 @@ $ pub outdated --json
 }
 
 $ pub outdated --no-color
-Dependencies  Current       Upgradable    Resolvable  Latest       
-foo           *1.0.0-dev.1  *1.0.0-dev.1  *0.9.0      1.0.0-dev.2  
-mop           *0.10.0-dev   *0.10.0-dev   0.10.0      0.10.0       
+Dependencies  Current       Upgradable    Resolvable   Latest       
+foo           *1.0.0-dev.1  *1.0.0-dev.1  1.0.0-dev.2  1.0.0-dev.2  
+mop           *0.10.0-dev   *0.10.0-dev   0.10.0       0.10.0       
 
 dev_dependencies: all up-to-date
 
@@ -49,10 +49,10 @@ transitive dev_dependencies: all up-to-date
 To update these dependencies, edit pubspec.yaml.
 
 $ pub outdated --no-color --up-to-date
-Dependencies  Current       Upgradable    Resolvable  Latest       
-bar           0.9.0         0.9.0         0.9.0       0.9.0        
-foo           *1.0.0-dev.1  *1.0.0-dev.1  *0.9.0      1.0.0-dev.2  
-mop           *0.10.0-dev   *0.10.0-dev   0.10.0      0.10.0       
+Dependencies  Current       Upgradable    Resolvable   Latest       
+bar           0.9.0         0.9.0         0.9.0        0.9.0        
+foo           *1.0.0-dev.1  *1.0.0-dev.1  1.0.0-dev.2  1.0.0-dev.2  
+mop           *0.10.0-dev   *0.10.0-dev   0.10.0       0.10.0       
 
 dev_dependencies: all up-to-date
 
@@ -64,10 +64,10 @@ transitive dev_dependencies: all up-to-date
 To update these dependencies, edit pubspec.yaml.
 
 $ pub outdated --no-color --prereleases
-Dependencies  Current       Upgradable    Resolvable  Latest       
-bar           *0.9.0        *0.9.0        *0.9.0      1.0.0-dev.2  
-foo           *1.0.0-dev.1  *1.0.0-dev.1  *0.9.0      1.0.0-dev.2  
-mop           *0.10.0-dev   *0.10.0-dev   *0.10.0     1.0.0-dev    
+Dependencies  Current       Upgradable    Resolvable   Latest       
+bar           *0.9.0        *0.9.0        *0.9.0       1.0.0-dev.2  
+foo           *1.0.0-dev.1  *1.0.0-dev.1  1.0.0-dev.2  1.0.0-dev.2  
+mop           *0.10.0-dev   *0.10.0-dev   *0.10.0      1.0.0-dev    
 
 dev_dependencies: all up-to-date
 
@@ -79,9 +79,9 @@ transitive dev_dependencies: all up-to-date
 To update these dependencies, edit pubspec.yaml.
 
 $ pub outdated --no-color --no-dev-dependencies
-Dependencies  Current       Upgradable    Resolvable  Latest       
-foo           *1.0.0-dev.1  *1.0.0-dev.1  *0.9.0      1.0.0-dev.2  
-mop           *0.10.0-dev   *0.10.0-dev   0.10.0      0.10.0       
+Dependencies  Current       Upgradable    Resolvable   Latest       
+foo           *1.0.0-dev.1  *1.0.0-dev.1  1.0.0-dev.2  1.0.0-dev.2  
+mop           *0.10.0-dev   *0.10.0-dev   0.10.0       0.10.0       
 
 transitive dependencies: all up-to-date
 
@@ -89,9 +89,9 @@ transitive dependencies: all up-to-date
 To update these dependencies, edit pubspec.yaml.
 
 $ pub outdated --no-color --no-dependency-overrides
-Dependencies  Current       Upgradable    Resolvable  Latest       
-foo           *1.0.0-dev.1  *1.0.0-dev.1  *0.9.0      1.0.0-dev.2  
-mop           *0.10.0-dev   *0.10.0-dev   0.10.0      0.10.0       
+Dependencies  Current       Upgradable    Resolvable   Latest       
+foo           *1.0.0-dev.1  *1.0.0-dev.1  1.0.0-dev.2  1.0.0-dev.2  
+mop           *0.10.0-dev   *0.10.0-dev   0.10.0       0.10.0       
 
 dev_dependencies: all up-to-date
 
@@ -106,10 +106,10 @@ $ pub outdated --no-color --mode=null-safety
 Running in 'null safety' mode.
 Showing packages where the current version doesn't fully support null safety.
 
-Dependencies  Current       Upgradable    Resolvable  Latest        
-bar           ✗0.9.0        ✗0.9.0        ✗0.9.0      ✗0.9.0        
-foo           ✗1.0.0-dev.1  ✗1.0.0-dev.1  ✗0.9.0      ✗1.0.0-dev.2  
-mop           ✗0.10.0-dev   ✗0.10.0-dev   ✗0.10.0     ✗0.10.0       
+Dependencies  Current       Upgradable    Resolvable    Latest        
+bar           ✗0.9.0        ✗0.9.0        ✗0.9.0        ✗0.9.0        
+foo           ✗1.0.0-dev.1  ✗1.0.0-dev.1  ✗1.0.0-dev.2  ✗1.0.0-dev.2  
+mop           ✗0.10.0-dev   ✗0.10.0-dev   ✗0.10.0       ✗0.10.0       
 
 dev_dependencies: all fully support null safety
 
@@ -153,7 +153,7 @@ $ pub outdated --json --mode=null-safety
         "nullSafety": false
       },
       "resolvable": {
-        "version": "0.9.0",
+        "version": "1.0.0-dev.2",
         "nullSafety": false
       },
       "latest": {
@@ -195,7 +195,7 @@ $ pub outdated --json --no-dev-dependencies
         "version": "1.0.0-dev.1"
       },
       "resolvable": {
-        "version": "0.9.0"
+        "version": "1.0.0-dev.2"
       },
       "latest": {
         "version": "1.0.0-dev.2"

--- a/test/pubspec_utils_test.dart
+++ b/test/pubspec_utils_test.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub/src/pubspec_utils.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('stripUpperBound', () {
+    test('works on version range', () {
+      final constraint = VersionConstraint.parse('>=1.0.0 <3.0.0');
+      final removedUpperBound = stripUpperBound(constraint);
+
+      expect(removedUpperBound.min, equals(Version(1, 0, 0)));
+      expect(removedUpperBound.includeMin, isTrue);
+      expect(removedUpperBound.max, isNull);
+    });
+
+    test('works on version range exclude min', () {
+      final constraint = VersionConstraint.parse('>0.0.1 <5.0.0');
+      final removedUpperBound = stripUpperBound(constraint);
+
+      expect(removedUpperBound.min, equals(Version(0, 0, 1)));
+      expect(removedUpperBound.includeMin, isFalse);
+      expect(removedUpperBound.max, isNull);
+    });
+
+    test('works on specific version constraint', () {
+      final constraint = VersionConstraint.parse('1.2.3');
+      final removedUpperBound = stripUpperBound(constraint);
+
+      expect(removedUpperBound.min, equals(Version(1, 2, 3)));
+      expect(removedUpperBound.includeMin, isTrue);
+      expect(removedUpperBound.max, isNull);
+    });
+
+    test('works on compatible version constraint', () {
+      final constraint = VersionConstraint.parse('^1.2.3');
+      final removedUpperBound = stripUpperBound(constraint);
+
+      expect(removedUpperBound.min, equals(Version(1, 2, 3)));
+      expect(removedUpperBound.includeMin, isTrue);
+      expect(removedUpperBound.max, isNull);
+    });
+
+    test('works on compatible version union', () {
+      final constraint1 = VersionConstraint.parse('>=1.2.3 <2.0.0');
+      final constraint2 = VersionConstraint.parse('>2.2.3 <=4.0.0');
+      final constraint = VersionUnion.fromRanges([constraint1, constraint2]);
+
+      final removedUpperBound = stripUpperBound(constraint);
+
+      expect(removedUpperBound.min, equals(Version(1, 2, 3)));
+      expect(removedUpperBound.includeMin, isTrue);
+      expect(removedUpperBound.max, isNull);
+    });
+
+    test(
+        'returns the empty version constraint when an empty version constraint '
+        'is provided', () {
+      final constraint = VersionConstraint.empty;
+
+      expect(stripUpperBound(constraint),
+          VersionRange(min: Version.none, max: Version.none));
+    });
+
+    test('returns empty version union on empty version union', () {
+      final constraint = VersionUnion.fromRanges([]);
+      expect(stripUpperBound(constraint),
+          VersionRange(min: Version.none, max: Version.none));
+    });
+  });
+}


### PR DESCRIPTION
Functions are also moved to a separate file in anticipation for sharing with #2619.

There is a modification to a `pub outdated` test golden file where for the prereleases variation in the test for pub outdated ([here](https://github.com/dart-lang/pub/blob/master/test/outdated/outdated_test.dart#L326:L354)), copied below for convenience:
```dart
test(
      'latest version reported while locked on a prerelease can be a prerelease',
      () async {
    await servePackages((builder) => builder
      ..serve('foo', '0.9.0')
      ..serve('foo', '1.0.0-dev.1')
      ..serve('foo', '1.0.0-dev.2')
      ..serve('bar', '0.9.0')
      ..serve('bar', '1.0.0-dev.1')
      ..serve('bar', '1.0.0-dev.2')
      ..serve('mop', '0.10.0-dev')
      ..serve('mop', '0.10.0')
      ..serve('mop', '1.0.0-dev'));
    await d.dir(appPath, [
      d.pubspec({
        'name': 'app',
        'version': '1.0.1',
        'dependencies': {
          'foo': '1.0.0-dev.1',
          'bar': '^0.9.0',
          'mop': '0.10.0-dev'
        },
      })
    ]).create();

    await pubGet();

    await variations('prereleases');
  });
```

I wanted to check why the corresponding output:

```
Dependencies  Current       Upgradable    Resolvable  Latest       
foo           *1.0.0-dev.1  *1.0.0-dev.1  *0.9.0      1.0.0-dev.2  
mop           *0.10.0-dev   *0.10.0-dev   0.10.0      0.10.0       
```

was correct for its resolvable version - shouldn't it be 1.0.0-dev.2, which is correctly determined in this PR? Let me know if the golden file was in fact correct, and I'll investigate why the behaviour happens.

Closes #2584 