### PR TITLE
`cache clean`

### DIFF
--- a/lib/src/command/cache.dart
+++ b/lib/src/command/cache.dart
@@ -4,6 +4,7 @@
 
 import '../command.dart';
 import 'cache_add.dart';
+import 'cache_clean.dart';
 import 'cache_list.dart';
 import 'cache_repair.dart';
 
@@ -19,6 +20,7 @@ class CacheCommand extends PubCommand {
   CacheCommand() {
     addSubcommand(CacheAddCommand());
     addSubcommand(CacheListCommand());
+    addSubcommand(CacheCleanCommand());
     addSubcommand(CacheRepairCommand());
   }
 }

--- a/lib/src/command/cache_clean.dart
+++ b/lib/src/command/cache_clean.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../command.dart';
+import '../command_runner.dart';
 import '../io.dart';
 import '../io.dart';
 import '../log.dart' as log;
@@ -27,9 +28,10 @@ class CacheCleanCommand extends PubCommand {
   @override
   Future<void> runProtected() async {
     if (dirExists(cache.rootDir)) {
-      if (argResults['force'] ||
-          await confirm(
-              'This will remove everything inside ${cache.rootDir}. Are you sure?')) {
+      if (argResults['force'] || await confirm('''
+This will remove everything inside ${cache.rootDir}.
+You will have to run `$topLevelProgram pub get` again in each project.
+Are you sure?''')) {
         log.message('Removing pub cache directory ${cache.rootDir}.');
         deleteEntry(cache.rootDir);
         ensureDir(cache.rootDir);

--- a/lib/src/command/cache_clean.dart
+++ b/lib/src/command/cache_clean.dart
@@ -4,6 +4,7 @@
 
 import '../command.dart';
 import '../io.dart';
+import '../io.dart';
 import '../log.dart' as log;
 
 class CacheCleanCommand extends PubCommand {
@@ -14,11 +15,25 @@ class CacheCleanCommand extends PubCommand {
   @override
   bool get takesArguments => false;
 
+  CacheCleanCommand() {
+    argParser.addFlag(
+      'force',
+      abbr: 'f',
+      help: 'Don\'t ask for confirmation.',
+      negatable: false,
+    );
+  }
+
   @override
   Future<void> runProtected() async {
-    if (entryExists(cache.rootDir)) {
-      log.message('Removing pub cache directory ${cache.rootDir}.');
-      deleteEntry(cache.rootDir);
+    if (dirExists(cache.rootDir)) {
+      if (argResults['force'] ||
+          await confirm(
+              'This will remove everything inside ${cache.rootDir}. Are you sure?')) {
+        log.message('Removing pub cache directory ${cache.rootDir}.');
+        deleteEntry(cache.rootDir);
+        ensureDir(cache.rootDir);
+      }
     } else {
       log.message('No pub cache at ${cache.rootDir}.');
     }

--- a/lib/src/command/cache_clean.dart
+++ b/lib/src/command/cache_clean.dart
@@ -10,7 +10,7 @@ class CacheCleanCommand extends PubCommand {
   @override
   String get name => 'clean';
   @override
-  String get description => 'Clears the entire system cache.';
+  String get description => 'Clears the global PUB_CACHE.';
   @override
   bool get takesArguments => false;
 

--- a/lib/src/command/cache_clean.dart
+++ b/lib/src/command/cache_clean.dart
@@ -5,7 +5,6 @@
 import '../command.dart';
 import '../command_runner.dart';
 import '../io.dart';
-import '../io.dart';
 import '../log.dart' as log;
 
 class CacheCleanCommand extends PubCommand {

--- a/lib/src/command/cache_clean.dart
+++ b/lib/src/command/cache_clean.dart
@@ -1,0 +1,26 @@
+// Copyright (c) 2021, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../command.dart';
+import '../io.dart';
+import '../log.dart' as log;
+
+class CacheCleanCommand extends PubCommand {
+  @override
+  String get name => 'clean';
+  @override
+  String get description => 'Clears the entire system cache.';
+  @override
+  bool get takesArguments => false;
+
+  @override
+  Future<void> runProtected() async {
+    if (entryExists(cache.rootDir)) {
+      log.message('Removing pub cache directory ${cache.rootDir}.');
+      deleteEntry(cache.rootDir);
+    } else {
+      log.message('No pub cache at ${cache.rootDir}.');
+    }
+  }
+}

--- a/test/cache/clean_test.dart
+++ b/test/cache/clean_test.dart
@@ -1,0 +1,31 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
+
+import 'package:path/path.dart' as path;
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+void main() {
+  test('running pub cache clean when there is no cache', () async {
+    final cache = path.join(d.sandbox, cachePath);
+
+    await runPub(args: ['cache', 'clean'], output: 'No pub cache at $cache.');
+  });
+
+  test('running pub cache clean deletes cache', () async {
+    await servePackages((b) => b..serve('foo', '1.1.2')..serve('bar', '1.2.3'));
+    await d.appDir({'foo': 'any', 'bar': 'any'}).create();
+    await pubGet();
+    final cache = path.join(d.sandbox, cachePath);
+    expect(dirExists(cache), isTrue);
+    await runPub(
+        args: ['cache', 'clean'],
+        output: 'Removing pub cache directory $cache.');
+    expect(dirExists(cache), isFalse);
+  });
+}


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub/issues/2521

We could consider letting the command only delete some files (for example leaving credentials.json), but I'm not sure the complexity is worth it - it is not that hard to log in again.