### PR TITLE
Allow package_config.json to contain flutter_gen

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -624,12 +624,7 @@ class Entrypoint {
 
       // Make sure that the packagePath agrees with the lock file about the
       // path to the package.
-      //
-      // TODO(sigurdm): We use the absolute paths to work around:
-      // https://github.com/dart-lang/package_config/issues/99
-      // For the case where Flutter has rewritten package_config.json.
-      if (p.absolute(p.normalize(packagePath)) !=
-          p.absolute(p.normalize(lockFilePackagePath))) {
+      if (p.normalize(packagePath) != p.normalize(lockFilePackagePath)) {
         return false;
       }
 

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -624,7 +624,12 @@ class Entrypoint {
 
       // Make sure that the packagePath agrees with the lock file about the
       // path to the package.
-      if (p.normalize(packagePath) != p.normalize(lockFilePackagePath)) {
+      //
+      // TODO(sigurdm): We use the absolute paths to work around:
+      // https://github.com/dart-lang/package_config/issues/99
+      // For the case where Flutter has rewritten package_config.json.
+      if (p.absolute(p.normalize(packagePath)) !=
+          p.absolute(p.normalize(lockFilePackagePath))) {
         return false;
       }
 
@@ -730,7 +735,8 @@ class Entrypoint {
     final packagesToCheck =
         cfg.packages.where((package) => package.name != 'flutter_gen');
     for (final pkg in packagesToCheck) {
-      // Pub always sets packageUri = lib/
+      // Pub always sets packageUri = 'lib/' but package:package_config might
+      // change it to 'lib'.
       if (pkg.packageUri == null ||
           (pkg.packageUri.toString() != 'lib' &&
               pkg.packageUri.toString() != 'lib/')) {

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -735,11 +735,8 @@ class Entrypoint {
     final packagesToCheck =
         cfg.packages.where((package) => package.name != 'flutter_gen');
     for (final pkg in packagesToCheck) {
-      // Pub always sets packageUri = 'lib/' but package:package_config might
-      // change it to 'lib'.
-      if (pkg.packageUri == null ||
-          (pkg.packageUri.toString() != 'lib' &&
-              pkg.packageUri.toString() != 'lib/')) {
+      // Pub always makes a packageUri of lib/
+      if (pkg.packageUri == null || pkg.packageUri.toString() != 'lib/') {
         badPackageConfig();
       }
       packagePathsMapping[pkg.name] =

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -31,7 +31,7 @@ class Package {
     return a.version.compareTo(b.version);
   }
 
-  /// The (absolute) path to the directory containing the package.
+  /// The path to the directory containing the package.
   final String dir;
 
   /// An in-memory package can be created for doing a resolution without having
@@ -135,9 +135,8 @@ class Package {
   /// [name] is the expected name of that package (e.g. the name given in the
   /// dependency), or `null` if the package being loaded is the entrypoint
   /// package.
-  Package.load(String name, String dir, SourceRegistry sources)
-      : pubspec = Pubspec.load(dir, sources, expectedName: name),
-        dir = p.absolute(dir);
+  Package.load(String name, this.dir, SourceRegistry sources)
+      : pubspec = Pubspec.load(dir, sources, expectedName: name);
 
   /// Constructs a package with the given pubspec.
   ///
@@ -145,7 +144,7 @@ class Package {
   Package.inMemory(this.pubspec) : dir = null;
 
   /// Creates a package with [pubspec] located at [dir].
-  Package(this.pubspec, String dir) : dir = p.absolute(dir);
+  Package(this.pubspec, this.dir);
 
   /// Given a relative path within this package, returns its absolute path.
   ///

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -31,7 +31,7 @@ class Package {
     return a.version.compareTo(b.version);
   }
 
-  /// The path to the directory containing the package.
+  /// The (absolute) path to the directory containing the package.
   final String dir;
 
   /// An in-memory package can be created for doing a resolution without having
@@ -135,8 +135,9 @@ class Package {
   /// [name] is the expected name of that package (e.g. the name given in the
   /// dependency), or `null` if the package being loaded is the entrypoint
   /// package.
-  Package.load(String name, this.dir, SourceRegistry sources)
-      : pubspec = Pubspec.load(dir, sources, expectedName: name);
+  Package.load(String name, String dir, SourceRegistry sources)
+      : pubspec = Pubspec.load(dir, sources, expectedName: name),
+        dir = p.absolute(dir);
 
   /// Constructs a package with the given pubspec.
   ///
@@ -144,7 +145,7 @@ class Package {
   Package.inMemory(this.pubspec) : dir = null;
 
   /// Creates a package with [pubspec] located at [dir].
-  Package(this.pubspec, this.dir);
+  Package(this.pubspec, String dir) : dir = p.absolute(dir);
 
   /// Given a relative path within this package, returns its absolute path.
   ///

--- a/lib/src/package_config.dart
+++ b/lib/src/package_config.dart
@@ -213,10 +213,13 @@ class PackageConfigEntry {
     }
 
     Uri packageUri;
-    final packageUriRaw = root['packageUri'];
+    var packageUriRaw = root['packageUri'];
     if (packageUriRaw != null) {
       if (packageUriRaw is! String) {
         _throw('packageUri', 'must be a string');
+      }
+      if (!packageUriRaw.endsWith('/')) {
+        packageUriRaw = '$packageUriRaw/';
       }
       try {
         packageUri = Uri.parse(packageUriRaw);


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/73870
Fixes: https://github.com/dart-lang/pub/issues/2806

This is somewhat a hack but should solve the immediate issue. It would be desirable to have 

* Flutter not rely on this by generating to a synthetic package
* Some well-defined mechanism for referring to synthetic code in a specific location.