### PR TITLE
No metadata when CI=true

### DIFF
--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -80,6 +80,11 @@ class _PubHttpClient extends http.BaseClient {
       if (request.url.origin != 'https://pub.dartlang.org') return false;
     }
 
+    if (Platform.environment.containsKey('CI') &&
+        Platform.environment['CI'] != 'false') {
+      return false;
+    }
+
     return true;
   }
 

--- a/test/hosted/metadata_test.dart
+++ b/test/hosted/metadata_test.dart
@@ -95,5 +95,19 @@ void main() {
 
       await pubCommand(command, silent: isNot(contains('X-Pub-')));
     });
+
+    test("doesn't send metadata headers when CI=true", () async {
+      await servePackages((builder) {
+        builder.serve('foo', '1.0.0');
+      });
+
+      await d.appDir({'foo': '1.0.0'}).create();
+
+      await pubCommand(command,
+          silent: isNot(contains('X-Pub-')),
+          environment: {
+            'CI': 'true',
+          });
+    });
   });
 }

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -374,6 +374,7 @@ String testVersion = '0.1.2+3';
 /// Gets the environment variables used to run pub in a test context.
 Map<String, String> getPubTestEnvironment([String tokenEndpoint]) {
   var environment = {
+    'CI': 'false', // unless explicitly given tests don't run pub in CI mode
     '_PUB_TESTING': 'true',
     'PUB_CACHE': _pathInSandbox(cachePath),
     'PUB_ENVIRONMENT': 'test-environment',


### PR DESCRIPTION
Follow up from https://github.com/dart-lang/pub/pull/2759, I think it's fair that we send no metadata when `CI=true`.