### PR TITLE
Fix request metadata when overriding dependencyType

### DIFF
--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -56,7 +56,9 @@ class _PubHttpClient extends http.BaseClient {
       }
 
       var type = Zone.current[#_dependencyType];
-      if (type != null) request.headers['X-Pub-Reason'] = type.toString();
+      if (type != null && type != DependencyType.none) {
+        request.headers['X-Pub-Reason'] = type.toString();
+      }
     }
 
     _requestStopwatches[request] = Stopwatch()..start();
@@ -285,8 +287,9 @@ set innerHttpClient(http.Client client) => _pubClient._inner = client;
 ///
 /// If [type] is [DependencyType.none], no extra metadata is added.
 Future<T> withDependencyType<T>(
-    DependencyType type, Future<T> Function() callback) {
-  if (type == DependencyType.none) return callback();
+  DependencyType type,
+  Future<T> Function() callback,
+) {
   return runZoned(callback, zoneValues: {#_dependencyType: type});
 }
 

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -489,6 +489,10 @@ void createPackageSymlink(String name, String target, String symlink,
 /// invocations of pub.
 final bool runningFromTest = Platform.environment.containsKey('_PUB_TESTING');
 
+final bool runningFromFlutter =
+    Platform.environment.containsKey('PUB_ENVIRONMENT') &&
+        Platform.environment['PUB_ENVIRONMENT'].contains('flutter_cli');
+
 /// A regular expression to match the script path of a pub script running from
 /// source in the Dart repo.
 final _dartRepoRegExp = RegExp(r'/third_party/pkg/pub/('


### PR DESCRIPTION
Running `dart pub get --verbose` in `flutter/gallery` shows:
```
IO  : Get versions from https://pub.dartlang.org/api/packages/url_launcher_platform_interface.
IO  : HTTP GET https://pub.dartlang.org/api/packages/url_launcher_platform_interface
    | Accept: application/vnd.pub.v2+json
    | X-Pub-OS: linux
    | X-Pub-Command: upgrade
    | X-Pub-Session-ID: 80D86525-9A4A-4468-AE49-23A6725FA366
    | X-Pub-Reason: direct
    | user-agent: Dart pub 2.12.0-248.0.dev
```

That's a problem... looking at the code it seems setting `dependencyType.none` does not override existing `dependencyType` in the current zone.

This has been causing issues since we introduced prefetching in Dart 2.8.


----------------

TL;DR: Dependency-type `direct` cannot be trusted since Dart 2.8.