### PR TITLE
Remove deprecation warning from pub top level.

### DIFF
--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -140,6 +140,9 @@ class PubCommandRunner extends CommandRunner<int> implements PubTopLevel {
   Future<int> runCommand(ArgResults topLevelResults) async {
     _checkDepsSynced();
 
+    await log.warningsOnlyUnlessTerminal(() => log
+        .message('The `pub` command is deprecated. Run `dart pub` instead.'));
+
     if (topLevelResults['version']) {
       log.message('Pub ${sdk.version}');
       return 0;

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -140,7 +140,7 @@ class PubCommandRunner extends CommandRunner<int> implements PubTopLevel {
   Future<int> runCommand(ArgResults topLevelResults) async {
     _checkDepsSynced();
 
-    if (p.basenameWithoutExtension(Platform.executable) == 'pub') {
+    if (Platform.environment['_PUB_DEPRECATED_COMMAND_WARNING'] == 'true') {
       await log.warningsOnlyUnlessTerminal(() => log
           .message('The `pub` command is deprecated. Run `dart pub` instead.'));
     }

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -140,8 +140,10 @@ class PubCommandRunner extends CommandRunner<int> implements PubTopLevel {
   Future<int> runCommand(ArgResults topLevelResults) async {
     _checkDepsSynced();
 
-    await log.warningsOnlyUnlessTerminal(() => log
-        .message('The `pub` command is deprecated. Run `dart pub` instead.'));
+    if (p.basenameWithoutExtension(Platform.executable) == 'pub') {
+      await log.warningsOnlyUnlessTerminal(() => log
+          .message('The `pub` command is deprecated. Run `dart pub` instead.'));
+    }
 
     if (topLevelResults['version']) {
       log.message('Pub ${sdk.version}');

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -140,11 +140,6 @@ class PubCommandRunner extends CommandRunner<int> implements PubTopLevel {
   Future<int> runCommand(ArgResults topLevelResults) async {
     _checkDepsSynced();
 
-    if (Platform.environment['_PUB_DEPRECATED_COMMAND_WARNING'] == 'true') {
-      await log.warningsOnlyUnlessTerminal(() => log
-          .message('The `pub` command is deprecated. Run `dart pub` instead.'));
-    }
-
     if (topLevelResults['version']) {
       log.message('Pub ${sdk.version}');
       return 0;

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -140,9 +140,6 @@ class PubCommandRunner extends CommandRunner<int> implements PubTopLevel {
   Future<int> runCommand(ArgResults topLevelResults) async {
     _checkDepsSynced();
 
-    await log.warningsOnlyUnlessTerminal(() => log
-        .message('The `pub` command is deprecated. Run `dart pub` instead.'));
-
     if (topLevelResults['version']) {
       log.message('Pub ${sdk.version}');
       return 0;


### PR DESCRIPTION
It caused breakage in `dart test` and `flutter pub`.

We considered testing for an environment variable that could be set up in the shell script starting pub in the sdk, but flutter invokes that same shell script.