### PR TITLE
Add CI_set to X-Pub-Environment if the CI environment variable is set

### DIFF
--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -50,9 +50,28 @@ class _PubHttpClient extends http.BaseClient {
       request.headers['X-Pub-Command'] = PubCommand.command;
       request.headers['X-Pub-Session-ID'] = _sessionId;
 
-      var environment = Platform.environment['PUB_ENVIRONMENT'];
-      if (environment != null) {
-        request.headers['X-Pub-Environment'] = environment;
+      String pubEnvironment;
+
+      if (Platform.environment.containsKey('CI')) {
+        pubEnvironment = 'CI_set';
+      }
+
+      var pubEnvironmentValue = Platform.environment['PUB_ENVIRONMENT'];
+
+      if (pubEnvironmentValue != null && pubEnvironmentValue.isNotEmpty) {
+        while (pubEnvironmentValue.startsWith('.')) {
+          pubEnvironmentValue = pubEnvironmentValue.substring(1);
+        }
+
+        if (pubEnvironment == null) {
+          pubEnvironment = pubEnvironmentValue;
+        } else {
+          pubEnvironment = '$pubEnvironment.$pubEnvironmentValue';
+        }
+      }
+
+      if (pubEnvironment != null) {
+        request.headers['X-Pub-Environment'] = pubEnvironment;
       }
 
       var type = Zone.current[#_dependencyType];

--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -52,7 +52,10 @@ class _PubHttpClient extends http.BaseClient {
 
       String pubEnvironment;
 
-      if (Platform.environment.containsKey('CI')) {
+      if (Platform.environment.containsKey('CI') &&
+          Platform.environment['CI'] != 'false') {
+        // Explicitly excluding the case where CI is set to 'false`
+        // This allows us to use this value for testing
         pubEnvironment = 'CI_set';
       }
 

--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -58,7 +58,7 @@ class _PubHttpClient extends http.BaseClient {
 
       var pubEnvironmentValue = Platform.environment['PUB_ENVIRONMENT'];
 
-      if (pubEnvironmentValue != null && pubEnvironmentValue.isNotEmpty) {
+      if (pubEnvironmentValue != null) {
         while (pubEnvironmentValue.startsWith('.')) {
           pubEnvironmentValue = pubEnvironmentValue.substring(1);
         }

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -467,7 +467,7 @@ Future<PubProcess> startPub(
     if (environment != null) ...environment,
     // Explicitly set CI to false if not provided - allows us to test this
     // feature on CI environments with the CI environment set
-    if (environment != null && !environment.containsKey('CI')) 'CI': 'false',
+    if (environment == null || !environment.containsKey('CI')) 'CI': 'false',
   };
 
   return await PubProcess.start(


### PR DESCRIPTION
Allows tracking of CI environments without requiring custom code in each
environment. Setting CI=true is a convention.

Fixes https://github.com/dart-lang/pub/issues/2758
