### PR TITLE
Remove docUrl for add command

### DIFF
--- a/lib/src/command/add.dart
+++ b/lib/src/command/add.dart
@@ -36,8 +36,6 @@ class AddCommand extends PubCommand {
   @override
   String get argumentsDescription => '<package>[:<constraint>] [options]';
   @override
-  String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-add';
-  @override
   bool get isOffline => argResults['offline'];
 
   bool get isDev => argResults['dev'];


### PR DESCRIPTION
It seems that a doc for `pub add` command (https://dart.dev/tools/pub/cmd/pub-add) doesn't exist.