### PR TITLE
Simplify test detection

### DIFF
--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -235,6 +235,7 @@ and include the logs in an issue on https://github.com/dart-lang/pub/issues/new
     var depsRev = match[1];
 
     String actualRev;
+    final pubRoot = p.dirname(p.dirname(p.fromUri(Platform.script)));
     try {
       actualRev =
           git.runSync(['rev-parse', 'HEAD'], workingDir: pubRoot).single;

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -829,15 +829,18 @@ bool _computeNoUnknownKeyword() {
 }
 
 final String _pathTo7zip = (() {
-  for (final candidate in [
-    // Try finding 7zip in the sdk path.
-    path.join(sdk.rootDirectory, 'lib', '_internal', 'pub', 'asset', '7zip',
-        '7za.exe'),
-    // We might be running from dart repo.
-    path.join(dartRepoRoot, 'third_party', '7zip', '7za.exe'),
-  ]) {
-    if (fileExists(candidate)) return candidate;
-  }
+  final candidate = runningFromDartRepo
+      ? path.join(dartRepoRoot, 'third_party', '7zip', '7za.exe')
+      : path.join(
+          sdk.rootDirectory,
+          'lib',
+          '_internal',
+          'pub',
+          'asset',
+          '7zip',
+          '7za.exe',
+        );
+  if (fileExists(candidate)) return candidate;
   throw StateError('Could not find 7zip.');
 })();
 

--- a/lib/src/sdk/dart.dart
+++ b/lib/src/sdk/dart.dart
@@ -23,11 +23,6 @@ class DartSdk extends Sdk {
   @override
   Version get firstPubVersion => Version.none;
 
-  /// The path to the root directory of the SDK.
-  ///
-  /// Note that if pub is running from source within the Dart repo (for example
-  /// when building Observatory), this will be the repo's "sdk/" directory,
-  /// which doesn't look exactly like the built SDK.
   static final String _rootDirectory = () {
     if (runningFromDartRepo) return p.join(dartRepoRoot, 'sdk');
 
@@ -49,6 +44,11 @@ class DartSdk extends Sdk {
     return Version.parse(sdkVersion);
   }();
 
+  /// The path to the root directory of the SDK.
+  ///
+  /// Note that if pub is running from source within the Dart repo (for example
+  /// when building Observatory), this will be the repo's "sdk/" directory,
+  /// which doesn't look exactly like the built SDK.
   String get rootDirectory => _rootDirectory;
 
   @override


### PR DESCRIPTION
By inlining we can constant fold whether we are in a test or not.

Also removes some dead code.