### PR TITLE
Use Dart library to read and write tar files

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -850,7 +850,8 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
         }
 
         ensureDir(parentDirectory);
-        createSymlink(path.relative(resolvedTarget, from: destination), filePath);
+        createSymlink(
+            path.relative(resolvedTarget, from: parentDirectory), filePath);
         break;
       case TypeFlag.link:
         // We generate hardlinks as symlinks too, but their path needs to be

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -824,18 +824,20 @@ ByteStream createTarGz(List<String> contents, {String baseDir}) {
   baseDir = path.absolute(baseDir);
 
   final tarContents = Stream.fromIterable(contents.map((entry) {
-    entry = path.absolute(path.normalize(entry));
+    entry = path.absolute(entry);
     if (!path.isWithin(baseDir, entry)) {
       throw ArgumentError('Entry $entry is not inside $baseDir.');
     }
 
     final relative = path.relative(entry, from: baseDir);
-    final file = File(entry);
+    // On Windows, we can't open some files without normalizing them
+    final file = File(path.normalize(entry));
     final stat = file.statSync();
 
     return tar.Entry(
       tar.Header(
-        name: relative,
+        // Ensure paths in tar files use forward slashes
+        name: path.url.joinAll(path.split(relative)),
         mode: stat.mode,
         size: stat.size,
         lastModified: stat.changed,

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -824,7 +824,7 @@ ByteStream createTarGz(List<String> contents, {String baseDir}) {
   baseDir = path.absolute(baseDir);
 
   final tarContents = Stream.fromIterable(contents.map((entry) {
-    entry = path.absolute(entry);
+    entry = path.absolute(path.normalize(entry));
     if (!path.isWithin(baseDir, entry)) {
       throw ArgumentError('Entry $entry is not inside $baseDir.');
     }

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -822,6 +822,15 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
 
     final parentDirectory = path.dirname(filePath);
 
+    bool checkValidTarget(String linkTarget) {
+      final isValid = path.isWithin(destination, linkTarget);
+      if (!isValid) {
+        log.fine('Skipping ${entry.name}: Invalid link target');
+      }
+
+      return isValid;
+    }
+
     switch (entry.type) {
       case TypeFlag.dir:
         ensureDir(filePath);
@@ -848,7 +857,7 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
         // Link to another file in this tar, relative from this entry.
         final resolvedTarget = path.joinAll(
             [parentDirectory, ...path.posix.split(entry.header.linkName)]);
-        if (!path.isWithin(destination, resolvedTarget)) {
+        if (!checkValidTarget(resolvedTarget)) {
           // Don't allow links to files outside of this tar.
           break;
         }
@@ -862,7 +871,7 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
         // to the root of the tar file (unlike symlink entries, whose linkName
         // is relative to the entry itself).
         final fromDestination = path.join(destination, entry.header.linkName);
-        if (!path.isWithin(destination, fromDestination)) {
+        if (!checkValidTarget(fromDestination)) {
           break; // Link points outside of the tar file.
         }
 

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -850,7 +850,7 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
         }
 
         ensureDir(parentDirectory);
-        createSymlink(resolvedTarget, filePath);
+        createSymlink(path.relative(resolvedTarget, from: destination), filePath);
         break;
       case TypeFlag.link:
         // We generate hardlinks as symlinks too, but their path needs to be

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -808,7 +808,7 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
         // Regular file
         deleteIfLink(filePath);
         ensureDir(parentDirectory);
-        await _createFileFromStream(entry, filePath);
+        await _createFileFromStream(entry.contents, filePath);
         break;
       case TypeFlag.symlink:
         // Link to another file in this tar, relative from this entry

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   shelf: ^0.7.0
   source_span: ^1.4.0
   stack_trace: ^1.0.0
-  tar: ^0.1.0-nullsafety.1
+  tar: ^0.2.0-nullsafety
   yaml: ^2.2.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   shelf: ^0.7.0
   source_span: ^1.4.0
   stack_trace: ^1.0.0
+  tar: ^0.1.0-nullsafety.1
   yaml: ^2.2.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   shelf: ^0.7.0
   source_span: ^1.4.0
   stack_trace: ^1.0.0
-  tar: ^0.2.0-nullsafety
+  tar: ^0.3.0-nullsafety
   yaml: ^2.2.0
 
 dev_dependencies:

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 import 'package:pub/src/exceptions.dart';
 import 'package:pub/src/io.dart';
+import 'package:tar/tar.dart';
 import 'package:test/test.dart';
 
 import 'descriptor.dart' as d;
@@ -408,7 +409,7 @@ void testExistencePredicate(String name, bool Function(String path) predicate,
                   ],
                 ),
                 tempDir),
-            throwsA(isA<FileSystemException>()));
+            throwsA(isA<TarException>()));
       });
     });
 

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -415,14 +415,18 @@ void testExistencePredicate(String name, bool Function(String path) predicate,
     test('throws on gzip error', () async {
       await withTempDir((tempDir) async {
         await expectLater(
-            () async => await extractTarGz(
-                Stream.fromIterable(
-                  [
-                    [10, 20, 30] // Not a good gz stream.
-                  ],
-                ),
-                tempDir),
-            throwsA(isA<FileSystemException>()));
+          () async => await extractTarGz(
+              Stream.fromIterable(
+                [
+                  [10, 20, 30] // Not a good gz stream.
+                ],
+              ),
+              tempDir),
+          throwsA(
+            isA<FormatException>().having((e) => e.message, 'message',
+                contains('Filter error, bad data')),
+          ),
+        );
       });
     });
   });

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -228,149 +228,6 @@ void main() {
     });
   });
 
-  testExistencePredicate('entryExists', entryExists,
-      forFile: true,
-      forFileSymlink: true,
-      forMultiLevelFileSymlink: true,
-      forDirectory: true,
-      forDirectorySymlink: true,
-      forMultiLevelDirectorySymlink: true,
-      forBrokenSymlink: true,
-      forMultiLevelBrokenSymlink: true);
-
-  testExistencePredicate('linkExists', linkExists,
-      forFile: false,
-      forFileSymlink: true,
-      forMultiLevelFileSymlink: true,
-      forDirectory: false,
-      forDirectorySymlink: true,
-      forMultiLevelDirectorySymlink: true,
-      forBrokenSymlink: true,
-      forMultiLevelBrokenSymlink: true);
-
-  testExistencePredicate('fileExists', fileExists,
-      forFile: true,
-      forFileSymlink: true,
-      forMultiLevelFileSymlink: true,
-      forDirectory: false,
-      forDirectorySymlink: false,
-      forMultiLevelDirectorySymlink: false,
-      forBrokenSymlink: false,
-      forMultiLevelBrokenSymlink: false);
-
-  testExistencePredicate('dirExists', dirExists,
-      forFile: false,
-      forFileSymlink: false,
-      forMultiLevelFileSymlink: false,
-      forDirectory: true,
-      forDirectorySymlink: true,
-      forMultiLevelDirectorySymlink: true,
-      forBrokenSymlink: false,
-      forMultiLevelBrokenSymlink: false);
-}
-
-void testExistencePredicate(String name, bool Function(String path) predicate,
-    {bool forFile,
-    bool forFileSymlink,
-    bool forMultiLevelFileSymlink,
-    bool forDirectory,
-    bool forDirectorySymlink,
-    bool forMultiLevelDirectorySymlink,
-    bool forBrokenSymlink,
-    bool forMultiLevelBrokenSymlink}) {
-  group(name, () {
-    test('returns $forFile for a file', () {
-      expect(withTempDir((temp) {
-        var file = path.join(temp, 'test.txt');
-        writeTextFile(file, 'contents');
-        expect(predicate(file), equals(forFile));
-      }), completes);
-    });
-
-    test('returns $forDirectory for a directory', () {
-      expect(withTempDir((temp) {
-        var file = path.join(temp, 'dir');
-        _createDir(file);
-        expect(predicate(file), equals(forDirectory));
-      }), completes);
-    });
-
-    test('returns $forDirectorySymlink for a symlink to a directory', () {
-      expect(withTempDir((temp) {
-        var targetPath = path.join(temp, 'dir');
-        var symlinkPath = path.join(temp, 'linkdir');
-        _createDir(targetPath);
-        createSymlink(targetPath, symlinkPath);
-        expect(predicate(symlinkPath), equals(forDirectorySymlink));
-      }), completes);
-    });
-
-    test(
-        'returns $forMultiLevelDirectorySymlink for a multi-level symlink to '
-        'a directory', () {
-      expect(withTempDir((temp) {
-        var targetPath = path.join(temp, 'dir');
-        var symlink1Path = path.join(temp, 'link1dir');
-        var symlink2Path = path.join(temp, 'link2dir');
-        _createDir(targetPath);
-        createSymlink(targetPath, symlink1Path);
-        createSymlink(symlink1Path, symlink2Path);
-        expect(predicate(symlink2Path), equals(forMultiLevelDirectorySymlink));
-      }), completes);
-    });
-
-    test('returns $forBrokenSymlink for a broken symlink', () {
-      expect(withTempDir((temp) {
-        var targetPath = path.join(temp, 'dir');
-        var symlinkPath = path.join(temp, 'linkdir');
-        _createDir(targetPath);
-        createSymlink(targetPath, symlinkPath);
-        deleteEntry(targetPath);
-        expect(predicate(symlinkPath), equals(forBrokenSymlink));
-      }), completes);
-    });
-
-    test('returns $forMultiLevelBrokenSymlink for a multi-level broken symlink',
-        () {
-      expect(withTempDir((temp) {
-        var targetPath = path.join(temp, 'dir');
-        var symlink1Path = path.join(temp, 'link1dir');
-        var symlink2Path = path.join(temp, 'link2dir');
-        _createDir(targetPath);
-        createSymlink(targetPath, symlink1Path);
-        createSymlink(symlink1Path, symlink2Path);
-        deleteEntry(targetPath);
-        expect(predicate(symlink2Path), equals(forMultiLevelBrokenSymlink));
-      }), completes);
-    });
-
-    // Windows doesn't support symlinking to files.
-    if (!Platform.isWindows) {
-      test('returns $forFileSymlink for a symlink to a file', () {
-        expect(withTempDir((temp) {
-          var targetPath = path.join(temp, 'test.txt');
-          var symlinkPath = path.join(temp, 'link.txt');
-          writeTextFile(targetPath, 'contents');
-          createSymlink(targetPath, symlinkPath);
-          expect(predicate(symlinkPath), equals(forFileSymlink));
-        }), completes);
-      });
-
-      test(
-          'returns $forMultiLevelFileSymlink for a multi-level symlink to a '
-          'file', () {
-        expect(withTempDir((temp) {
-          var targetPath = path.join(temp, 'test.txt');
-          var symlink1Path = path.join(temp, 'link1.txt');
-          var symlink2Path = path.join(temp, 'link2.txt');
-          writeTextFile(targetPath, 'contents');
-          createSymlink(targetPath, symlink1Path);
-          createSymlink(symlink1Path, symlink2Path);
-          expect(predicate(symlink2Path), equals(forMultiLevelFileSymlink));
-        }), completes);
-      });
-    }
-  });
   group('extractTarGz', () {
     test('decompresses simple archive', () async {
       await withTempDir((tempDir) async {
@@ -520,6 +377,150 @@ void testExistencePredicate(String name, bool Function(String path) predicate,
         await expectLater(Directory(tempDir).list(), emitsDone);
       });
     });
+  });
+
+  testExistencePredicate('entryExists', entryExists,
+      forFile: true,
+      forFileSymlink: true,
+      forMultiLevelFileSymlink: true,
+      forDirectory: true,
+      forDirectorySymlink: true,
+      forMultiLevelDirectorySymlink: true,
+      forBrokenSymlink: true,
+      forMultiLevelBrokenSymlink: true);
+
+  testExistencePredicate('linkExists', linkExists,
+      forFile: false,
+      forFileSymlink: true,
+      forMultiLevelFileSymlink: true,
+      forDirectory: false,
+      forDirectorySymlink: true,
+      forMultiLevelDirectorySymlink: true,
+      forBrokenSymlink: true,
+      forMultiLevelBrokenSymlink: true);
+
+  testExistencePredicate('fileExists', fileExists,
+      forFile: true,
+      forFileSymlink: true,
+      forMultiLevelFileSymlink: true,
+      forDirectory: false,
+      forDirectorySymlink: false,
+      forMultiLevelDirectorySymlink: false,
+      forBrokenSymlink: false,
+      forMultiLevelBrokenSymlink: false);
+
+  testExistencePredicate('dirExists', dirExists,
+      forFile: false,
+      forFileSymlink: false,
+      forMultiLevelFileSymlink: false,
+      forDirectory: true,
+      forDirectorySymlink: true,
+      forMultiLevelDirectorySymlink: true,
+      forBrokenSymlink: false,
+      forMultiLevelBrokenSymlink: false);
+}
+
+void testExistencePredicate(String name, bool Function(String path) predicate,
+    {bool forFile,
+    bool forFileSymlink,
+    bool forMultiLevelFileSymlink,
+    bool forDirectory,
+    bool forDirectorySymlink,
+    bool forMultiLevelDirectorySymlink,
+    bool forBrokenSymlink,
+    bool forMultiLevelBrokenSymlink}) {
+  group(name, () {
+    test('returns $forFile for a file', () {
+      expect(withTempDir((temp) {
+        var file = path.join(temp, 'test.txt');
+        writeTextFile(file, 'contents');
+        expect(predicate(file), equals(forFile));
+      }), completes);
+    });
+
+    test('returns $forDirectory for a directory', () {
+      expect(withTempDir((temp) {
+        var file = path.join(temp, 'dir');
+        _createDir(file);
+        expect(predicate(file), equals(forDirectory));
+      }), completes);
+    });
+
+    test('returns $forDirectorySymlink for a symlink to a directory', () {
+      expect(withTempDir((temp) {
+        var targetPath = path.join(temp, 'dir');
+        var symlinkPath = path.join(temp, 'linkdir');
+        _createDir(targetPath);
+        createSymlink(targetPath, symlinkPath);
+        expect(predicate(symlinkPath), equals(forDirectorySymlink));
+      }), completes);
+    });
+
+    test(
+        'returns $forMultiLevelDirectorySymlink for a multi-level symlink to '
+        'a directory', () {
+      expect(withTempDir((temp) {
+        var targetPath = path.join(temp, 'dir');
+        var symlink1Path = path.join(temp, 'link1dir');
+        var symlink2Path = path.join(temp, 'link2dir');
+        _createDir(targetPath);
+        createSymlink(targetPath, symlink1Path);
+        createSymlink(symlink1Path, symlink2Path);
+        expect(predicate(symlink2Path), equals(forMultiLevelDirectorySymlink));
+      }), completes);
+    });
+
+    test('returns $forBrokenSymlink for a broken symlink', () {
+      expect(withTempDir((temp) {
+        var targetPath = path.join(temp, 'dir');
+        var symlinkPath = path.join(temp, 'linkdir');
+        _createDir(targetPath);
+        createSymlink(targetPath, symlinkPath);
+        deleteEntry(targetPath);
+        expect(predicate(symlinkPath), equals(forBrokenSymlink));
+      }), completes);
+    });
+
+    test('returns $forMultiLevelBrokenSymlink for a multi-level broken symlink',
+        () {
+      expect(withTempDir((temp) {
+        var targetPath = path.join(temp, 'dir');
+        var symlink1Path = path.join(temp, 'link1dir');
+        var symlink2Path = path.join(temp, 'link2dir');
+        _createDir(targetPath);
+        createSymlink(targetPath, symlink1Path);
+        createSymlink(symlink1Path, symlink2Path);
+        deleteEntry(targetPath);
+        expect(predicate(symlink2Path), equals(forMultiLevelBrokenSymlink));
+      }), completes);
+    });
+
+    // Windows doesn't support symlinking to files.
+    if (!Platform.isWindows) {
+      test('returns $forFileSymlink for a symlink to a file', () {
+        expect(withTempDir((temp) {
+          var targetPath = path.join(temp, 'test.txt');
+          var symlinkPath = path.join(temp, 'link.txt');
+          writeTextFile(targetPath, 'contents');
+          createSymlink(targetPath, symlinkPath);
+          expect(predicate(symlinkPath), equals(forFileSymlink));
+        }), completes);
+      });
+
+      test(
+          'returns $forMultiLevelFileSymlink for a multi-level symlink to a '
+          'file', () {
+        expect(withTempDir((temp) {
+          var targetPath = path.join(temp, 'test.txt');
+          var symlink1Path = path.join(temp, 'link1.txt');
+          var symlink2Path = path.join(temp, 'link2.txt');
+          writeTextFile(targetPath, 'contents');
+          createSymlink(targetPath, symlink1Path);
+          createSymlink(symlink1Path, symlink2Path);
+          expect(predicate(symlink2Path), equals(forMultiLevelFileSymlink));
+        }), completes);
+      });
+    }
   });
 }
 


### PR DESCRIPTION
Uses `pkg:tar` to read and write tar files. That package is based on stream transformers and generally tries to minimize memory overhead. It supports the ustar format and extended PAX headers.

For testing, I ran `tool/extract_all_pub_dev.dart`, but only with the latest version of each package. To test backwards-compatibility, I published some packages with `pkg:tar` to a personal pub server and downloaded them with the regular pub on Linux and Windows. I don't have access to a Mac, but I can run more tests on the other OSes if needed.

Full disclosure: I wrote the tar package. 
Closes #1602 (and a bunch of related issues).