### PR TITLE
Avoid manually disabling analytics on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ jobs:
 before_script:
   - dart --snapshot="$_PUB_TEST_SNAPSHOT" bin/pub.dart
   - find test -name "*_test\\.dart" | sort > .dart_tool/test_files
-  - dart --disable-analytics
 
 # Only building these branches means that we don't run two builds for each pull
 # request.


### PR DESCRIPTION
I believe `dart CLI` already knows about this: https://github.com/dart-lang/sdk/blob/master/pkg/dartdev/lib/src/analytics.dart#L126