### PR TITLE
Minor cleanup to reduce risk of using path.current

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -902,13 +902,16 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
 /// working directory.
 ///
 /// Returns a [ByteStream] that emits the contents of the archive.
-ByteStream createTarGz(List<String> contents, {String baseDir}) {
+ByteStream createTarGz(
+  List<String> contents, {
+  @required String baseDir,
+}) {
   var buffer = StringBuffer();
   buffer.write('Creating .tar.gz stream containing:\n');
   contents.forEach(buffer.writeln);
   log.fine(buffer.toString());
 
-  baseDir ??= path.current;
+  ArgumentError.checkNotNull(baseDir, 'baseDir');
   baseDir = path.absolute(baseDir);
 
   final tarContents = Stream.fromIterable(contents.map((entry) {


### PR DESCRIPTION
This shouldn't have any side-effect, as nobody is calling without `baseDir`, this just stops people from using said footgun in the future.