### PR TITLE
Don't show 'precompiling' from `global run` unless in terminal

### DIFF
--- a/lib/src/command/global_run.dart
+++ b/lib/src/command/global_run.dart
@@ -70,7 +70,8 @@ class GlobalRunCommand extends PubCommand {
         Executable.adaptProgramName(package, executable), args,
         vmArgs: vmArgs,
         enableAsserts: argResults['enable-asserts'] || argResults['checked'],
-        recompile: globalEntrypoint.precompileExecutable);
+        recompile: (executable) => log.warningsOnlyUnlessTerminal(
+            () => globalEntrypoint.precompileExecutable(executable)));
     await flushThenExit(exitCode);
   }
 }

--- a/test/global/binstubs/outdated_binstub_runs_pub_global_test.dart
+++ b/test/global/binstubs/outdated_binstub_runs_pub_global_test.dart
@@ -93,12 +93,7 @@ void main() {
         ['arg1', 'arg2'],
         environment: getEnvironment());
 
-    expect(
-        await process.stdout.rest.toList(),
-        allOf([
-          contains('Precompiled foo:script.'),
-          contains('ok [arg1, arg2]')
-        ]));
+    expect(await process.stdout.rest.toList(), contains('ok [arg1, arg2]'));
 
     expect(
       binStub('foo-script'),


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/2660