### PR TITLE
Minor refactoring of BoundSource to reduce risk of mistakes

### DIFF
--- a/lib/src/solver/package_lister.dart
+++ b/lib/src/solver/package_lister.dart
@@ -440,14 +440,10 @@ class _RootSource extends BoundSource {
 
   @override
   Source get source => throw _unsupported;
+
   @override
   SystemCache get systemCache => throw _unsupported;
-  @override
-  Future<List<PackageId>> doGetVersions(PackageRef ref) => throw _unsupported;
-  @override
-  Future<Pubspec> doDescribe(PackageId id) => throw _unsupported;
-  @override
-  Future get(PackageId id, String symlink) => throw _unsupported;
+
   @override
   String getDirectory(PackageId id) => throw _unsupported;
 }

--- a/lib/src/source/cached.dart
+++ b/lib/src/source/cached.dart
@@ -20,7 +20,7 @@ import '../source.dart';
 /// packages or the package needs to be "frozen" at the point in time that it's
 /// installed. (For example, Git packages are cached because installing from
 /// the same repo over time may yield different commits.)
-abstract class CachedSource extends BoundSource {
+abstract class CachedSource extends BoundSourceBase {
   /// The root directory of this source's cache within the system cache.
   ///
   /// This shouldn't be overridden by subclasses.
@@ -29,6 +29,7 @@ abstract class CachedSource extends BoundSource {
   /// If [id] is already in the system cache, just loads it from there.
   ///
   /// Otherwise, defers to the subclass.
+  @protected
   @override
   Future<Pubspec> doDescribe(PackageId id) async {
     var packageDir = getDirectory(id);
@@ -46,13 +47,6 @@ abstract class CachedSource extends BoundSource {
   /// This will only be called for packages that have not yet been installed in
   /// the system cache.
   Future<Pubspec> describeUncached(PackageId id);
-
-  @override
-  Future get(PackageId id, String symlink) {
-    return downloadToSystemCache(id).then((pkg) {
-      createPackageSymlink(id.name, pkg.dir, symlink);
-    });
-  }
 
   /// Determines if the package identified by [id] is already downloaded to the
   /// system cache.

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -224,6 +225,7 @@ class BoundGitSource extends CachedSource {
     });
   }
 
+  @protected
   @override
   Future<List<PackageId>> doGetVersions(PackageRef ref) async {
     return await _pool.withResource(() async {

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -8,6 +8,7 @@ import 'dart:io' as io;
 
 import 'package:collection/collection.dart' show maxBy;
 import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:pedantic/pedantic.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -228,6 +229,7 @@ class BoundHostedSource extends CachedSource {
 
   /// Downloads a list of all versions of a package that are available from the
   /// site.
+  @protected
   @override
   Future<List<PackageId>> doGetVersions(PackageRef ref) async {
     final versions = await _scheduler.schedule(ref);
@@ -520,6 +522,7 @@ class _OfflineHostedSource extends BoundHostedSource {
       : super(source, systemCache);
 
   /// Gets the list of all versions of [ref] that are in the system cache.
+  @protected
   @override
   Future<List<PackageId>> doGetVersions(PackageRef ref) async {
     var parsed = source._parseDescription(ref.description);

--- a/lib/src/source/path.dart
+++ b/lib/src/source/path.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 
@@ -153,7 +154,7 @@ class PathSource extends Source {
 }
 
 /// The [BoundSource] for [PathSource].
-class BoundPathSource extends BoundSource {
+class BoundPathSource extends BoundSourceBase {
   @override
   final PathSource source;
 
@@ -162,6 +163,7 @@ class BoundPathSource extends BoundSource {
 
   BoundPathSource(this.source, this.systemCache);
 
+  @protected
   @override
   Future<List<PackageId>> doGetVersions(PackageRef ref) async {
     // There's only one package ID for a given path. We just need to find the
@@ -172,21 +174,13 @@ class BoundPathSource extends BoundSource {
     return [id];
   }
 
+  @protected
   @override
   Future<Pubspec> doDescribe(PackageId id) async => _loadPubspec(id.toRef());
 
   Pubspec _loadPubspec(PackageRef ref) {
     var dir = _validatePath(ref.name, ref.description);
     return Pubspec.load(dir, systemCache.sources, expectedName: ref.name);
-  }
-
-  @override
-  Future get(PackageId id, String symlink) {
-    return Future.sync(() {
-      var dir = _validatePath(id.name, id.description);
-      createPackageSymlink(id.name, dir, symlink,
-          relative: id.description['relative']);
-    });
   }
 
   @override

--- a/lib/src/source/sdk.dart
+++ b/lib/src/source/sdk.dart
@@ -4,10 +4,10 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../exceptions.dart';
-import '../io.dart';
 import '../package_name.dart';
 import '../pubspec.dart';
 import '../sdk.dart';
@@ -61,7 +61,7 @@ class SdkSource extends Source {
 }
 
 /// The [BoundSource] for [SdkSource].
-class BoundSdkSource extends BoundSource {
+class BoundSdkSource extends BoundSourceBase {
   @override
   final SdkSource source;
 
@@ -70,6 +70,7 @@ class BoundSdkSource extends BoundSource {
 
   BoundSdkSource(this.source, this.systemCache);
 
+  @protected
   @override
   Future<List<PackageId>> doGetVersions(PackageRef ref) async {
     var pubspec = _loadPubspec(ref);
@@ -78,6 +79,7 @@ class BoundSdkSource extends BoundSource {
     return [id];
   }
 
+  @protected
   @override
   Future<Pubspec> doDescribe(PackageId id) async => _loadPubspec(id);
 
@@ -88,11 +90,6 @@ class BoundSdkSource extends BoundSource {
   Pubspec _loadPubspec(PackageName package) =>
       Pubspec.load(_verifiedPackagePath(package), systemCache.sources,
           expectedName: package.name);
-
-  @override
-  Future get(PackageId id, String symlink) async {
-    createPackageSymlink(id.name, _verifiedPackagePath(id), symlink);
-  }
 
   /// Returns the path for the given [package].
   ///

--- a/lib/src/source/unknown.dart
+++ b/lib/src/source/unknown.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../package_name.dart';
@@ -51,7 +52,7 @@ class UnknownSource extends Source {
       PackageId(name, this, version, description);
 }
 
-class _BoundUnknownSource extends BoundSource {
+class _BoundUnknownSource extends BoundSourceBase {
   @override
   final UnknownSource source;
 
@@ -60,18 +61,16 @@ class _BoundUnknownSource extends BoundSource {
 
   _BoundUnknownSource(this.source, this.systemCache);
 
+  @protected
   @override
   Future<List<PackageId>> doGetVersions(PackageRef ref) =>
       throw UnsupportedError(
           "Cannot get package versions from unknown source '${source.name}'.");
 
+  @protected
   @override
   Future<Pubspec> doDescribe(PackageId id) => throw UnsupportedError(
       "Cannot describe a package from unknown source '${source.name}'.");
-
-  @override
-  Future get(PackageId id, String symlink) =>
-      throw UnsupportedError("Cannot get an unknown source '${source.name}'.");
 
   /// Returns the directory where this package can be found locally.
   @override


### PR DESCRIPTION
I'm not sure about `BoundSourceBase`, maybe we should make it go away completely.
Or change it into a mix-in or something else.. I just really liked using
`@visibleForOverridding`, `@protected` and `@nonVirtual` because they protect us from making mistakes.

I'm also not sure we need to use `BoundSourceBase` for `_BoundUnknownSource`, but that
might be something we can cleanup later.