### PR TITLE
Fix reproduction command

### DIFF
--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -183,7 +183,7 @@ abstract class PubCommand extends Command<int> {
         log.error("""
 This is an unexpected error. Please run
 
-    pub --trace ${runner.executableName} ${_topCommand.name} ${_topCommand.argResults.arguments.map(protectArgument).join(' ')}
+    dart pub --trace ${_topCommand.name} ${_topCommand.argResults.arguments.map(protectArgument).join(' ')}
 
 and include the logs in an issue on https://github.com/dart-lang/pub/issues/new
 """);


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub/issues/2792

By always asking for `dart pub --trace` we should get correct reproduction of both `flutter pub` and `pub` toplevel commands, even though the command looks different. (the `dart` executable in flutter/bin will set the FLUTTER_ROOT variable leading to the right behaviour.).