### PR TITLE
Show outdated sdk packages.

### DIFF
--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:meta/meta.dart';
+import 'package:pub/src/source/path.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../command.dart';
@@ -19,6 +20,7 @@ import '../package_name.dart';
 import '../pubspec.dart';
 import '../pubspec_utils.dart';
 import '../solver.dart';
+import '../source/git.dart';
 import '../source/sdk.dart' show SdkSource;
 import '../system_cache.dart';
 import '../utils.dart';
@@ -218,7 +220,7 @@ class OutdatedCommand extends PubCommand {
       ...upgradablePackages,
       ...resolvablePackages
     ]) {
-      if (!visited.add(id.name) || id.source is SdkSource) continue;
+      if (!visited.add(id.name)) continue;
       rows.add(await analyzeDependency(id.toRef()));
     }
 
@@ -771,7 +773,16 @@ class _VersionDetails {
   /// A string representation of this version to include in the outdated report.
   String get describe {
     final version = _pubspec.version;
-    final suffix = _overridden ? ' (overridden)' : '';
+    var suffix = '';
+    if (_overridden) {
+      suffix = ' (overridden)';
+    } else if (_id.source is SdkSource) {
+      suffix = ' (sdk)';
+    } else if (_id.source is GitSource) {
+      suffix = ' (git)';
+    } else if (_id.source is PathSource) {
+      suffix = ' (path)';
+    }
     return '$version$suffix';
   }
 

--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:meta/meta.dart';
-import 'package:pub/src/source/path.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../command.dart';
@@ -21,6 +20,7 @@ import '../pubspec.dart';
 import '../pubspec_utils.dart';
 import '../solver.dart';
 import '../source/git.dart';
+import '../source/path.dart';
 import '../source/sdk.dart' show SdkSource;
 import '../system_cache.dart';
 import '../utils.dart';

--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -777,7 +777,8 @@ class _VersionDetails {
     if (_overridden) {
       suffix = ' (overridden)';
     } else if (_id.source is SdkSource) {
-      suffix = ' (sdk)';
+      // Version is not relevant for sdk-packages.
+      return '(sdk)';
     } else if (_id.source is GitSource) {
       suffix = ' (git)';
     } else if (_id.source is PathSource) {

--- a/test/outdated/goldens/handles_sdk_dependencies.txt
+++ b/test/outdated/goldens/handles_sdk_dependencies.txt
@@ -111,8 +111,7 @@ Showing dependencies that are currently not opted in to null-safety.
 Package Name  Current  Upgradable  Resolvable  Latest  
 
 direct dependencies:
-flutter       ✗(sdk)   ✗(sdk)      ✗(sdk)      ✗(sdk)  
-foo           ✗1.1.0   ✗1.1.0      ✗2.0.0      ✗2.0.0  
+foo           ✗1.1.0   ✗1.1.0      ✓2.0.0      ✓2.0.0  
 
 dev_dependencies:
 flutter_test  ✗(sdk)   ✗(sdk)      ✗(sdk)      ✗(sdk)  
@@ -128,8 +127,7 @@ Showing dependencies that are currently not opted in to null-safety.
 Package Name  Current  Upgradable  Resolvable  Latest  
 
 direct dependencies:
-flutter       ✗(sdk)   ✗(sdk)      ✗(sdk)      ✗(sdk)  
-foo           ✗1.1.0   ✗1.1.0      ✗2.0.0      ✗2.0.0  
+foo           ✗1.1.0   ✗1.1.0      ✓2.0.0      ✓2.0.0  
 
 dev_dependencies:
 flutter_test  ✗(sdk)   ✗(sdk)      ✗(sdk)      ✗(sdk)  
@@ -145,8 +143,7 @@ Showing dependencies that are currently not opted in to null-safety.
 Package Name  Current  Upgradable  Resolvable  Latest  
 
 direct dependencies:
-flutter       ✗(sdk)   ✗(sdk)      ✗(sdk)      ✗(sdk)  
-foo           ✗1.1.0   ✗1.1.0      ✗2.0.0      ✗2.0.0  
+foo           ✗1.1.0   ✗1.1.0      ✓2.0.0      ✓2.0.0  
 
 dev_dependencies:
 flutter_test  ✗(sdk)   ✗(sdk)      ✗(sdk)      ✗(sdk)  
@@ -157,25 +154,6 @@ To update it, edit pubspec.yaml, or run `dart pub upgrade --null-safety`.
 $ pub outdated --json --mode=null-safety
 {
   "packages": [
-    {
-      "package": "flutter",
-      "current": {
-        "version": "1.0.0",
-        "nullSafety": false
-      },
-      "upgradable": {
-        "version": "1.0.0",
-        "nullSafety": false
-      },
-      "resolvable": {
-        "version": "1.0.0",
-        "nullSafety": false
-      },
-      "latest": {
-        "version": "1.0.0",
-        "nullSafety": false
-      }
-    },
     {
       "package": "flutter_test",
       "current": {
@@ -207,11 +185,11 @@ $ pub outdated --json --mode=null-safety
       },
       "resolvable": {
         "version": "2.0.0",
-        "nullSafety": false
+        "nullSafety": true
       },
       "latest": {
         "version": "2.0.0",
-        "nullSafety": false
+        "nullSafety": true
       }
     }
   ]

--- a/test/outdated/goldens/ignores_sdk_dependencies.txt
+++ b/test/outdated/goldens/ignores_sdk_dependencies.txt
@@ -51,12 +51,14 @@ $ pub outdated --no-color --up-to-date
 Showing outdated packages.
 [*] indicates versions that are not the latest available.
 
-Package Name  Current  Upgradable  Resolvable  Latest  
+Package Name  Current      Upgradable   Resolvable   Latest       
 
 direct dependencies:
-foo           *1.1.0   *1.1.0      2.0.0       2.0.0   
+flutter       1.0.0 (sdk)  1.0.0 (sdk)  1.0.0 (sdk)  1.0.0 (sdk)  
+foo           *1.1.0       *1.1.0       2.0.0        2.0.0        
 
-dev_dependencies: all up-to-date.
+dev_dependencies:
+flutter_test  1.0.0 (sdk)  1.0.0 (sdk)  1.0.0 (sdk)  1.0.0 (sdk)  
 
 1 dependency is constrained to a version that is older than a resolvable version.
 To update it, edit pubspec.yaml, or run `dart pub upgrade --major-versions`.
@@ -106,12 +108,14 @@ Showing dependencies that are currently not opted in to null-safety.
 [✗] indicates versions without null safety support.
 [✓] indicates versions opting in to null safety.
 
-Package Name  Current  Upgradable  Resolvable  Latest  
+Package Name  Current       Upgradable    Resolvable    Latest        
 
 direct dependencies:
-foo           ✗1.1.0   ✗1.1.0      ✗2.0.0      ✗2.0.0  
+flutter       ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  
+foo           ✗1.1.0        ✗1.1.0        ✗2.0.0        ✗2.0.0        
 
-dev_dependencies: all support null safety.
+dev_dependencies:
+flutter_test  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  
 
 1 dependency is constrained to a version that is older than a resolvable version.
 To update it, edit pubspec.yaml, or run `dart pub upgrade --null-safety`.
@@ -121,12 +125,14 @@ Showing dependencies that are currently not opted in to null-safety.
 [✗] indicates versions without null safety support.
 [✓] indicates versions opting in to null safety.
 
-Package Name  Current  Upgradable  Resolvable  Latest  
+Package Name  Current       Upgradable    Resolvable    Latest        
 
 direct dependencies:
-foo           ✗1.1.0   ✗1.1.0      ✗2.0.0      ✗2.0.0  
+flutter       ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  
+foo           ✗1.1.0        ✗1.1.0        ✗2.0.0        ✗2.0.0        
 
-dev_dependencies: all support null safety.
+dev_dependencies:
+flutter_test  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  
 
 1 dependency is constrained to a version that is older than a resolvable version.
 To update it, edit pubspec.yaml, or run `dart pub upgrade --null-safety`.
@@ -136,12 +142,14 @@ Showing dependencies that are currently not opted in to null-safety.
 [✗] indicates versions without null safety support.
 [✓] indicates versions opting in to null safety.
 
-Package Name  Current  Upgradable  Resolvable  Latest  
+Package Name  Current       Upgradable    Resolvable    Latest        
 
 direct dependencies:
-foo           ✗1.1.0   ✗1.1.0      ✗2.0.0      ✗2.0.0  
+flutter       ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  
+foo           ✗1.1.0        ✗1.1.0        ✗2.0.0        ✗2.0.0        
 
-dev_dependencies: all support null safety.
+dev_dependencies:
+flutter_test  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  
 
 1 dependency is constrained to a version that is older than a resolvable version.
 To update it, edit pubspec.yaml, or run `dart pub upgrade --null-safety`.
@@ -149,6 +157,44 @@ To update it, edit pubspec.yaml, or run `dart pub upgrade --null-safety`.
 $ pub outdated --json --mode=null-safety
 {
   "packages": [
+    {
+      "package": "flutter",
+      "current": {
+        "version": "1.0.0",
+        "nullSafety": false
+      },
+      "upgradable": {
+        "version": "1.0.0",
+        "nullSafety": false
+      },
+      "resolvable": {
+        "version": "1.0.0",
+        "nullSafety": false
+      },
+      "latest": {
+        "version": "1.0.0",
+        "nullSafety": false
+      }
+    },
+    {
+      "package": "flutter_test",
+      "current": {
+        "version": "1.0.0",
+        "nullSafety": false
+      },
+      "upgradable": {
+        "version": "1.0.0",
+        "nullSafety": false
+      },
+      "resolvable": {
+        "version": "1.0.0",
+        "nullSafety": false
+      },
+      "latest": {
+        "version": "1.0.0",
+        "nullSafety": false
+      }
+    },
     {
       "package": "foo",
       "current": {

--- a/test/outdated/goldens/ignores_sdk_dependencies.txt
+++ b/test/outdated/goldens/ignores_sdk_dependencies.txt
@@ -51,14 +51,14 @@ $ pub outdated --no-color --up-to-date
 Showing outdated packages.
 [*] indicates versions that are not the latest available.
 
-Package Name  Current      Upgradable   Resolvable   Latest       
+Package Name  Current  Upgradable  Resolvable  Latest  
 
 direct dependencies:
-flutter       1.0.0 (sdk)  1.0.0 (sdk)  1.0.0 (sdk)  1.0.0 (sdk)  
-foo           *1.1.0       *1.1.0       2.0.0        2.0.0        
+flutter       (sdk)    (sdk)       (sdk)       (sdk)   
+foo           *1.1.0   *1.1.0      2.0.0       2.0.0   
 
 dev_dependencies:
-flutter_test  1.0.0 (sdk)  1.0.0 (sdk)  1.0.0 (sdk)  1.0.0 (sdk)  
+flutter_test  (sdk)    (sdk)       (sdk)       (sdk)   
 
 1 dependency is constrained to a version that is older than a resolvable version.
 To update it, edit pubspec.yaml, or run `dart pub upgrade --major-versions`.
@@ -108,14 +108,14 @@ Showing dependencies that are currently not opted in to null-safety.
 [✗] indicates versions without null safety support.
 [✓] indicates versions opting in to null safety.
 
-Package Name  Current       Upgradable    Resolvable    Latest        
+Package Name  Current  Upgradable  Resolvable  Latest  
 
 direct dependencies:
-flutter       ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  
-foo           ✗1.1.0        ✗1.1.0        ✗2.0.0        ✗2.0.0        
+flutter       ✗(sdk)   ✗(sdk)      ✗(sdk)      ✗(sdk)  
+foo           ✗1.1.0   ✗1.1.0      ✗2.0.0      ✗2.0.0  
 
 dev_dependencies:
-flutter_test  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  
+flutter_test  ✗(sdk)   ✗(sdk)      ✗(sdk)      ✗(sdk)  
 
 1 dependency is constrained to a version that is older than a resolvable version.
 To update it, edit pubspec.yaml, or run `dart pub upgrade --null-safety`.
@@ -125,14 +125,14 @@ Showing dependencies that are currently not opted in to null-safety.
 [✗] indicates versions without null safety support.
 [✓] indicates versions opting in to null safety.
 
-Package Name  Current       Upgradable    Resolvable    Latest        
+Package Name  Current  Upgradable  Resolvable  Latest  
 
 direct dependencies:
-flutter       ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  
-foo           ✗1.1.0        ✗1.1.0        ✗2.0.0        ✗2.0.0        
+flutter       ✗(sdk)   ✗(sdk)      ✗(sdk)      ✗(sdk)  
+foo           ✗1.1.0   ✗1.1.0      ✗2.0.0      ✗2.0.0  
 
 dev_dependencies:
-flutter_test  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  
+flutter_test  ✗(sdk)   ✗(sdk)      ✗(sdk)      ✗(sdk)  
 
 1 dependency is constrained to a version that is older than a resolvable version.
 To update it, edit pubspec.yaml, or run `dart pub upgrade --null-safety`.
@@ -142,14 +142,14 @@ Showing dependencies that are currently not opted in to null-safety.
 [✗] indicates versions without null safety support.
 [✓] indicates versions opting in to null safety.
 
-Package Name  Current       Upgradable    Resolvable    Latest        
+Package Name  Current  Upgradable  Resolvable  Latest  
 
 direct dependencies:
-flutter       ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  
-foo           ✗1.1.0        ✗1.1.0        ✗2.0.0        ✗2.0.0        
+flutter       ✗(sdk)   ✗(sdk)      ✗(sdk)      ✗(sdk)  
+foo           ✗1.1.0   ✗1.1.0      ✗2.0.0      ✗2.0.0  
 
 dev_dependencies:
-flutter_test  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  ✗1.0.0 (sdk)  
+flutter_test  ✗(sdk)   ✗(sdk)      ✗(sdk)      ✗(sdk)  
 
 1 dependency is constrained to a version that is older than a resolvable version.
 To update it, edit pubspec.yaml, or run `dart pub upgrade --null-safety`.

--- a/test/outdated/goldens/newer_versions.txt
+++ b/test/outdated/goldens/newer_versions.txt
@@ -132,23 +132,23 @@ $ pub outdated --no-color --up-to-date
 Showing outdated packages.
 [*] indicates versions that are not the latest available.
 
-Package Name   Current  Upgradable  Resolvable  Latest  
+Package Name   Current       Upgradable    Resolvable    Latest        
 
 direct dependencies:
-bar            1.0.0    1.0.0       1.0.0       1.0.0   
-foo            *1.2.3   *1.3.0      *2.0.0      3.0.0   
-local_package  0.0.1    0.0.1       0.0.1       0.0.1   
+bar            1.0.0         1.0.0         1.0.0         1.0.0         
+foo            *1.2.3        *1.3.0        *2.0.0        3.0.0         
+local_package  0.0.1 (path)  0.0.1 (path)  0.0.1 (path)  0.0.1 (path)  
 
 dev_dependencies:
-builder        *1.2.3   *1.3.0      2.0.0       2.0.0   
+builder        *1.2.3        *1.3.0        2.0.0         2.0.0         
 
 transitive dependencies:
-transitive     *1.2.3   *1.3.0      *1.3.0      2.0.0   
-transitive2    -        -           1.0.0       1.0.0   
+transitive     *1.2.3        *1.3.0        *1.3.0        2.0.0         
+transitive2    -             -             1.0.0         1.0.0         
 
 transitive dev_dependencies:
-dev_trans      *1.0.0   -           *1.0.0      2.0.0   
-transitive3    -        -           1.0.0       1.0.0   
+dev_trans      *1.0.0        -             *1.0.0        2.0.0         
+transitive3    -             -             1.0.0         1.0.0         
 
 3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `dart pub upgrade`.
@@ -231,15 +231,15 @@ Showing dependencies that are currently not opted in to null-safety.
 [✗] indicates versions without null safety support.
 [✓] indicates versions opting in to null safety.
 
-Package Name   Current  Upgradable  Resolvable  Latest        
+Package Name   Current        Upgradable     Resolvable     Latest         
 
 direct dependencies:
-bar            ✗1.0.0   ✗1.0.0      ✗1.0.0      ✗1.0.0        
-foo            ✗1.2.3   ✗1.3.0      ✗2.0.0      ✗3.0.0        
-local_package  ✗0.0.1   ✗0.0.1      ✗0.0.1      ✗0.0.1        
+bar            ✗1.0.0         ✗1.0.0         ✗1.0.0         ✗1.0.0         
+foo            ✗1.2.3         ✗1.3.0         ✗2.0.0         ✗3.0.0         
+local_package  ✗0.0.1 (path)  ✗0.0.1 (path)  ✗0.0.1 (path)  ✗0.0.1 (path)  
 
 dev_dependencies:
-builder        ✗1.2.3   ✗1.3.0      ✗2.0.0      ✗3.0.0-alpha  
+builder        ✗1.2.3         ✗1.3.0         ✗2.0.0         ✗3.0.0-alpha   
 
 2 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `dart pub upgrade`.
@@ -252,23 +252,23 @@ Showing dependencies that are currently not opted in to null-safety.
 [✗] indicates versions without null safety support.
 [✓] indicates versions opting in to null safety.
 
-Package Name   Current  Upgradable  Resolvable  Latest        
+Package Name   Current        Upgradable     Resolvable     Latest         
 
 direct dependencies:
-bar            ✗1.0.0   ✗1.0.0      ✗1.0.0      ✗1.0.0        
-foo            ✗1.2.3   ✗1.3.0      ✗2.0.0      ✗3.0.0        
-local_package  ✗0.0.1   ✗0.0.1      ✗0.0.1      ✗0.0.1        
+bar            ✗1.0.0         ✗1.0.0         ✗1.0.0         ✗1.0.0         
+foo            ✗1.2.3         ✗1.3.0         ✗2.0.0         ✗3.0.0         
+local_package  ✗0.0.1 (path)  ✗0.0.1 (path)  ✗0.0.1 (path)  ✗0.0.1 (path)  
 
 dev_dependencies:
-builder        ✗1.2.3   ✗1.3.0      ✗2.0.0      ✗3.0.0-alpha  
+builder        ✗1.2.3         ✗1.3.0         ✗2.0.0         ✗3.0.0-alpha   
 
 transitive dependencies:
-transitive     ✗1.2.3   ✗1.3.0      ✗1.3.0      ✗2.0.0        
-transitive2    -        -           ✗1.0.0      ✗1.0.0        
+transitive     ✗1.2.3         ✗1.3.0         ✗1.3.0         ✗2.0.0         
+transitive2    -              -              ✗1.0.0         ✗1.0.0         
 
 transitive dev_dependencies:
-dev_trans      ✗1.0.0   -           ✗1.0.0      ✗2.0.0        
-transitive3    -        -           ✗1.0.0      ✗1.0.0        
+dev_trans      ✗1.0.0         -              ✗1.0.0         ✗2.0.0         
+transitive3    -              -              ✗1.0.0         ✗1.0.0         
 
 3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `dart pub upgrade`.
@@ -281,15 +281,15 @@ Showing dependencies that are currently not opted in to null-safety.
 [✗] indicates versions without null safety support.
 [✓] indicates versions opting in to null safety.
 
-Package Name   Current  Upgradable  Resolvable  Latest  
+Package Name   Current        Upgradable     Resolvable     Latest         
 
 direct dependencies:
-bar            ✗1.0.0   ✗1.0.0      ✗1.0.0      ✗1.0.0  
-foo            ✗1.2.3   ✗1.3.0      ✗2.0.0      ✗3.0.0  
-local_package  ✗0.0.1   ✗0.0.1      ✗0.0.1      ✗0.0.1  
+bar            ✗1.0.0         ✗1.0.0         ✗1.0.0         ✗1.0.0         
+foo            ✗1.2.3         ✗1.3.0         ✗2.0.0         ✗3.0.0         
+local_package  ✗0.0.1 (path)  ✗0.0.1 (path)  ✗0.0.1 (path)  ✗0.0.1 (path)  
 
 dev_dependencies:
-builder        ✗1.2.3   ✗1.3.0      ✗2.0.0      ✗2.0.0  
+builder        ✗1.2.3         ✗1.3.0         ✗2.0.0         ✗2.0.0         
 
 2 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `dart pub upgrade`.

--- a/test/outdated/outdated_test.dart
+++ b/test/outdated/outdated_test.dart
@@ -362,20 +362,26 @@ Future<void> main() async {
     await variations('prereleases');
   });
 
-  test('ignores SDK dependencies', () async {
+  test('Handles SDK dependencies', () async {
     await servePackages((builder) => builder
-      ..serve('foo', '1.0.0')
-      ..serve('foo', '1.1.0')
-      ..serve('foo', '2.0.0'));
+      ..serve('foo', '1.0.0', pubspec: {
+        'environment': {'sdk': '>=2.10.0 <3.0.0'}
+      })
+      ..serve('foo', '1.1.0', pubspec: {
+        'environment': {'sdk': '>=2.10.0 <3.0.0'}
+      })
+      ..serve('foo', '2.0.0', pubspec: {
+        'environment': {'sdk': '>=2.12.0 <3.0.0'}
+      }));
 
     await d.dir('flutter-root', [
       d.file('version', '1.2.3'),
       d.dir('packages', [
         d.dir('flutter', [
-          d.libPubspec('flutter', '1.0.0'),
+          d.libPubspec('flutter', '1.0.0', sdk: '>=2.12.0 <3.0.0'),
         ]),
         d.dir('flutter_test', [
-          d.libPubspec('flutter_test', '1.0.0'),
+          d.libPubspec('flutter_test', '1.0.0', sdk: '>=2.10.0 <3.0.0'),
         ]),
       ]),
     ]).create();
@@ -384,6 +390,7 @@ Future<void> main() async {
       d.pubspec({
         'name': 'app',
         'version': '1.0.1',
+        'environment': {'sdk': '>=2.12.0 <3.0.0'},
         'dependencies': {
           'foo': '^1.0.0',
           'flutter': {
@@ -401,10 +408,12 @@ Future<void> main() async {
 
     await pubGet(environment: {
       'FLUTTER_ROOT': d.path('flutter-root'),
+      '_PUB_TEST_SDK_VERSION': '2.13.0'
     });
 
-    await variations('ignores_sdk_dependencies', environment: {
+    await variations('handles_sdk_dependencies', environment: {
       'FLUTTER_ROOT': d.path('flutter-root'),
+      '_PUB_TEST_SDK_VERSION': '2.13.0'
     });
   });
 }


### PR DESCRIPTION
Mention the source of non-hosted package-versions.

Fixes: https://github.com/dart-lang/pub/issues/2832