### PR TITLE
Deprecate --server argument to `pub publish` and `pub uploader`.

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -61,7 +61,9 @@ class LishCommand extends PubCommand {
         negatable: false,
         help: 'Publish without confirmation if there are no errors.');
     argParser.addOption('server',
-        help: 'The package server to which to upload this package.');
+        help: 'The package server to which to upload this package.\n'
+            'DEPRECATED: use `publish_to` in your pubspec.yaml or set the \n'
+            '\$PUB_HOSTED_URL environment variable.');
   }
 
   Future _publish(List<int> packageBytes) async {

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -61,9 +61,8 @@ class LishCommand extends PubCommand {
         negatable: false,
         help: 'Publish without confirmation if there are no errors.');
     argParser.addOption('server',
-        help: 'The package server to which to upload this package.\n'
-            'DEPRECATED: use `publish_to` in your pubspec.yaml or set the \n'
-            '\$PUB_HOSTED_URL environment variable.');
+        help: 'The package server to which to upload this package.',
+        hide: true);
   }
 
   Future _publish(List<int> packageBytes) async {
@@ -117,6 +116,16 @@ class LishCommand extends PubCommand {
 
   @override
   Future runProtected() async {
+    if (argResults.wasParsed('server')) {
+      await log.warningsOnlyUnlessTerminal(() {
+        log.message(
+          '''
+The --server option is deprecated. Use `publish_to` in your pubspec.yaml or set
+the \$PUB_HOSTED_URL environment variable.''',
+        );
+      });
+    }
+
     if (force && dryRun) {
       usageException('Cannot use both --force and --dry-run.');
     }

--- a/lib/src/command/uploader.dart
+++ b/lib/src/command/uploader.dart
@@ -32,7 +32,8 @@ class UploaderCommand extends PubCommand {
         defaultsTo: Platform.environment['PUB_HOSTED_URL'] ??
             'https://pub.dartlang.org',
         help: 'The package server on which the package is hosted.\n'
-            'DEPRECATED: use `publish_to` in your pubspec.yaml or set \$PUB_HOSTED_URL.');
+            'DEPRECATED: use `publish_to` in your pubspec.yaml or set the\n'
+            '\$PUB_HOSTED_URL environment variable.');
     argParser.addOption('package',
         help: 'The package whose uploaders will be modified.\n'
             '(defaults to the current package)');

--- a/lib/src/command/uploader.dart
+++ b/lib/src/command/uploader.dart
@@ -31,9 +31,8 @@ class UploaderCommand extends PubCommand {
     argParser.addOption('server',
         defaultsTo: Platform.environment['PUB_HOSTED_URL'] ??
             'https://pub.dartlang.org',
-        help: 'The package server on which the package is hosted.\n'
-            'DEPRECATED: use `publish_to` in your pubspec.yaml or set the\n'
-            '\$PUB_HOSTED_URL environment variable.');
+        help: 'The package server on which the package is hosted.\n',
+        hide: true);
     argParser.addOption('package',
         help: 'The package whose uploaders will be modified.\n'
             '(defaults to the current package)');
@@ -41,6 +40,15 @@ class UploaderCommand extends PubCommand {
 
   @override
   Future<void> runProtected() async {
+    if (argResults.wasParsed('server')) {
+      await log.warningsOnlyUnlessTerminal(() {
+        log.message(
+          '''
+The --server option is deprecated. Use `publish_to` in your pubspec.yaml or set
+the \$PUB_HOSTED_URL environment variable.''',
+        );
+      });
+    }
     if (argResults.rest.isEmpty) {
       log.error('No uploader command given.');
       printUsage();

--- a/lib/src/command/uploader.dart
+++ b/lib/src/command/uploader.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import '../command.dart';
 import '../exit_codes.dart' as exit_codes;
@@ -28,8 +29,10 @@ class UploaderCommand extends PubCommand {
 
   UploaderCommand() {
     argParser.addOption('server',
-        defaultsTo: cache.sources.hosted.defaultUrl,
-        help: 'The package server on which the package is hosted.');
+        defaultsTo: Platform.environment['PUB_HOSTED_URL'] ??
+            'https://pub.dartlang.org',
+        help: 'The package server on which the package is hosted.\n'
+            'DEPRECATED: use `publish_to` in your pubspec.yaml or set \$PUB_HOSTED_URL.');
     argParser.addOption('package',
         help: 'The package whose uploaders will be modified.\n'
             '(defaults to the current package)');

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -62,7 +62,7 @@ class HostedSource extends Source {
     var url = io.Platform.environment['PUB_HOSTED_URL'];
     if (url == null) return null;
     var uri = Uri.parse(url);
-    if (uri.scheme != 'http' && uri.scheme != 'https') {
+    if (!['http', 'https'].contains(uri.scheme.toLowerCase())) {
       throw ConfigException(
           '`PUB_HOSTED_URL` must have either the scheme "https://" or "http://". '
           '"$url" is invalid.');

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -62,10 +62,10 @@ class HostedSource extends Source {
     var url = io.Platform.environment['PUB_HOSTED_URL'];
     if (url == null) return null;
     var uri = Uri.parse(url);
-    if (uri.scheme?.isEmpty ?? true) {
+    if (uri.scheme != 'http' && uri.scheme != 'https') {
       throw ConfigException(
-          '`PUB_HOSTED_URL` must include a scheme such as "https://". '
-          '$url is invalid');
+          '`PUB_HOSTED_URL` must have either the scheme "https://" or "http://". '
+          '"$url" is invalid.');
     }
     return url;
   }

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -62,7 +62,7 @@ class HostedSource extends Source {
     var url = io.Platform.environment['PUB_HOSTED_URL'];
     if (url == null) return null;
     var uri = Uri.parse(url);
-    if (!['http', 'https'].contains(uri.scheme.toLowerCase())) {
+    if (!uri.isScheme('http') && !uri.isScheme('https')) {
       throw ConfigException(
           '`PUB_HOSTED_URL` must have either the scheme "https://" or "http://". '
           '"$url" is invalid.');

--- a/test/get/hosted/explain_bad_hosted_url_test.dart
+++ b/test/get/hosted/explain_bad_hosted_url_test.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('Complains nicely about invalid PUB_HOSTED_URL', () async {
+    await d.appDir({'foo': 'any'}).create();
+
+    // Get once so it gets cached.
+    await pubGet(
+        environment: {'PUB_HOSTED_URL': 'abc://bad_scheme.com'},
+        error: contains(
+            'PUB_HOSTED_URL` must have either the scheme "https://" or "http://".'),
+        exitCode: 78);
+
+    await pubGet(
+        environment: {'PUB_HOSTED_URL': ''},
+        error: contains(
+            'PUB_HOSTED_URL` must have either the scheme "https://" or "http://".'),
+        exitCode: 78);
+  });
+}

--- a/test/lish/does_not_publish_if_private_with_server_arg_test.dart
+++ b/test/lish/does_not_publish_if_private_with_server_arg_test.dart
@@ -18,8 +18,10 @@ void main() {
     await d.dir(appPath, [d.pubspec(pkg)]).create();
 
     await runPub(
-        args: ['lish', '--server', 'http://example.com'],
-        error: startsWith('A private package cannot be published.'),
-        exitCode: exit_codes.DATA);
+      args: ['lish'],
+      error: startsWith('A private package cannot be published.'),
+      environment: {'PUB_HOSTED_URL': 'http://example.com'},
+      exitCode: exit_codes.DATA,
+    );
   });
 }

--- a/test/lish/force_cannot_be_combined_with_dry_run_test.dart
+++ b/test/lish/force_cannot_be_combined_with_dry_run_test.dart
@@ -2,9 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';
@@ -14,16 +13,18 @@ void main() {
 
   test('--force cannot be combined with --dry-run', () async {
     await runPub(args: ['lish', '--force', '--dry-run'], error: '''
-          Cannot use both --force and --dry-run.
-          
-          Usage: pub publish [options]
-          -h, --help       Print this usage information.
-          -n, --dry-run    Validate but do not publish the package.
-          -f, --force      Publish without confirmation if there are no errors.
-              --server     The package server to which to upload this package.
+Cannot use both --force and --dry-run.
 
-          Run "pub help" to see global options.
-          See https://dart.dev/tools/pub/cmd/pub-lish for detailed documentation.
-          ''', exitCode: exit_codes.USAGE);
+Usage: pub publish [options]
+-h, --help       Print this usage information.
+-n, --dry-run    Validate but do not publish the package.
+-f, --force      Publish without confirmation if there are no errors.
+    --server     The package server to which to upload this package.
+                  DEPRECATED: use `publish_to` in your pubspec.yaml or set the
+                  \$PUB_HOSTED_URL environment variable.
+
+Run "pub help" to see global options.
+See https://dart.dev/tools/pub/cmd/pub-lish for detailed documentation.
+''', exitCode: exit_codes.USAGE);
   });
 }

--- a/test/lish/force_cannot_be_combined_with_dry_run_test.dart
+++ b/test/lish/force_cannot_be_combined_with_dry_run_test.dart
@@ -19,9 +19,6 @@ Usage: pub publish [options]
 -h, --help       Print this usage information.
 -n, --dry-run    Validate but do not publish the package.
 -f, --force      Publish without confirmation if there are no errors.
-    --server     The package server to which to upload this package.
-                  DEPRECATED: use `publish_to` in your pubspec.yaml or set the
-                  \$PUB_HOSTED_URL environment variable.
 
 Run "pub help" to see global options.
 See https://dart.dev/tools/pub/cmd/pub-lish for detailed documentation.

--- a/test/pub_uploader_test.dart
+++ b/test/pub_uploader_test.dart
@@ -20,6 +20,8 @@ Manage uploaders for a package on pub.dartlang.org.
 Usage: pub uploader [options] {add/remove} <email>
 -h, --help       Print this usage information.
     --server     The package server on which the package is hosted.
+                 DEPRECATED: use `publish_to` in your pubspec.yaml or set the
+                 \$PUB_HOSTED_URL environment variable.
                  (defaults to "https://pub.dartlang.org")
     --package    The package whose uploaders will be modified.
                  (defaults to the current package)

--- a/test/pub_uploader_test.dart
+++ b/test/pub_uploader_test.dart
@@ -5,11 +5,10 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
-
-import 'package:pub/src/exit_codes.dart' as exit_codes;
 
 import 'descriptor.dart' as d;
 import 'test_pub.dart';
@@ -19,10 +18,6 @@ Manage uploaders for a package on pub.dartlang.org.
 
 Usage: pub uploader [options] {add/remove} <email>
 -h, --help       Print this usage information.
-    --server     The package server on which the package is hosted.
-                 DEPRECATED: use `publish_to` in your pubspec.yaml or set the
-                 \$PUB_HOSTED_URL environment variable.
-                 (defaults to "https://pub.dartlang.org")
     --package    The package whose uploaders will be modified.
                  (defaults to the current package)
 
@@ -32,8 +27,11 @@ See https://dart.dev/tools/pub/cmd/pub-uploader for detailed documentation.
 
 Future<TestProcess> startPubUploader(PackageServer server, List<String> args) {
   var tokenEndpoint = Uri.parse(server.url).resolve('/token').toString();
-  var allArgs = ['uploader', '--server', tokenEndpoint, ...args];
-  return startPub(args: allArgs, tokenEndpoint: tokenEndpoint);
+  var allArgs = ['uploader', ...args];
+  return startPub(
+      args: allArgs,
+      tokenEndpoint: tokenEndpoint,
+      environment: {'PUB_HOSTED_URL': tokenEndpoint});
 }
 
 void main() {

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -336,8 +336,11 @@ Future runPub(
 Future<PubProcess> startPublish(PackageServer server,
     {List<String> args}) async {
   var tokenEndpoint = Uri.parse(server.url).resolve('/token').toString();
-  args = ['lish', '--server', server.url, ...?args];
-  return await startPub(args: args, tokenEndpoint: tokenEndpoint);
+  args = ['lish', ...?args];
+  return await startPub(
+      args: args,
+      tokenEndpoint: tokenEndpoint,
+      environment: {'PUB_HOSTED_URL': server.url});
 }
 
 /// Handles the beginning confirmation process for uploading a packages.


### PR DESCRIPTION
This argument does not really work optimally.

This also fixes the error message given when
PUB_HOSTED_URL has a bad scheme.

Fixes: https://github.com/dart-lang/pub/issues/2695