### PR TITLE
Fix pub remove --dry-run

### DIFF
--- a/lib/src/command/add.dart
+++ b/lib/src/command/add.dart
@@ -134,8 +134,11 @@ class AddCommand extends PubCommand {
 
       await Entrypoint.global(newRoot, entrypoint.lockFile, cache,
               solveResult: solveResult)
-          .acquireDependencies(SolveType.GET,
-              dryRun: true, precompile: argResults['precompile']);
+          .acquireDependencies(
+        SolveType.GET,
+        dryRun: true,
+        precompile: argResults['precompile'],
+      );
     } else {
       /// Update the `pubspec.yaml` before calling [acquireDependencies] to
       /// ensure that the modification timestamp on `pubspec.lock` and

--- a/lib/src/command/add.dart
+++ b/lib/src/command/add.dart
@@ -132,6 +132,7 @@ class AddCommand extends PubCommand {
       /// to this new dependency.
       final newRoot = Package.inMemory(updatedPubSpec);
 
+      // TODO(jonasfj): Stop abusing Entrypoint.global for dry-run output
       await Entrypoint.global(newRoot, entrypoint.lockFile, cache,
               solveResult: solveResult)
           .acquireDependencies(

--- a/lib/src/command/remove.dart
+++ b/lib/src/command/remove.dart
@@ -57,8 +57,11 @@ class RemoveCommand extends PubCommand {
       final newRoot = Package.inMemory(newPubspec);
 
       await Entrypoint.global(newRoot, entrypoint.lockFile, cache)
-          .acquireDependencies(SolveType.GET,
-              precompile: argResults['precompile']);
+          .acquireDependencies(
+        SolveType.GET,
+        precompile: argResults['precompile'],
+        dryRun: true,
+      );
     } else {
       /// Update the pubspec.
       _writeRemovalToPubspec(packages);


### PR DESCRIPTION
Fix case where `pub remove foo --dry-run` might update `PUB_CACHE/global_packages/`

I'm not entirely sure what happens here.. But I think think we are abusing the `Entrypoint.global`
constructor to produce the same output from `--dry-run` as you would get from mutating the
pubspec and running `Entrypoint.acquireDependenices`.