### PR TITLE
Handle package:tar cancellations

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -196,16 +196,6 @@ void writeTextFile(String file, String contents,
 }
 
 /// Creates [file] and writes [contents] to it.
-Future<void> writeBinaryFileFromStream(
-  String file,
-  Stream<List<int>> contents,
-) async {
-  deleteIfLink(file);
-  log.fine('Writing text file $file.');
-  await File(file).openWrite().addStream(contents);
-}
-
-/// Creates [file] and writes [contents] to it.
 ///
 /// If [dontLogContents] is `true`, the contents of the file will never be
 /// logged.
@@ -227,7 +217,7 @@ Future<void> writeTextFileAsync(String file, String contents,
 ///
 /// Replaces any file already at that path. Completes when the file is done
 /// being written.
-Future<String> _createFileFromStream(Stream<List<int>> stream, String file) {
+Future<String> createFileFromStream(Stream<List<int>> stream, String file) {
   // TODO(nweiz): remove extra logging when we figure out the windows bot issue.
   log.io('Creating $file from stream.');
 
@@ -866,7 +856,7 @@ Future extractTarGz(Stream<List<int>> stream, String destination) async {
         // Regular file
         deleteIfLink(filePath);
         ensureDir(parentDirectory);
-        await _createFileFromStream(entry.contents, filePath);
+        await createFileFromStream(entry.contents, filePath);
 
         if (Platform.isLinux || Platform.isMacOS) {
           // Apply executable bits from tar header, but don't change r/w bits

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -170,6 +170,13 @@ List<int> readBinaryFile(String file) {
   return contents;
 }
 
+/// Reads the contents of the binary file [file] as a [Stream].
+Stream<List<int>> readBinaryFileAsSream(String file) {
+  log.io('Reading binary file $file.');
+  var contents = File(file).openRead();
+  return contents;
+}
+
 /// Creates [file] and writes [contents] to it.
 ///
 /// If [dontLogContents] is `true`, the contents of the file will never be
@@ -186,6 +193,16 @@ void writeTextFile(String file, String contents,
 
   deleteIfLink(file);
   File(file).writeAsStringSync(contents, encoding: encoding);
+}
+
+/// Creates [file] and writes [contents] to it.
+Future<void> writeBinaryFileFromStream(
+  String file,
+  Stream<List<int>> contents,
+) async {
+  deleteIfLink(file);
+  log.fine('Writing text file $file.');
+  await File(file).openWrite().addStream(contents);
 }
 
 /// Creates [file] and writes [contents] to it.

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -574,6 +574,11 @@ class BoundHostedSource extends CachedSource {
     var response = await httpClient.send(http.Request('GET', url));
 
     try {
+      // We download the archive to disk instead of streaming it directly into
+      // the tar unpacking. This simplifies stream handling.
+      // Package:tar cancels the stream when it reaches end-of-archive, and
+      // cancelling a http stream makes it not reusable.
+      // There are ways around this, and we might revisit this later.
       await writeBinaryFileFromStream(archivePath, response.stream);
       await extractTarGz(readBinaryFileAsSream(archivePath), tempDir);
 

--- a/test/get/hosted/get_stress_test.dart
+++ b/test/get/hosted/get_stress_test.dart
@@ -1,0 +1,36 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('gets more than 16 packages from a pub server', () async {
+    await servePackages((builder) {
+      builder.serve('foo', '1.2.3');
+      for (var i = 0; i < 20; i++) {
+        builder.serve('pkg$i', '1.$i.0');
+      }
+    });
+
+    await d.appDir({
+      'foo': '1.2.3',
+      for (var i = 0; i < 20; i++) 'pkg$i': '^1.$i.0',
+    }).create();
+
+    await pubGet();
+
+    await d.cacheDir({
+      'foo': '1.2.3',
+      for (var i = 0; i < 20; i++) 'pkg$i': '1.$i.0',
+    }).validate();
+
+    await d.appPackagesFile({
+      'foo': '1.2.3',
+      for (var i = 0; i < 20; i++) 'pkg$i': '1.$i.0',
+    }).validate();
+  });
+}


### PR DESCRIPTION
Rolling `pub` into the Dart SDK was reverted, due to an intermittent failure.

I dug into it, and found that `pub get` fails to fetch all dependencies if there is more than 16.
I'm not exactly sure what is going on, I suspect we got some concurrency wrong.

Probably because we don't allow more than 16 concurrent downloads.
Still not sure what caused the queuing to not work as it used to, it's not like we changed anything there.

This PR adds a test that `pub get` can fetch more than 16 dependencies. That's always nice to test, especially when 16 is a magic number wrt. to limiting concurrent downloads.

Culprit from `git bisect`.
```
9a70949e25e9407423c68af5aed0f52b0655fe09 is the first bad commit
commit 9a70949e25e9407423c68af5aed0f52b0655fe09
Date:   Fri Feb 5 13:51:03 2021 +0100

    Use Dart library to read and write tar files (#2817)

 lib/src/io.dart   | 318 ++++++++++++++++++++++--------------------------------
 pubspec.yaml      |   1 +
 test/io_test.dart | 248 ++++++++++++++++++++++++++++++++----------
 3 files changed, 322 insertions(+), 245 deletions(-)
bisect run success
```

FYI @simolus3 