### PR TITLE
Warn about discontinued packages on pub get/upgrade

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -266,7 +266,7 @@ class Entrypoint {
       _saveLockFile(result);
     }
 
-    result.summarizeChanges(type, cache, dryRun: dryRun);
+    await result.summarizeChanges(type, cache, dryRun: dryRun);
 
     if (!dryRun) {
       /// Build a package graph from the version solver results so we don't

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -716,8 +716,6 @@ class Entrypoint {
     // If the version is different from 2, then it must be a newer incompatible
     // version, hence, the user should run `pub get` with the downgraded SDK.
     if (cfg.configVersion != 2) {
-      print('b');
-
       badPackageConfig();
     }
 
@@ -725,7 +723,6 @@ class Entrypoint {
     for (final pkg in cfg.packages) {
       // Pub always sets packageUri = lib/
       if (pkg.packageUri == null || pkg.packageUri.toString() != 'lib/') {
-        print('a');
         badPackageConfig();
       }
       packagePathsMapping[pkg.name] =

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -259,14 +259,14 @@ class Entrypoint {
       }
     }
 
-    result.showReport(type);
+    await result.showReport(type, cache);
 
     if (!dryRun) {
       await Future.wait(result.packages.map(_get));
       _saveLockFile(result);
     }
 
-    result.summarizeChanges(type, dryRun: dryRun);
+    result.summarizeChanges(type, cache, dryRun: dryRun);
 
     if (!dryRun) {
       /// Build a package graph from the version solver results so we don't
@@ -716,6 +716,8 @@ class Entrypoint {
     // If the version is different from 2, then it must be a newer incompatible
     // version, hence, the user should run `pub get` with the downgraded SDK.
     if (cfg.configVersion != 2) {
+      print('b');
+
       badPackageConfig();
     }
 
@@ -723,6 +725,7 @@ class Entrypoint {
     for (final pkg in cfg.packages) {
       // Pub always sets packageUri = lib/
       if (pkg.packageUri == null || pkg.packageUri.toString() != 'lib/') {
+        print('a');
         badPackageConfig();
       }
       packagePathsMapping[pkg.name] =

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -212,7 +212,7 @@ The package ${dep.name} is already activated at newest available version.
 To recompile executables, first run `global decativate ${dep.name}`.
 ''');
     } else {
-      result.showReport(SolveType.GET);
+      await result.showReport(SolveType.GET, cache);
     }
 
     // Make sure all of the dependencies are locally installed.

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -152,6 +152,10 @@ String _resolveLink(String link) {
 /// Reads the contents of the text file [file].
 String readTextFile(String file) => File(file).readAsStringSync(encoding: utf8);
 
+/// Reads the contents of the text file [file].
+Future<String> readTextFileAsync(String file) =>
+    File(file).readAsString(encoding: utf8);
+
 /// Reads the contents of the binary file [file].
 List<int> readBinaryFile(String file) {
   log.io('Reading binary file $file.');
@@ -164,7 +168,7 @@ List<int> readBinaryFile(String file) {
 ///
 /// If [dontLogContents] is `true`, the contents of the file will never be
 /// logged.
-String writeTextFile(String file, String contents,
+void writeTextFile(String file, String contents,
     {bool dontLogContents = false, Encoding encoding}) {
   encoding ??= utf8;
 
@@ -176,7 +180,24 @@ String writeTextFile(String file, String contents,
 
   deleteIfLink(file);
   File(file).writeAsStringSync(contents, encoding: encoding);
-  return file;
+}
+
+/// Creates [file] and writes [contents] to it.
+///
+/// If [dontLogContents] is `true`, the contents of the file will never be
+/// logged.
+Future<void> writeTextFileAsync(String file, String contents,
+    {bool dontLogContents = false, Encoding encoding}) async {
+  encoding ??= utf8;
+
+  // Sanity check: don't spew a huge file.
+  log.io('Writing ${contents.length} characters to text file $file.');
+  if (!dontLogContents && contents.length < 1024 * 1024) {
+    log.fine('Contents:\n$contents');
+  }
+
+  deleteIfLink(file);
+  await File(file).writeAsString(contents, encoding: encoding);
 }
 
 /// Writes [stream] to a new file at path [file].

--- a/lib/src/rate_limited_scheduler.dart
+++ b/lib/src/rate_limited_scheduler.dart
@@ -50,6 +50,9 @@ class RateLimitedScheduler<J, V> {
   /// The results of ongoing and finished jobs.
   final Map<J, Completer<V>> _cache = <J, Completer<V>>{};
 
+  /// Provides sync access to completed results.
+  final Map<J, V> _results = <J, V>{};
+
   /// Tasks that are waiting to be run.
   final Queue<_Task<J>> _queue = Queue<_Task<J>>();
 
@@ -80,7 +83,8 @@ class RateLimitedScheduler<J, V> {
 
     // Use an async function to catch sync exceptions from _runJob.
     Future<V> runJob() async {
-      return await task.zone.runUnary(_runJob, task.jobId);
+      return _results[task.jobId] =
+          await task.zone.runUnary(_runJob, task.jobId);
     }
 
     completer.complete(runJob());
@@ -131,6 +135,10 @@ class RateLimitedScheduler<J, V> {
     }
     return completer.future;
   }
+
+  /// Returns the result of running [jobId] if that is already done.
+  /// Otherwise returns `null`.
+  V peek(J jobId) => _results[jobId];
 }
 
 class _Task<J> {

--- a/lib/src/solver/report.dart
+++ b/lib/src/solver/report.dart
@@ -144,7 +144,7 @@ class SolveReport {
       /// time for packages that were not changed.
       final status =
           await _cache.source(id.source).status(id, Duration(days: 3));
-      if (status.isDiscontinued) {
+      if (status.isDiscontinued ?? false) {
         final suffix = status.discontinuedReplacedBy == null
             ? ''
             : ' it has been replaced by package:${status.discontinuedReplacedBy}';

--- a/lib/src/solver/result.dart
+++ b/lib/src/solver/result.dart
@@ -10,6 +10,7 @@ import '../package.dart';
 import '../package_name.dart';
 import '../pubspec.dart';
 import '../source_registry.dart';
+import '../system_cache.dart';
 import 'report.dart';
 import 'type.dart';
 
@@ -90,8 +91,9 @@ class SolveResult {
   /// Displays a report of what changes were made to the lockfile.
   ///
   /// [type] is the type of version resolution that was run.
-  void showReport(SolveType type) {
-    SolveReport(type, _sources, _root, _previousLockFile, this).show();
+  Future<void> showReport(SolveType type, SystemCache cache) async {
+    await SolveReport(type, _sources, _root, _previousLockFile, this, cache)
+        .show();
   }
 
   /// Displays a one-line message summarizing what changes were made (or would
@@ -101,8 +103,10 @@ class SolveResult {
   /// that are not at the latest available version.
   ///
   /// [type] is the type of version resolution that was run.
-  void summarizeChanges(SolveType type, {bool dryRun = false}) {
-    final report = SolveReport(type, _sources, _root, _previousLockFile, this);
+  void summarizeChanges(SolveType type, SystemCache cache,
+      {bool dryRun = false}) {
+    final report =
+        SolveReport(type, _sources, _root, _previousLockFile, this, cache);
     report.summarize(dryRun: dryRun);
     if (type == SolveType.UPGRADE) {
       report.reportOutdated();

--- a/lib/src/solver/result.dart
+++ b/lib/src/solver/result.dart
@@ -103,11 +103,12 @@ class SolveResult {
   /// that are not at the latest available version.
   ///
   /// [type] is the type of version resolution that was run.
-  void summarizeChanges(SolveType type, SystemCache cache,
-      {bool dryRun = false}) {
+  Future<void> summarizeChanges(SolveType type, SystemCache cache,
+      {bool dryRun = false}) async {
     final report =
         SolveReport(type, _sources, _root, _previousLockFile, this, cache);
     report.summarize(dryRun: dryRun);
+    await report.reportDiscontinued();
     if (type == SolveType.UPGRADE) {
       report.reportOutdated();
     }

--- a/lib/src/source.dart
+++ b/lib/src/source.dart
@@ -234,10 +234,26 @@ abstract class BoundSource {
   /// If the source is cached, this will be a path in the system cache.
   String getDirectory(PackageId id);
 
+  /// Returns metadata about a given package. Information about remotely hosted
+  /// packages can be cached for up to [maxAge].
+  Future<PackageStatus> status(PackageId id, Duration maxAge) async =>
+      // Default implementation has no metadata.
+      PackageStatus();
+
   /// Stores [pubspec] so it's returned when [describe] is called with [id].
   ///
   /// This is notionally protected; it should only be called by subclasses.
   void memoizePubspec(PackageId id, Pubspec pubspec) {
     _pubspecs[id] = pubspec;
   }
+}
+
+/// Metadata about a [PackageId].
+class PackageStatus {
+  /// `null` if not [isDiscontinued]. Otherwise contains the
+  /// replacement string provided by the host or `null` if there is no
+  /// replacement.
+  final String discontinuedReplacedBy;
+  final bool isDiscontinued;
+  PackageStatus({this.isDiscontinued, this.discontinuedReplacedBy});
 }

--- a/lib/src/source.dart
+++ b/lib/src/source.dart
@@ -255,5 +255,6 @@ class PackageStatus {
   /// replacement.
   final String discontinuedReplacedBy;
   final bool isDiscontinued;
-  PackageStatus({this.isDiscontinued, this.discontinuedReplacedBy});
+  PackageStatus({isDiscontinued, this.discontinuedReplacedBy})
+      : isDiscontinued = isDiscontinued ?? false;
 }

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -311,9 +311,16 @@ class BoundHostedSource extends CachedSource {
     versionListing ??= await _cachedVersionListingResponse(ref, maxAge);
     // Otherwise retrieve the info from the host.
     versionListing ??= await _scheduler.schedule(ref);
+
+    final listing = versionListing[id];
     // If we don't have the specific version we return the empty response.
+    //
+    // This should not happen. But in production we want to avoid a crash, since
+    // it is more or less harmless.
+    //
     // TODO(sigurdm): Consider representing the non-existence of the
     // package-version in the return value.
+    assert(listing != null);
     return versionListing[id]?.status ?? PackageStatus();
   }
 

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -385,13 +385,21 @@ class BoundHostedSource extends CachedSource {
         final results = <RepairResult>[];
         var packages = <Package>[];
         for (var entry in listDir(serverDir)) {
-          try {
-            packages.add(Package.load(null, entry, systemCache.sources));
-          } catch (error, stackTrace) {
-            log.error('Failed to load package', error, stackTrace);
-            results.add(RepairResult(_idForBasename(p.basename(entry)),
-                success: false));
-            tryDeleteEntry(entry);
+          if (dirExists(entry)) {
+            try {
+              packages.add(Package.load(null, entry, systemCache.sources));
+            } catch (error, stackTrace) {
+              log.error('Failed to load package', error, stackTrace);
+              results.add(RepairResult(_idForBasename(p.basename(entry)),
+                  success: false));
+              tryDeleteEntry(entry);
+            }
+          } else {
+            if (entry.endsWith('-versions.json')) {
+              // A cached version listing response.
+              // Just delete it - it will be re-retrieved.
+              tryDeleteEntry(entry);
+            }
           }
         }
 

--- a/test/add/common/invalid_options.dart
+++ b/test/add/common/invalid_options.dart
@@ -39,7 +39,8 @@ void main() {
   test('cannot use both --path and --host-<option> flags', () async {
     // Make the default server serve errors. Only the custom server should
     // be accessed.
-    await serveErrors();
+    await serveNoPackages();
+    globalPackageServer.serveErrors();
 
     final server = await PackageServer.start((builder) {
       builder.serve('foo', '1.2.3');
@@ -75,7 +76,8 @@ void main() {
   test('cannot use both --hosted-url and --git-<option> flags', () async {
     // Make the default server serve errors. Only the custom server should
     // be accessed.
-    await serveErrors();
+    await serveNoPackages();
+    globalPackageServer.serveErrors();
 
     final server = await PackageServer.start((builder) {
       builder.serve('foo', '1.2.3');

--- a/test/descriptor_server.dart
+++ b/test/descriptor_server.dart
@@ -9,8 +9,6 @@ import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:test/test.dart' hide fail;
 
-import 'package:pub/src/utils.dart';
-
 import 'descriptor.dart' as d;
 
 /// The global [DescriptorServer] that's used by default.
@@ -38,11 +36,6 @@ DescriptorServer _globalServer;
 /// via [server]. Subsequent calls to [serve] replace the previous server.
 Future serve([List<d.Descriptor> contents]) async {
   globalServer = (await DescriptorServer.start())..contents.addAll(contents);
-}
-
-/// Like [serve], but reports an error if a request ever comes in to the server.
-Future serveErrors() async {
-  globalServer = await DescriptorServer.errors();
 }
 
 class DescriptorServer {
@@ -75,11 +68,7 @@ class DescriptorServer {
 
   /// Creates a server that reports an error if a request is ever received.
   static Future<DescriptorServer> errors() async =>
-      DescriptorServer._(await shelf_io.IOServer.bind('localhost', 0))
-        ..extraHandlers[RegExp('.*')] = (request) {
-          fail('The HTTP server received an unexpected request:\n'
-              '${request.method} ${request.requestedUri}');
-        };
+      DescriptorServer._(await shelf_io.IOServer.bind('localhost', 0));
 
   DescriptorServer._(this._server) : _baseDir = d.dir('serve-dir', []) {
     _server.mount((request) async {

--- a/test/get/hosted/warn_about_discontinued_test.dart
+++ b/test/get/hosted/warn_about_discontinued_test.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:path/path.dart' as p;
+import 'package:pub/src/command/cache_repair.dart';
 import 'package:test/test.dart';
 
 import 'package:pub/src/io.dart';
@@ -25,10 +26,10 @@ void main() {
     // A pub get straight away will not trigger the warning, as we cache
     // responses for a while.
     await pubGet();
-    final fooVersionsCache = p.join(d.sandbox, cachePath, 'hosted',
-        'localhost%58${globalServer.port}', 'foo-versions.json');
-    final transitiveVersionsCache = p.join(d.sandbox, cachePath, 'hosted',
-        'localhost%58${globalServer.port}', 'transitive-versions.json');
+    final fooVersionsCache = p.join(
+        globalPackageServer.cachingPath, '.versions', 'foo-versions.json');
+    final transitiveVersionsCache = p.join(globalPackageServer.cachingPath,
+        '.versions', 'transitive-versions.json');
     expect(fileExists(fooVersionsCache), isTrue);
     expect(fileExists(transitiveVersionsCache), isTrue);
     deleteEntry(fooVersionsCache);
@@ -51,6 +52,11 @@ void main() {
     c2['isDiscontinued'] = false;
     writeTextFile(fooVersionsCache, json.encode(c2));
     await pubGet(warning: isEmpty);
+    // Repairing the cache should reset the package listing caches.
+    await runPub(args: ['cache', 'repair']);
+    await pubGet(
+        warning:
+            'Package foo has been discontinued it has been replaced by package bar.');
   });
 }
 // /private/var/folders/zf/dv4m6qs906n6t1zhjt9jfdw4006vgn/T/dart_test_dskJEn/cache/hosted/localhost%5856564/foo-versions.json.

--- a/test/get/hosted/warn_about_discontinued_test.dart
+++ b/test/get/hosted/warn_about_discontinued_test.dart
@@ -5,7 +5,6 @@
 import 'dart:convert';
 
 import 'package:path/path.dart' as p;
-import 'package:pub/src/command/cache_repair.dart';
 import 'package:test/test.dart';
 
 import 'package:pub/src/io.dart';

--- a/test/get/hosted/warn_about_discontinued_test.dart
+++ b/test/get/hosted/warn_about_discontinued_test.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'package:pub/src/io.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('Warns about discontinued packages', () async {
+    await servePackages((builder) => builder.serve('foo', '1.2.3'));
+    await d.appDir({'foo': '1.2.3'}).create();
+    await pubGet();
+
+    globalPackageServer.add((builder) => builder.discontinue('foo'));
+    // A pub get straight away will not trigger the warning, as we cache
+    // responses for a while.
+    await pubGet();
+    final versionsCache = p.join(d.sandbox, cachePath, 'hosted',
+        'localhost%58${globalServer.port}', 'foo-versions.json');
+    expect(fileExists(versionsCache), isTrue);
+    deleteEntry(versionsCache);
+    await pubGet(warning: 'Package:foo has been discontinued.');
+    expect(fileExists(versionsCache), isTrue);
+    final c = json.decode(readTextFile(versionsCache));
+    // Make the cache artificially old.
+    c['timestamp'] =
+        DateTime.now().subtract(Duration(days: 5)).toIso8601String();
+    writeTextFile(versionsCache, json.encode(c));
+    globalPackageServer
+        .add((builder) => builder.discontinue('foo', replacementText: 'bar'));
+    await pubGet(
+        warning:
+            'Package:foo has been discontinued it has been replaced by package:bar.');
+    final c2 = json.decode(readTextFile(versionsCache));
+    // Make a bad cached value to test that responses are actually from cache.
+    c2['response']['isDiscontinued'] = false;
+    writeTextFile(versionsCache, json.encode(c2));
+    await pubGet(warning: isEmpty);
+  });
+}
+// /private/var/folders/zf/dv4m6qs906n6t1zhjt9jfdw4006vgn/T/dart_test_dskJEn/cache/hosted/localhost%5856564/foo-versions.json.

--- a/test/get/hosted/warn_about_discontinued_test.dart
+++ b/test/get/hosted/warn_about_discontinued_test.dart
@@ -20,15 +20,15 @@ void main() {
     await d.appDir({'foo': '1.2.3'}).create();
     await pubGet();
 
-    globalPackageServer.add((builder) => builder.discontinue('foo'));
-    globalPackageServer.add((builder) => builder.discontinue('transitive'));
+    globalPackageServer.add(
+        (builder) => builder..discontinue('foo')..discontinue('transitive'));
     // A pub get straight away will not trigger the warning, as we cache
     // responses for a while.
     await pubGet();
-    final fooVersionsCache = p.join(
-        globalPackageServer.cachingPath, '.versions', 'foo-versions.json');
-    final transitiveVersionsCache = p.join(globalPackageServer.cachingPath,
-        '.versions', 'transitive-versions.json');
+    final fooVersionsCache =
+        p.join(globalPackageServer.cachingPath, '.cache', 'foo-versions.json');
+    final transitiveVersionsCache = p.join(
+        globalPackageServer.cachingPath, '.cache', 'transitive-versions.json');
     expect(fileExists(fooVersionsCache), isTrue);
     expect(fileExists(transitiveVersionsCache), isTrue);
     deleteEntry(fooVersionsCache);
@@ -56,6 +56,15 @@ void main() {
     await pubGet(
         warning:
             'Package foo has been discontinued it has been replaced by package bar.');
+    // Test that --offline won't try to access the server for retrieving the
+    // status.
+    await serveErrors();
+    await pubGet(
+        args: ['--offline'],
+        warning:
+            'Package foo has been discontinued it has been replaced by package bar.');
+    deleteEntry(fooVersionsCache);
+    deleteEntry(transitiveVersionsCache);
+    await pubGet(args: ['--offline']);
   });
 }
-// /private/var/folders/zf/dv4m6qs906n6t1zhjt9jfdw4006vgn/T/dart_test_dskJEn/cache/hosted/localhost%5856564/foo-versions.json.


### PR DESCRIPTION
The responses from the version listings are cached in the pub cache, such that we don't have to re-query the server on a `pub get` where pubspec.lock already exists and the packages are in cache already.

The cached responses are stored as a json:
```
{
  ...<body>
  "_fetchedAt": Iso8601String
}
```

The cached file will be at `<PUB_CACHE>/hosted/<url>/.cache/<package-name>-versions.json`

where body is the decoded response from the server.

This gives a maximum delay of the discontinued warning of 3 days from the actual discontinuation.

To see if a cached response is too old we both check the file modified timestamp (for speed) and the json timestamp (for extra robustness).

One hope is that the cached responses can be used for speeding up `pub get` itself, if/when we have a faster way of checking if the package-listing is up-to-date...
