### PR TITLE
Fix experiments tests for Dart 2.11

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: pub
 publish_to: none
 
 environment:
-  sdk: ">=2.9.0 <3.0.0"
+  sdk: ">=2.11.0-0 <3.0.0"
 
 dependencies:
   # Note: Pub's test infrastructure assumes that any dependencies used in tests

--- a/test/run/enable_experiments_test.dart
+++ b/test/run/enable_experiments_test.dart
@@ -2,48 +2,39 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
-import 'package:pub/src/language_version.dart';
-import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';
 
 void main() {
-  test(
-    'Succeeds running experimental code.',
-    () async {
-      await d.dir(appPath, [
-        d.appPubspec(),
-        d.dir('bin', [
-          d.file('script.dart', '''
+  test('Succeeds running experimental code.', () async {
+    await d.dir(appPath, [
+      d.appPubspec(),
+      d.dir('bin', [
+        d.file('script.dart', '''
   main() {
     int? a = int.tryParse('123');
   }
 ''')
-        ])
-      ]).create();
-      await pubGet();
-      await runPub(
-          args: ['run', '--enable-experiment=non-nullable', 'bin/script.dart']);
-    },
-    skip: Platform.version.contains('2.9') || Platform.version.contains('2.10')
-        ? false
-        : 'experiment non-nullable only available for test on sdk 2.9 and 2.10',
-  );
+      ])
+    ]).create();
+    await pubGet();
+    await runPub(
+      args: ['run', '--enable-experiment=non-nullable', 'bin/script.dart'],
+    );
+  });
 
-  test(
-    'Passes --no-sound-null-safety to the vm',
-    () async {
-      await d.dir(appPath, [
-        d.pubspec({
-          'name': 'test_package',
-          'environment': {'sdk': '>=2.10.0 <=3.0.0'}
-        }),
-        d.dir('bin', [
-          d.file('script.dart', '''
+  test('Passes --no-sound-null-safety to the vm', () async {
+    const nullSafeEnabledVM = '2.11.0';
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'test_package',
+        'environment': {'sdk': '>=$nullSafeEnabledVM <=3.0.0'}
+      }),
+      d.dir('bin', [
+        d.file('script.dart', '''
 import 'package:test_package/foo.dart';
 
 main() {
@@ -51,36 +42,32 @@ main() {
   int b = p;
 }
 ''')
-        ]),
-        d.dir(
-          'lib',
-          [
-            d.file('foo.dart', '''
+      ]),
+      d.dir(
+        'lib',
+        [
+          d.file('foo.dart', '''
 // @dart = 2.8
 int p = 10;
 '''),
-          ],
-        ),
-      ]).create();
-      await pubGet(environment: {'_PUB_TEST_SDK_VERSION': '2.10.0'});
-      await runPub(args: [
-        'run',
-        '--no-sound-null-safety',
-        '--enable-experiment=non-nullable',
-        'bin/script.dart'
-      ], environment: {
-        '_PUB_TEST_SDK_VERSION': '2.10.0'
-      });
-      await runPub(
-          args: ['run', '--enable-experiment=non-nullable', 'bin/script.dart'],
-          environment: {'_PUB_TEST_SDK_VERSION': '2.10.0'},
-          error: contains("A library can't opt out of null safety by default"),
-          exitCode: 254);
-    },
-    skip: LanguageVersion.fromVersion(
-                Version.parse(Platform.version.split(' ').first)) >=
-            LanguageVersion.fromVersion(Version(2, 10, 0))
-        ? false
-        : '--sound-null-safety only available from sdk 2.10',
-  );
+        ],
+      ),
+    ]).create();
+
+    const environment = {'_PUB_TEST_SDK_VERSION': nullSafeEnabledVM};
+
+    await pubGet(environment: environment);
+    await runPub(args: [
+      'run',
+      '--no-sound-null-safety',
+      '--enable-experiment=non-nullable',
+      'bin/script.dart'
+    ], environment: environment);
+    await runPub(
+      args: ['run', '--enable-experiment=non-nullable', 'bin/script.dart'],
+      environment: environment,
+      error: contains("A library can't opt out of null safety by default"),
+      exitCode: 254,
+    );
+  });
 }


### PR DESCRIPTION
Tests for pub will only ever be run on the latest dev release, so
no need to skip on previous SDKs