### PR TITLE
`publish --dry-run` informs that the server might do more checks

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -158,6 +158,8 @@ the \$PUB_HOSTED_URL environment variable.''',
       overrideExitCode(exit_codes.DATA);
       return;
     } else if (dryRun) {
+      log.message(
+          'The server might run further checks on the package before accepting it.');
       return;
     } else {
       await _publish(await packageBytesFuture);

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -158,8 +158,7 @@ the \$PUB_HOSTED_URL environment variable.''',
       overrideExitCode(exit_codes.DATA);
       return;
     } else if (dryRun) {
-      log.message(
-          'The server might run further checks on the package before accepting it.');
+      log.message('The server may enforce additional checks.');
       return;
     } else {
       await _publish(await packageBytesFuture);

--- a/test/goldens/directory_option.txt
+++ b/test/goldens/directory_option.txt
@@ -68,6 +68,7 @@ Publishing test_pkg 1.0.0 to http://localhost:$PORT:
 |-- lib
 |   '-- test_pkg.dart
 '-- pubspec.yaml
+The server may enforce additional checks.
 [ERR] 
 [ERR] Package has 0 warnings.
 

--- a/test/lish/dry_run_warns_about_server_checks.dart
+++ b/test/lish/dry_run_warns_about_server_checks.dart
@@ -12,8 +12,7 @@ void main() {
     await d.validPackage.create();
     await runPub(
       args: ['publish', '--dry-run'],
-      output: contains(
-          'The server might run further checks on the package before accepting it.'),
+      output: contains('The server may enforce additional checks.'),
     );
   });
 }

--- a/test/lish/dry_run_warns_about_server_checks.dart
+++ b/test/lish/dry_run_warns_about_server_checks.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+void main() {
+  test('--dry-run mentions that checks are not exhaustive', () async {
+    await d.validPackage.create();
+    await runPub(
+      args: ['publish', '--dry-run'],
+      output: contains(
+          'The server might run further checks on the package before accepting it.'),
+    );
+  });
+}


### PR DESCRIPTION
This somewhat improves the situation of: https://github.com/dart-lang/pub/issues/2828