### PR TITLE
Downgrade actually modifies `pubspec.lock`

### DIFF
--- a/lib/src/command/downgrade.dart
+++ b/lib/src/command/downgrade.dart
@@ -14,8 +14,7 @@ class DowngradeCommand extends PubCommand {
   String get name => 'downgrade';
   @override
   String get description =>
-      "Downgrade the current package's dependencies to oldest versions.\n\n"
-      "This doesn't modify the lockfile, so it can be reset with \"pub get\".";
+      "Downgrade the current package's dependencies to oldest versions.\n\n";
   @override
   String get argumentsDescription => '[dependencies...]';
   @override


### PR DESCRIPTION
Downgrade was introduced here: https://codereview.chromium.org//365993007

And it seems there was always a call to `saveLockfile()`.

Not saving the lockfile would also lead pub to complain when doing `pub run`.