### PR TITLE
Add command to fail if extra arguments are passed

### DIFF
--- a/lib/src/command/add.dart
+++ b/lib/src/command/add.dart
@@ -82,6 +82,8 @@ class AddCommand extends PubCommand {
   Future<void> runProtected() async {
     if (argResults.rest.isEmpty) {
       usageException('Must specify a package to be added.');
+    } else if (argResults.rest.length > 1) {
+      usageException('Takes only a single argument.');
     }
 
     final packageInformation = _parsePackage(argResults.rest.first);

--- a/test/add/common/add_test.dart
+++ b/test/add/common/add_test.dart
@@ -37,6 +37,30 @@ void main() {
   });
 
   group('normally', () {
+    test('fails if extra arguments are passed', () async {
+      await servePackages((builder) {
+        builder.serve('foo', '1.2.2');
+      });
+
+      await d.dir(appPath, [
+        d.pubspec({'name': 'myapp'})
+      ]).create();
+
+      await pubAdd(
+          args: ['foo', '^1.2.2'],
+          exitCode: exit_codes.USAGE,
+          error: contains('Takes only a single argument.'));
+
+      await d.dir(appPath, [
+        d.pubspec({
+          'name': 'myapp',
+        }),
+        d.nothing('.dart_tool/package_config.json'),
+        d.nothing('pubspec.lock'),
+        d.nothing('.packages'),
+      ]).validate();
+    });
+
     test('adds a package from a pub server', () async {
       await servePackages((builder) => builder.serve('foo', '1.2.3'));
 


### PR DESCRIPTION
## Description

Added usage exception if extra arguments are passed.

Fixes #2923 

cc @sigurdm @jonasfj 

I am bit unsure whether to put the test case into `add_test.dart` or `invalid_options.dart`. So, as of now it's in `add_test` let me know if its needs to be changed.