### PR TITLE
Deprecate flutter constraint upper bound

### DIFF
--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -227,6 +227,7 @@ class Package {
     // path package, since re-parsing a path is very expensive relative to
     // string operations.
     Iterable<String> files;
+    print('$useGitIgnore $inGitRepo');
     if (useGitIgnore && inGitRepo) {
       // List all files that aren't gitignored, including those not checked in
       // to Git. Use [beneath] as the working dir rather than passing it as a

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -227,7 +227,6 @@ class Package {
     // path package, since re-parsing a path is very expensive relative to
     // string operations.
     Iterable<String> files;
-    print('$useGitIgnore $inGitRepo');
     if (useGitIgnore && inGitRepo) {
       // List all files that aren't gitignored, including those not checked in
       // to Git. Use [beneath] as the working dir rather than passing it as a

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -342,7 +342,10 @@ class Pubspec {
       }
       if (name.value == 'sdk') return;
 
-      constraints[name.value as String] = _parseVersionConstraint(constraint);
+      constraints[name.value as String] = _parseVersionConstraint(constraint,
+          // Flutter constraints get special treatment, as Flutter won't be
+          // using semantic versioning to mark breaking releases.
+          ignoreUpperBound: name.value == 'flutter');
     });
 
     return constraints;
@@ -676,8 +679,11 @@ class Pubspec {
   /// If or [defaultUpperBoundConstraint] is specified then it will be set as
   /// the max constraint if the original constraint doesn't have an upper
   /// bound and it is compatible with [defaultUpperBoundConstraint].
+  ///
+  /// If [ignoreUpperBound
   VersionConstraint _parseVersionConstraint(YamlNode node,
-      {VersionConstraint defaultUpperBoundConstraint}) {
+      {VersionConstraint defaultUpperBoundConstraint,
+      bool ignoreUpperBound = false}) {
     if (node?.value == null) {
       return defaultUpperBoundConstraint ?? VersionConstraint.any;
     }
@@ -693,6 +699,9 @@ class Pubspec {
           defaultUpperBoundConstraint.allowsAny(constraint)) {
         constraint = VersionConstraint.intersection(
             [constraint, defaultUpperBoundConstraint]);
+      }
+      if (ignoreUpperBound && constraint is VersionRange) {
+        return VersionRange(min: constraint.min);
       }
       return constraint;
     });

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -680,7 +680,7 @@ class Pubspec {
   /// the max constraint if the original constraint doesn't have an upper
   /// bound and it is compatible with [defaultUpperBoundConstraint].
   ///
-  /// If [ignoreUpperBound
+  /// If [ignoreUpperBound] the max constraint is ignored.
   VersionConstraint _parseVersionConstraint(YamlNode node,
       {VersionConstraint defaultUpperBoundConstraint,
       bool ignoreUpperBound = false}) {
@@ -701,7 +701,8 @@ class Pubspec {
             [constraint, defaultUpperBoundConstraint]);
       }
       if (ignoreUpperBound && constraint is VersionRange) {
-        return VersionRange(min: constraint.min);
+        return VersionRange(
+            min: constraint.min, includeMin: constraint.includeMin);
       }
       return constraint;
     });

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -17,6 +17,7 @@ import 'validator/dependency_override.dart';
 import 'validator/deprecated_fields.dart';
 import 'validator/directory.dart';
 import 'validator/executable.dart';
+import 'validator/flutter_constraint.dart';
 import 'validator/flutter_plugin_format.dart';
 import 'validator/language_version.dart';
 import 'validator/license.dart';
@@ -135,6 +136,7 @@ abstract class Validator {
       ChangelogValidator(entrypoint),
       SdkConstraintValidator(entrypoint),
       StrictDependenciesValidator(entrypoint),
+      FlutterConstraintValidator(entrypoint),
       FlutterPluginFormatValidator(entrypoint),
       LanguageVersionValidator(entrypoint),
       RelativeVersionNumberingValidator(entrypoint, serverUrl),

--- a/lib/src/validator/flutter_constraint.dart
+++ b/lib/src/validator/flutter_constraint.dart
@@ -14,7 +14,7 @@ class FlutterConstraintValidator extends Validator {
   FlutterConstraintValidator(Entrypoint entrypoint) : super(entrypoint);
   // TODO(sigurdm): Find a proper url for explaining this.
   static const explanationUrl =
-      'https://github.com/flutter/flutter/issues/68143';
+      'https://dart.dev/go/flutter-upper-bound-deprecation';
 
   @override
   Future validate() async {

--- a/lib/src/validator/flutter_constraint.dart
+++ b/lib/src/validator/flutter_constraint.dart
@@ -12,7 +12,6 @@ import '../validator.dart';
 /// Validates that a package's flutter constraint doesn't contain an upper bound
 class FlutterConstraintValidator extends Validator {
   FlutterConstraintValidator(Entrypoint entrypoint) : super(entrypoint);
-  // TODO(sigurdm): Find a proper url for explaining this.
   static const explanationUrl =
       'https://dart.dev/go/flutter-upper-bound-deprecation';
 

--- a/lib/src/validator/flutter_constraint.dart
+++ b/lib/src/validator/flutter_constraint.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:pub_semver/pub_semver.dart';
+
+import '../entrypoint.dart';
+import '../validator.dart';
+
+/// Validates that a package's flutter constraint doesn't contain an upper bound
+class FlutterConstraintValidator extends Validator {
+  FlutterConstraintValidator(Entrypoint entrypoint) : super(entrypoint);
+  // TODO(sigurdm): Find a proper url for explaining this.
+  static const explanationUrl =
+      'https://github.com/flutter/flutter/issues/68143';
+
+  @override
+  Future validate() async {
+    final environment = entrypoint.root.pubspec.fields['environment'];
+    if (environment is Map) {
+      final flutterConstraint = environment['flutter'];
+      if (flutterConstraint is String) {
+        final constraint = VersionConstraint.parse(flutterConstraint);
+        if (constraint is VersionRange && constraint.max != null) {
+          final replacement = constraint.min == null
+              ? 'You can replace the constraint with `any`.'
+              : 'You can replace that with just the lower bound: `>=${constraint.min}`.';
+
+          warnings.add('''
+The Flutter constraint should not have an upper bound.
+In your pubspec.yaml the constraint is currently `$flutterConstraint`.
+
+$replacement
+
+See $explanationUrl''');
+        }
+      }
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,4 @@
 name: pub
-publish_to: none
 
 environment:
   sdk: ">=2.11.0-0 <3.0.0"

--- a/test/get/flutter_constraint_upper_bound_ignored_test.dart
+++ b/test/get/flutter_constraint_upper_bound_ignored_test.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+void main() {
+  test('pub get succeeds despite of "invalid" flutter upper bound', () async {
+    final fakeFlutterRoot =
+        d.dir('fake_flutter_root', [d.file('version', '1.23.0')]);
+    await fakeFlutterRoot.create();
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'environment': {'flutter': '>=0.5.0 <1.0.0'}
+      }),
+    ]).create();
+
+    await pubGet(
+        exitCode: exit_codes.SUCCESS,
+        environment: {'FLUTTER_ROOT': fakeFlutterRoot.io.path});
+  });
+}

--- a/test/must_pub_get_test.dart
+++ b/test/must_pub_get_test.dart
@@ -348,14 +348,14 @@ foo:http://example.com/
 
       await pubGet(environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')});
 
-      await d.dir('flutter', [d.file('version', '2.4.6')]).create();
+      await d.dir('flutter', [d.file('version', '0.9.0')]).create();
 
       // Run pub manually here because otherwise we don't have access to
       // d.sandbox.
       await runPub(
           args: ['run', 'script'],
           environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')},
-          error: "Flutter 2.4.6 is incompatible with your dependencies' SDK "
+          error: "Flutter 0.9.0 is incompatible with your dependencies' SDK "
               'constraints. Please run "pub get" again.',
           exitCode: exit_codes.DATA);
     });

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -393,7 +393,7 @@ environment:
         expect(pubspec.sdkConstraints,
             containsPair('dart', VersionConstraint.parse('>=1.2.3 <2.3.4')));
         expect(pubspec.sdkConstraints,
-            containsPair('flutter', VersionConstraint.parse('^0.1.2')));
+            containsPair('flutter', VersionConstraint.parse('>=0.1.2')));
         expect(pubspec.sdkConstraints,
             containsPair('fuchsia', VersionConstraint.parse('^5.6.7')));
       });
@@ -574,7 +574,7 @@ features:
         expect(feature.sdkConstraints,
             containsPair('dart', VersionConstraint.parse('^1.0.0')));
         expect(feature.sdkConstraints,
-            containsPair('flutter', VersionConstraint.parse('^2.0.0')));
+            containsPair('flutter', VersionConstraint.parse('>=2.0.0')));
         expect(feature.sdkConstraints,
             containsPair('fuchsia', VersionConstraint.parse('^3.0.0')));
       });

--- a/test/validator/flutter_constraint_test.dart
+++ b/test/validator/flutter_constraint_test.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+Future<void> expectValidation(error, int exitCode) async {
+  await runPub(
+    error: error,
+    args: ['publish', '--dry-run'],
+    environment: {'_PUB_TEST_SDK_VERSION': '2.12.0'},
+    workingDirectory: d.path(appPath),
+    exitCode: exitCode,
+  );
+}
+
+Future<void> setup({
+  String flutterConstraint,
+}) async {
+  final fakeFlutterRoot =
+      d.dir('fake_flutter_root', [d.file('version', '1.23.0')]);
+  await fakeFlutterRoot.create();
+  await d.validPackage.create();
+  await d.dir(appPath, [
+    d.pubspec({
+      'name': 'test_pkg',
+      'description':
+          'A just long enough decription to fit the requirement of 60 characters',
+      'homepage': 'https://example.com/',
+      'version': '1.0.0',
+      'environment': {
+        'sdk': '>=2.9.0 <3.0.0',
+        if (flutterConstraint != null) 'flutter': flutterConstraint
+      },
+    }),
+  ]).create();
+  await pubGet(environment: {
+    '_PUB_TEST_SDK_VERSION': '2.12.0',
+    'FLUTTER_ROOT': fakeFlutterRoot.io.path
+  });
+}
+
+void main() {
+  test('No warning with no flutter constraint', () async {
+    await setup();
+    await expectValidation(contains('Package has 0 warnings.'), 0);
+  });
+  test('No warning with no flutter upper bound', () async {
+    await setup(flutterConstraint: '>=1.20.0');
+    await expectValidation(contains('Package has 0 warnings.'), 0);
+  });
+  test('Warn when upper bound', () async {
+    await setup(flutterConstraint: '>=1.20.0 <=2.0.0');
+    await expectValidation(
+        allOf([
+          contains(
+              'You can replace that with just the lower bound: `>=1.20.0`.'),
+          contains('Package has 1 warning.'),
+        ]),
+        65);
+  });
+  test('Warn when only upper bound', () async {
+    await setup(flutterConstraint: '<2.0.0');
+    await expectValidation(
+        allOf([
+          contains('You can replace the constraint with `any`.'),
+          contains('Package has 1 warning.'),
+        ]),
+        65);
+  });
+}


### PR DESCRIPTION
Ignore any flutter sdk upper bound when parsing `pubspec.yaml`s.

Warn about the flutter sdk upper bounds before publishing.

We need a better url to point to.