### PR TITLE
Don't allow outdated taking arguments

### DIFF
--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -41,6 +41,9 @@ class OutdatedCommand extends PubCommand {
   /// when we are outputting machine-readable json.
   bool get _shouldShowSpinner => stdout.hasTerminal && !argResults['json'];
 
+  @override
+  bool get takesArguments => false;
+
   OutdatedCommand() {
     argParser.addFlag(
       'color',

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -134,8 +134,13 @@ class PubCommandRunner extends CommandRunner<int> implements PubTopLevel {
 
   @override
   Future<int> run(Iterable<String> args) async {
-    _argResults = parse(args);
-    return await runCommand(_argResults) ?? exit_codes.SUCCESS;
+    try {
+      _argResults = parse(args);
+      return await runCommand(_argResults) ?? exit_codes.SUCCESS;
+    } on UsageException catch (error) {
+      log.exception(error);
+      return exit_codes.USAGE;
+    }
   }
 
   @override
@@ -146,12 +151,7 @@ class PubCommandRunner extends CommandRunner<int> implements PubTopLevel {
       log.message('Pub ${sdk.version}');
       return 0;
     }
-    try {
-      return await super.runCommand(topLevelResults);
-    } on UsageException catch (error) {
-      log.exception(error);
-      return exit_codes.USAGE;
-    }
+    return await super.runCommand(topLevelResults);
   }
 
   @override

--- a/test/outdated/goldens/bad_arguments.txt
+++ b/test/outdated/goldens/bad_arguments.txt
@@ -1,0 +1,56 @@
+$ pub outdated random_argument
+[ERR] Command "outdated" does not take any arguments.
+[ERR] 
+[ERR] Usage: pub outdated [options]
+[ERR] -h, --help                         Print this usage information.
+[ERR]     --[no-]color                   Whether to color the output.
+[ERR]                                    Defaults to color when connected to a
+[ERR]                                    terminal, and no-color otherwise.
+[ERR]     --[no-]dependency-overrides    Show resolutions with `dependency_overrides`.
+[ERR]                                    (defaults to on)
+[ERR]     --[no-]dev-dependencies        Take dev dependencies into account.
+[ERR]                                    (defaults to on)
+[ERR]     --json                         Output the results using a json format.
+[ERR]     --mode=<PROPERTY>              Highlight versions with PROPERTY.
+[ERR]                                    Only packages currently missing that PROPERTY
+[ERR]                                    will be included unless --show-all.
+[ERR]                                    [outdated (default), null-safety]
+[ERR]     --[no-]prereleases             Include prereleases in latest version.
+[ERR]                                    (defaults to on in --mode=null-safety).
+[ERR]     --[no-]show-all                Include dependencies that are already
+[ERR]                                    fullfilling --mode.
+[ERR]     --[no-]transitive              Show transitive dependencies.
+[ERR]                                    (defaults to off in --mode=null-safety).
+[ERR] 
+[ERR] Run "pub help" to see global options.
+[ERR] See https://dart.dev/tools/pub/cmd/pub-outdated for detailed documentation.
+[Exit code] 64
+
+$ pub outdated --bad_flag
+[ERR] Could not find an option named "bad_flag".
+[ERR] 
+[ERR] Usage: pub outdated [options]
+[ERR] -h, --help                         Print this usage information.
+[ERR]     --[no-]color                   Whether to color the output.
+[ERR]                                    Defaults to color when connected to a
+[ERR]                                    terminal, and no-color otherwise.
+[ERR]     --[no-]dependency-overrides    Show resolutions with `dependency_overrides`.
+[ERR]                                    (defaults to on)
+[ERR]     --[no-]dev-dependencies        Take dev dependencies into account.
+[ERR]                                    (defaults to on)
+[ERR]     --json                         Output the results using a json format.
+[ERR]     --mode=<PROPERTY>              Highlight versions with PROPERTY.
+[ERR]                                    Only packages currently missing that PROPERTY
+[ERR]                                    will be included unless --show-all.
+[ERR]                                    [outdated (default), null-safety]
+[ERR]     --[no-]prereleases             Include prereleases in latest version.
+[ERR]                                    (defaults to on in --mode=null-safety).
+[ERR]     --[no-]show-all                Include dependencies that are already
+[ERR]                                    fullfilling --mode.
+[ERR]     --[no-]transitive              Show transitive dependencies.
+[ERR]                                    (defaults to off in --mode=null-safety).
+[ERR] 
+[ERR] Run "pub help" to see global options.
+[ERR] See https://dart.dev/tools/pub/cmd/pub-outdated for detailed documentation.
+[Exit code] 64
+

--- a/test/outdated/goldens/no_pubspec.txt
+++ b/test/outdated/goldens/no_pubspec.txt
@@ -1,0 +1,4 @@
+$ pub outdated 
+[ERR] Could not find a file named "pubspec.yaml" in "$SANDBOX/myapp".
+[Exit code] 66
+

--- a/test/outdated/outdated_test.dart
+++ b/test/outdated/outdated_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:test/test.dart';
 import '../descriptor.dart' as d;
 import '../golden_file.dart';
@@ -24,7 +26,10 @@ Future<void> runPubOutdated(List<String> args, StringBuffer buffer,
   ].join('\n'));
   final stderrLines = await process.stderr.rest.toList();
   for (final line in stderrLines) {
-    buffer.writeln('[ERR] ${line.replaceAll(d.sandbox, r'$SANDBOX')}');
+    final sanitized = line
+        .replaceAll(d.sandbox, r'$SANDBOX')
+        .replaceAll(Platform.pathSeparator, '/');
+    buffer.writeln('[ERR] $sanitized');
   }
   if (exitCode != 0) {
     buffer.writeln('[Exit code] $exitCode');


### PR DESCRIPTION
Also fixes an issue where stack traces would be exposed to the user in case of some parsing errors (when using the `pub` binary - I don't think this happens with `dart pub`.
Fixes: https://github.com/dart-lang/pub/issues/2868