### PR TITLE
[Prototype] add support for a --channel flag

### DIFF
--- a/lib/src/command/downgrade.dart
+++ b/lib/src/command/downgrade.dart
@@ -24,6 +24,8 @@ class DowngradeCommand extends PubCommand {
   @override
   bool get isOffline => argResults['offline'];
 
+  String get channel => argResults['channel'];
+
   DowngradeCommand() {
     argParser.addFlag('offline',
         help: 'Use cached packages instead of accessing the network.');
@@ -32,6 +34,10 @@ class DowngradeCommand extends PubCommand {
         abbr: 'n',
         negatable: false,
         help: "Report what dependencies would change but don't change any.");
+
+    argParser.addOption('channel',
+        help: 'Pre-release channel to allow, matches the first component of '
+            'pre-release versions');
 
     argParser.addFlag('packages-dir', hide: true);
   }
@@ -44,7 +50,7 @@ class DowngradeCommand extends PubCommand {
     }
     var dryRun = argResults['dry-run'];
     await entrypoint.acquireDependencies(SolveType.DOWNGRADE,
-        useLatest: argResults.rest, dryRun: dryRun);
+        useLatest: argResults.rest, dryRun: dryRun, channel: channel);
 
     if (isOffline) {
       log.warning('Warning: Downgrading when offline may not update you to '

--- a/lib/src/command/get.dart
+++ b/lib/src/command/get.dart
@@ -20,6 +20,7 @@ class GetCommand extends PubCommand {
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-get';
   @override
   bool get isOffline => argResults['offline'];
+  String get channel => argResults['channel'];
 
   GetCommand() {
     argParser.addFlag('offline',
@@ -34,6 +35,10 @@ class GetCommand extends PubCommand {
         help: 'Precompile executables in immediate dependencies.');
 
     argParser.addFlag('packages-dir', hide: true);
+
+    argParser.addOption('channel',
+        help: 'Pre-release channel to allow, matches the first component of '
+            'pre-release versions');
   }
 
   @override
@@ -43,6 +48,8 @@ class GetCommand extends PubCommand {
           'The --packages-dir flag is no longer used and does nothing.'));
     }
     return entrypoint.acquireDependencies(SolveType.GET,
-        dryRun: argResults['dry-run'], precompile: argResults['precompile']);
+        dryRun: argResults['dry-run'],
+        precompile: argResults['precompile'],
+        channel: channel);
   }
 }

--- a/lib/src/command/global_activate.dart
+++ b/lib/src/command/global_activate.dart
@@ -19,6 +19,8 @@ class GlobalActivateCommand extends PubCommand {
   @override
   String get invocation => 'pub global activate <package> [version-constraint]';
 
+  String get channel => argResults['channel'];
+
   GlobalActivateCommand() {
     argParser.addOption('source',
         abbr: 's',
@@ -46,6 +48,10 @@ class GlobalActivateCommand extends PubCommand {
         abbr: 'u',
         help:
             'A custom pub server URL for the package. Only applies when using the `hosted` source.');
+
+    argParser.addOption('channel',
+        help: 'Pre-release channel to allow, matches the first component of '
+            'pre-release versions');
   }
 
   @override
@@ -99,7 +105,7 @@ class GlobalActivateCommand extends PubCommand {
         // TODO(rnystrom): Allow passing in a Git ref too.
         validateNoExtraArgs();
         return globals.activateGit(repo, executables,
-            features: features, overwriteBinStubs: overwrite);
+            features: features, overwriteBinStubs: overwrite, channel: channel);
 
       case 'hosted':
         var package = readArg('No package to activate given.');
@@ -116,7 +122,10 @@ class GlobalActivateCommand extends PubCommand {
 
         validateNoExtraArgs();
         return globals.activateHosted(package, constraint, executables,
-            features: features, overwriteBinStubs: overwrite, url: hostedUrl);
+            features: features,
+            overwriteBinStubs: overwrite,
+            url: hostedUrl,
+            channel: channel);
 
       case 'path':
         if (features.isNotEmpty) {
@@ -129,7 +138,7 @@ class GlobalActivateCommand extends PubCommand {
         var path = readArg('No package to activate given.');
         validateNoExtraArgs();
         return globals.activatePath(path, executables,
-            overwriteBinStubs: overwrite);
+            overwriteBinStubs: overwrite, channel: channel);
     }
 
     throw StateError('unreachable');

--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -619,10 +619,8 @@ Showing packages where the current version doesn't fully support null safety.
           ids.map(
             (id) async => MapEntry(
               id,
-              await nullSafetyAnalyzer.nullSafetyCompliance(
-                id,
-                containingPath: path.absolute(entrypoint.root.dir),
-              ),
+              await nullSafetyAnalyzer.nullSafetyCompliance(id,
+                  containingPath: path.absolute(entrypoint.root.dir)),
             ),
           ),
         ),

--- a/lib/src/command/remove.dart
+++ b/lib/src/command/remove.dart
@@ -30,6 +30,8 @@ class RemoveCommand extends PubCommand {
 
   bool get isDryRun => argResults['dry-run'];
 
+  String get channel => argResults['channel'];
+
   RemoveCommand() {
     argParser.addFlag('offline',
         help: 'Use cached packages instead of accessing the network.');
@@ -41,6 +43,10 @@ class RemoveCommand extends PubCommand {
 
     argParser.addFlag('precompile',
         help: 'Precompile executables in immediate dependencies.');
+
+    argParser.addOption('channel',
+        help: 'Pre-release channel to allow, matches the first component of '
+            'pre-release versions');
   }
 
   @override
@@ -58,13 +64,13 @@ class RemoveCommand extends PubCommand {
 
       await Entrypoint.global(newRoot, entrypoint.lockFile, cache)
           .acquireDependencies(SolveType.GET,
-              precompile: argResults['precompile']);
+              precompile: argResults['precompile'], channel: channel);
     } else {
       /// Update the pubspec.
       _writeRemovalToPubspec(packages);
 
       await Entrypoint.current(cache).acquireDependencies(SolveType.GET,
-          precompile: argResults['precompile']);
+          precompile: argResults['precompile'], channel: channel);
     }
   }
 

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -23,6 +23,8 @@ class UpgradeCommand extends PubCommand {
   @override
   bool get isOffline => argResults['offline'];
 
+  String get channel => argResults['channel'];
+
   UpgradeCommand() {
     argParser.addFlag('offline',
         help: 'Use cached packages instead of accessing the network.');
@@ -34,6 +36,10 @@ class UpgradeCommand extends PubCommand {
 
     argParser.addFlag('precompile',
         help: 'Precompile executables in immediate dependencies.');
+
+    argParser.addOption('channel',
+        help: 'Pre-release channel to allow, matches the first component of '
+            'pre-release versions');
 
     argParser.addFlag('packages-dir', hide: true);
   }
@@ -47,7 +53,8 @@ class UpgradeCommand extends PubCommand {
     await entrypoint.acquireDependencies(SolveType.UPGRADE,
         useLatest: argResults.rest,
         dryRun: argResults['dry-run'],
-        precompile: argResults['precompile']);
+        precompile: argResults['precompile'],
+        channel: channel);
 
     if (isOffline) {
       log.warning('Warning: Upgrading when offline may not update you to the '

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -223,7 +223,8 @@ class Entrypoint {
   Future acquireDependencies(SolveType type,
       {List<String> useLatest,
       bool dryRun = false,
-      bool precompile = false}) async {
+      bool precompile = false,
+      @required String channel}) async {
     var result = await log.progress(
       'Resolving dependencies',
       () => resolveVersions(
@@ -232,6 +233,7 @@ class Entrypoint {
         root,
         lockFile: lockFile,
         useLatest: useLatest,
+        channel: channel,
       ),
     );
 

--- a/lib/src/null_safety_analysis.dart
+++ b/lib/src/null_safety_analysis.dart
@@ -104,11 +104,8 @@ class NullSafetyAnalysis {
 
     SolveResult result;
     try {
-      result = await resolveVersions(
-        SolveType.GET,
-        _systemCache,
-        root,
-      );
+      result = await resolveVersions(SolveType.GET, _systemCache, root,
+          channel: 'nullsafety');
     } on SolveFailure catch (e) {
       return NullSafetyAnalysisResult(NullSafetyCompliance.analysisFailed,
           'Could not resolve constraints: $e');

--- a/lib/src/solver.dart
+++ b/lib/src/solver.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
+
 import 'lock_file.dart';
 import 'package.dart';
 import 'solver/failure.dart';
@@ -28,13 +30,14 @@ export 'solver/type.dart';
 /// If [upgradeAll] is true, the contents of [lockFile] are ignored.
 Future<SolveResult> resolveVersions(
     SolveType type, SystemCache cache, Package root,
-    {LockFile lockFile, Iterable<String> useLatest}) {
+    {LockFile lockFile, Iterable<String> useLatest, @required String channel}) {
   return VersionSolver(
     type,
     cache,
     root,
     lockFile ?? LockFile.empty(),
     useLatest ?? const [],
+    channel,
   ).solve();
 }
 
@@ -53,10 +56,10 @@ Future<SolveResult> resolveVersions(
 /// If [upgradeAll] is true, the contents of [lockFile] are ignored.
 Future<SolveResult> tryResolveVersions(
     SolveType type, SystemCache cache, Package root,
-    {LockFile lockFile, Iterable<String> useLatest}) async {
+    {LockFile lockFile, Iterable<String> useLatest, String channel}) async {
   try {
     return await resolveVersions(type, cache, root,
-        lockFile: lockFile, useLatest: useLatest);
+        lockFile: lockFile, useLatest: useLatest, channel: channel);
   } on SolveFailure {
     return null;
   }

--- a/lib/src/solver/package_lister.dart
+++ b/lib/src/solver/package_lister.dart
@@ -170,7 +170,8 @@ class PackageLister {
       // major/minor version as the min constraint are valid.
       if (constraint is VersionRange) {
         var min = constraint.min;
-        if (min.isPreRelease &&
+        if (min != null &&
+            min.isPreRelease &&
             id.version.major == min.major &&
             id.version.minor == min.minor) {
           return id;


### PR DESCRIPTION
This implements an idea I have been considering to allow for release channels for pub packages. This would significantly improve our story around things like null safety, and pre-releases in general.

I define the "channel" for a given version to be the first component of its pre-release version, so a version like `1.2.3-nullsafety.1` is considered to be a part of the "nullsafety" channel.

I then implemented the following changes to pub:

- Add a `--channel` command line argument to all commands that do version solves.
  - **Note**: based on comments below I would revert this option in favor of configuration in the pubspec only 
- Add a required `String channel` argument to the `bestVersion` method.
- Update the `bestVersion` method to **never select pre-release versions by default** (this is technically breaking)
  - They are allowed if explicitly pinned, or if the min constraint is a pre-release version (but only for that same major/minor version) 
- Update the `bestVersion` method to treat pre-release versions with a matching channel equally to stable versions

The meat of the implementation change is [here](https://github.com/dart-lang/pub/pull/2665/files#diff-c454966c2c84f2e98c5a1941050143b0R162), the rest is just plumbing and arg parsing.

I think the configuration here would likely want to be extended to allow setting the channel permanently via the pubspec (possibly under environment), and I also think it should be configurable per package dependency so that you can opt in to the dev channel for instance on a given package only.

This should generally allow for a much more useful pre-release mechanism, which also prevents users from getting undesired pre-releases.

cc @leafpetersen @natebosch @mit-mit @munificent @jonasfj 