### PR TITLE
pub.dartlang.org is now pub.dev.

### DIFF
--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -5,7 +5,7 @@ This document specifies the REST API that a hosted pub package repository must
 implement.
 
 A hosted pub package repository is a server from which packages can be
-downloaded, the default public pub server is `'https://pub.dartlang.org'`.
+downloaded, the default public pub server is `'https://pub.dev'`.
 This can be overwritten in the `dependencies` of a `pubspec.yaml` or specified
 with the environment variable `PUB_HOSTED_URL`. In the rest of this document we
 shall refer to the base URL as `PUB_HOSTED_URL`.

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -21,7 +21,7 @@ class LishCommand extends PubCommand {
   @override
   String get name => 'publish';
   @override
-  String get description => 'Publish the current package to pub.dartlang.org.';
+  String get description => 'Publish the current package to pub.dev.';
   @override
   String get invocation => 'pub publish [options]';
   @override

--- a/lib/src/command/logout.dart
+++ b/lib/src/command/logout.dart
@@ -12,7 +12,7 @@ class LogoutCommand extends PubCommand {
   @override
   String get name => 'logout';
   @override
-  String get description => 'Log out of pub.dartlang.org.';
+  String get description => 'Log out of pub.dev.';
   @override
   String get invocation => 'pub logout';
 

--- a/lib/src/command/uploader.dart
+++ b/lib/src/command/uploader.dart
@@ -17,7 +17,7 @@ class UploaderCommand extends PubCommand {
   String get name => 'uploader';
   @override
   String get description =>
-      'Manage uploaders for a package on pub.dartlang.org.';
+      'Manage uploaders for a package on pub.dev.';
   @override
   String get invocation => 'pub uploader [options] {add/remove} <email>';
   @override

--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -24,9 +24,9 @@ import 'utils.dart';
 /// Headers and field names that should be censored in the log output.
 const _censoredFields = ['refresh_token', 'authorization'];
 
-/// Headers required for pub.dartlang.org API requests.
+/// Headers required for pub.dev API requests.
 ///
-/// The Accept header tells pub.dartlang.org which version of the API we're
+/// The Accept header tells pub.dev which version of the API we're
 /// expecting, so it can either serve that version or give us a 406 error if
 /// it's not supported.
 const pubApiHeaders = {'Accept': 'application/vnd.pub.v2+json'};
@@ -77,7 +77,7 @@ class _PubHttpClient extends http.BaseClient {
         return false;
       }
     } else {
-      if (request.url.origin != 'https://pub.dartlang.org') return false;
+      if (request.url.origin != 'https://pub.dev') return false;
     }
 
     return true;
@@ -212,7 +212,7 @@ class _ThrowingClient extends http.BaseClient {
     }
 
     if (status == 500 &&
-        (request.url.host == 'pub.dartlang.org' ||
+        (request.url.host == 'pub.dev' ||
             request.url.host == 'storage.googleapis.com')) {
       fail('HTTP error 500: Internal Server Error at ${request.url}.\n'
           'This is likely a transient error. Please try again later.');
@@ -268,7 +268,7 @@ final httpClient = ThrottleClient(
 http.Client get innerHttpClient => _pubClient._inner;
 set innerHttpClient(http.Client client) => _pubClient._inner = client;
 
-/// Runs [callback] in a zone where all HTTP requests sent to `pub.dartlang.org`
+/// Runs [callback] in a zone where all HTTP requests sent to `pub.dev`
 /// will indicate the [type] of the relationship between the root package and
 /// the package being requested.
 ///
@@ -279,7 +279,7 @@ Future<T> withDependencyType<T>(
   return runZoned(callback, zoneValues: {#_dependencyType: type});
 }
 
-/// Handles a successful JSON-formatted response from pub.dartlang.org.
+/// Handles a successful JSON-formatted response from pub.dev.
 ///
 /// These responses are expected to be of the form `{"success": {"message":
 /// "some message"}}`. If the format is correct, the message will be printed;
@@ -294,7 +294,7 @@ void handleJsonSuccess(http.Response response) {
   log.message(log.green(parsed['success']['message']));
 }
 
-/// Handles an unsuccessful JSON-formatted response from pub.dartlang.org.
+/// Handles an unsuccessful JSON-formatted response from pub.dev.
 ///
 /// These responses are expected to be of the form `{"error": {"message": "some
 /// message"}}`. If the format is correct, the message will be raised as an

--- a/lib/src/oauth2.dart
+++ b/lib/src/oauth2.dart
@@ -75,7 +75,7 @@ void _clearCredentials(SystemCache cache) {
 void logout(SystemCache cache) {
   var credentialsFile = _credentialsFile(cache);
   if (entryExists(_credentialsFile(cache))) {
-    log.message('Logging out of pub.dartlang.org.');
+    log.message('Logging out of pub.dev.');
     log.message('Deleting $credentialsFile');
     _clearCredentials(cache);
   } else {
@@ -177,7 +177,7 @@ void _saveCredentials(SystemCache cache, Credentials credentials) {
 String _credentialsFile(SystemCache cache) =>
     path.join(cache.rootDir, 'credentials.json');
 
-/// Gets the user to authorize pub as a client of pub.dartlang.org via oauth2.
+/// Gets the user to authorize pub as a client of pub.dev via oauth2.
 ///
 /// Returns a Future that completes to a fully-authorized [Client].
 Future<Client> _authorize() async {
@@ -207,7 +207,7 @@ Future<Client> _authorize() async {
     completer
         .complete(grant.handleAuthorizationResponse(queryToMap(queryString)));
 
-    return shelf.Response.found('https://pub.dartlang.org/authorized');
+    return shelf.Response.found('https://pub.dev/authorized');
   });
 
   var authUrl = grant.getAuthorizationUrl(

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -85,7 +85,7 @@ class Package {
   /// if no README file is found.
   ///
   /// If multiple READMEs are found, this uses the same conventions as
-  /// pub.dartlang.org for choosing the primary one: the README with the fewest
+  /// pub.dev for choosing the primary one: the README with the fewest
   /// extensions that is lexically ordered first is chosen.
   String get readmePath {
     var readmes = listFiles(recursive: false, useGitIgnore: true)

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -25,7 +25,7 @@ import 'utils.dart';
 ///
 /// This allows dot-separated valid Dart identifiers. The dots are there for
 /// compatibility with Google's internal Dart packages, but they may not be used
-/// when publishing a package to pub.dartlang.org.
+/// when publishing a package to pub.dev.
 final _packageName =
     RegExp('^${identifierRegExp.pattern}(\\.${identifierRegExp.pattern})*\$');
 

--- a/lib/src/source.dart
+++ b/lib/src/source.dart
@@ -78,7 +78,7 @@ abstract class Source {
   ///
   /// [containingPath] is the path to the pubspec where this description
   /// appears. It may be `null` if the description is coming from some in-memory
-  /// source (such as pulling down a pubspec from pub.dartlang.org).
+  /// source (such as pulling down a pubspec from pub.dev).
   ///
   /// The description in the returned [PackageRef] need bear no resemblance to
   /// the original user-provided description.

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -42,7 +42,18 @@ class HostedSource extends Source {
 
   /// Gets the default URL for the package server for hosted dependencies.
   String get defaultUrl {
-    return _defaultUrl ??= _pubHostedUrlConfig() ?? 'https://pub.dev';
+    // Changing this to pub.dev raises the following concerns:
+    //
+    //  1. It would blow through users caches.
+    //  2. It would cause conflicts for users checking pubspec.lock into git, if using
+    //     different versions of the dart-sdk / pub client.
+    //  3. It might cause other problems (investigation needed) for pubspec.lock across
+    //     different versions of the dart-sdk / pub client.
+    //  4. It would expand the API surface we're committed to supporting long-term.
+    //
+    // Clearly, a bit of investigation is necessary before we update this to
+    // pub.dev, it might be attractive to do next time we change the server API.
+    return _defaultUrl ??= _pubHostedUrlConfig() ?? 'https://pub.dartlang.org';
   }
 
   String _defaultUrl;

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -42,18 +42,7 @@ class HostedSource extends Source {
 
   /// Gets the default URL for the package server for hosted dependencies.
   String get defaultUrl {
-    // Changing this to pub.dev raises the following concerns:
-    //
-    //  1. It would blow through users caches.
-    //  2. It would cause conflicts for users checking pubspec.lock into git, if using
-    //     different versions of the dart-sdk / pub client.
-    //  3. It might cause other problems (investigation needed) for pubspec.lock across
-    //     different versions of the dart-sdk / pub client.
-    //  4. It would expand the API surface we're committed to supporting long-term.
-    //
-    // Clearly, a bit of investigation is necessary before we update this to
-    // pub.dev, it might be attractive to do next time we change the server API.
-    return _defaultUrl ??= _pubHostedUrlConfig() ?? 'https://pub.dartlang.org';
+    return _defaultUrl ??= _pubHostedUrlConfig() ?? 'https://pub.dev';
   }
 
   String _defaultUrl;

--- a/test/cache/list_test.dart
+++ b/test/cache/list_test.dart
@@ -12,7 +12,7 @@ import '../test_pub.dart';
 void main() {
   String hostedDir(package) {
     return path.join(
-        d.sandbox, cachePath, 'hosted', 'pub.dartlang.org', package);
+        d.sandbox, cachePath, 'hosted', 'pub.dev', package);
   }
 
   test('running pub cache list when there is no cache', () async {
@@ -22,7 +22,7 @@ void main() {
   test('running pub cache list on empty cache', () async {
     // Set up a cache.
     await d.dir(cachePath, [
-      d.dir('hosted', [d.dir('pub.dartlang.org', [])])
+      d.dir('hosted', [d.dir('pub.dev', [])])
     ]).create();
 
     await runPub(args: ['cache', 'list'], outputJson: {'packages': {}});
@@ -32,7 +32,7 @@ void main() {
     // Set up a cache.
     await d.dir(cachePath, [
       d.dir('hosted', [
-        d.dir('pub.dartlang.org', [
+        d.dir('pub.dev', [
           d.dir('foo-1.2.3', [d.libPubspec('foo', '1.2.3'), d.libDir('foo')]),
           d.dir('bar-2.0.0', [d.libPubspec('bar', '2.0.0'), d.libDir('bar')])
         ])
@@ -58,7 +58,7 @@ void main() {
     // Set up a cache.
     await d.dir(cachePath, [
       d.dir('hosted', [
-        d.dir('pub.dartlang.org', [
+        d.dir('pub.dev', [
           d.dir('foo-1.2.3', [
             d.libPubspec('foo', '1.2.3', deps: {
               'bar': {'bad': 'bar'}

--- a/test/global/activate/custom_hosted_url_test.dart
+++ b/test/global/activate/custom_hosted_url_test.dart
@@ -8,7 +8,7 @@ import '../../test_pub.dart';
 
 void main() {
   test('activating a package from a custom pub server', () async {
-    // The default pub server (i.e. pub.dartlang.org).
+    // The default pub server (i.e. pub.dev).
     await servePackages((builder) {
       builder.serve('baz', '1.0.0');
     });

--- a/test/oauth2/logout_test.dart
+++ b/test/oauth2/logout_test.dart
@@ -17,7 +17,7 @@ void main() {
         .create();
 
     await runPub(
-        args: ['logout'], output: contains('Logging out of pub.dartlang.org.'));
+        args: ['logout'], output: contains('Logging out of pub.dev.'));
 
     await d.dir(cachePath, [d.nothing('credentials.json')]).validate();
   });

--- a/test/oauth2/utils.dart
+++ b/test/oauth2/utils.dart
@@ -37,7 +37,7 @@ Future authorizePub(TestProcess pub, PackageServer server,
   var response =
       await (http.Request('GET', redirectUrl)..followRedirects = false).send();
   expect(response.headers['location'],
-      equals('https://pub.dartlang.org/authorized'));
+      equals('https://pub.dev/authorized'));
 }
 
 void handleAccessTokenRequest(PackageServer server, String accessToken) {

--- a/test/package_server.dart
+++ b/test/package_server.dart
@@ -18,7 +18,7 @@ import 'test_pub.dart';
 PackageServer get globalPackageServer => _globalPackageServer;
 PackageServer _globalPackageServer;
 
-/// Creates an HTTP server that replicates the structure of pub.dartlang.org and
+/// Creates an HTTP server that replicates the structure of pub.dev and
 /// makes it the current [globalServer].
 ///
 /// Calls [callback] with a [PackageServerBuilder] that's used to specify
@@ -71,7 +71,7 @@ class PackageServer {
   /// Handlers for requests not easily described as packages.
   Map<Pattern, shelf.Handler> get extraHandlers => _inner.extraHandlers;
 
-  /// Creates an HTTP server that replicates the structure of pub.dartlang.org.
+  /// Creates an HTTP server that replicates the structure of pub.dev.
   ///
   /// Calls [callback] with a [PackageServerBuilder] that's used to specify
   /// which packages to serve.

--- a/test/pub_test.dart
+++ b/test/pub_test.dart
@@ -35,13 +35,13 @@ void main() {
           downgrade   Downgrade the current package's dependencies to oldest versions.
           get         Get the current package's dependencies.
           global      Work with global packages.
-          logout      Log out of pub.dartlang.org.
+          logout      Log out of pub.dev.
           outdated    Analyze your dependencies to find which ones can be upgraded.
-          publish     Publish the current package to pub.dartlang.org.
+          publish     Publish the current package to pub.dev.
           remove      Removes a dependency from the current package.
           run         Run an executable from a package.
           upgrade     Upgrade the current package's dependencies to latest versions.
-          uploader    Manage uploaders for a package on pub.dartlang.org.
+          uploader    Manage uploaders for a package on pub.dev.
           version     Print pub version.
 
         Run "pub help <command>" for more information about a command.

--- a/test/pub_uploader_test.dart
+++ b/test/pub_uploader_test.dart
@@ -15,12 +15,12 @@ import 'descriptor.dart' as d;
 import 'test_pub.dart';
 
 const _usageString = '''
-Manage uploaders for a package on pub.dartlang.org.
+Manage uploaders for a package on pub.dev.
 
 Usage: pub uploader [options] {add/remove} <email>
 -h, --help       Print this usage information.
     --server     The package server on which the package is hosted.
-                 (defaults to "https://pub.dartlang.org")
+                 (defaults to "https://pub.dev")
     --package    The package whose uploaders will be modified.
                  (defaults to the current package)
 

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -449,7 +449,7 @@ publish_to: none
 
       test('throws on non-absolute URLs', () {
         expectPubspecException(
-            'publish_to: pub.dartlang.org', (pubspec) => pubspec.publishTo);
+            'publish_to: pub.dev', (pubspec) => pubspec.publishTo);
       });
     });
 

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -633,7 +633,7 @@ String packagePath(String package) {
   }
 
   return p.join(
-      SystemCache.defaultDir, 'hosted/pub.dartlang.org/$package-${id.version}');
+      SystemCache.defaultDir, 'hosted/pub.dev/$package-${id.version}');
 }
 
 /// Uses [client] as the mock HTTP client for this test.
@@ -660,7 +660,7 @@ Map packageMap(
   var package = <String, dynamic>{
     'name': name,
     'version': version,
-    'homepage': 'http://pub.dartlang.org',
+    'homepage': 'http://pub.dev',
     'description': 'A package, I guess.'
   };
 
@@ -673,7 +673,7 @@ Map packageMap(
 /// Resolves [target] relative to the path to pub's `test/asset` directory.
 String testAssetPath(String target) => p.join(pubRoot, 'test', 'asset', target);
 
-/// Returns a Map in the format used by the pub.dartlang.org API to represent a
+/// Returns a Map in the format used by the pub.dev API to represent a
 /// package version.
 ///
 /// [pubspec] is the parsed pubspec of the package version. If [full] is true,

--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -269,7 +269,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'bar',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'http://pub.dev'
                       }
                     }
                   }
@@ -296,7 +296,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'foo',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'http://pub.dev'
                       }
                     }
                   }
@@ -320,7 +320,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'foo',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'http://pub.dev'
                       }
                     }
                   }
@@ -380,7 +380,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'bar',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'http://pub.dev'
                       }
                     }
                   }
@@ -407,7 +407,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'foo',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'http://pub.dev'
                       }
                     }
                   }
@@ -429,7 +429,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'foo',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'http://pub.dev'
                       }
                     }
                   }
@@ -453,7 +453,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'foo',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'http://pub.dev'
                       }
                     }
                   }

--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -42,7 +42,7 @@ Future setUpDependency(Map dep, {List<String> hostedVersions}) {
             'uploaders': ['nweiz@google.com'],
             'versions': hostedVersions
                 .map((version) => packageVersionApiMap(
-                    'https://pub.dartlang.org', packageMap('foo', version)))
+                    'https://pub.dev', packageMap('foo', version)))
                 .toList()
           }),
           200));

--- a/test/validator/pubspec_field_test.dart
+++ b/test/validator/pubspec_field_test.dart
@@ -23,7 +23,7 @@ void main() {
 
     test('has an HTTPS homepage URL', () async {
       var pkg = packageMap('test_pkg', '1.0.0');
-      pkg['homepage'] = 'https://pub.dartlang.org';
+      pkg['homepage'] = 'https://pub.dev';
       await d.dir(appPath, [d.pubspec(pkg)]).create();
 
       await expectValidation(pubspecField);
@@ -32,7 +32,7 @@ void main() {
     test('has an HTTPS repository URL instead of homepage', () async {
       var pkg = packageMap('test_pkg', '1.0.0');
       pkg.remove('homepage');
-      pkg['repository'] = 'https://pub.dartlang.org';
+      pkg['repository'] = 'https://pub.dev';
       await d.dir(appPath, [d.pubspec(pkg)]).create();
 
       await expectValidation(pubspecField);
@@ -40,7 +40,7 @@ void main() {
 
     test('has an HTTPS documentation URL', () async {
       var pkg = packageMap('test_pkg', '1.0.0');
-      pkg['documentation'] = 'https://pub.dartlang.org';
+      pkg['documentation'] = 'https://pub.dev';
       await d.dir(appPath, [d.pubspec(pkg)]).create();
 
       await expectValidation(pubspecField);

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -2946,7 +2946,7 @@ Future expectResolves(
 
     if (dep.source is HostedSource && dep.description is String) {
       // If the dep uses the default hosted source, grab it from the test
-      // package server rather than pub.dartlang.org.
+      // package server rather than pub.dev.
       dep = registry.hosted
           .refFor(dep.name, url: globalPackageServer.url)
           .withConstraint(dep.constraint);


### PR DESCRIPTION
Updated in logout description

The pub tool still displays [pub.dartlang.org] which is now [pub.dev](https://pub.dev)

Fixed this problem in logout.dart and publish.dart