### PR TITLE
Use the frontend server to compile pub executables

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -68,5 +68,5 @@ jobs:
           tail -n+$offset $_TESTS_FILE | head -n$tests_per_shard > $_TESTS_FILE.${{ matrix.shard }}
         shell: bash
       - name: Run tests
-        run: dart test --preset travis $(cat $_TESTS_FILE.${{ matrix.shard }})
+        run: dart test --use-data-isolate-strategy --preset travis $(cat $_TESTS_FILE.${{ matrix.shard }})
         shell: bash

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -16,6 +16,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:cli_util/cli_util.dart';
 import 'package:frontend_server_client/frontend_server_client.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import 'exceptions.dart';
@@ -34,41 +35,6 @@ bool isEntrypoint(CompilationUnit dart) {
         node.name.name == 'main' &&
         node.functionExpression.parameters.parameters.length <= 2;
   });
-}
-
-/// Snapshots the Dart executable at [executablePath] to a snapshot at
-/// [snapshotPath].
-///
-/// If [packageConfigFile] is passed, it's used to resolve `package:` URIs in
-/// the executable. Otherwise, a `packages/` directory or a package spec is
-/// inferred from the executable's location.
-///
-/// If [name] is passed, it is used to describe the executable in logs and error
-/// messages.
-Future snapshot(
-  String executablePath,
-  String snapshotPath, {
-  String packageConfigFile,
-  String name,
-}) async {
-  final args = [
-    if (packageConfigFile != null) '--packages=$packageConfigFile',
-    '--snapshot=$snapshotPath',
-    p.toUri(executablePath).toString()
-  ];
-
-  final result = await runProcess(Platform.executable, args);
-  final highlightedName = name = log.bold(name ?? executablePath.toString());
-  if (result.success) {
-    log.message('Precompiled $highlightedName.');
-  } else {
-    // Don't leave partial results.
-    deleteEntry(snapshotPath);
-
-    throw ApplicationException(
-        log.yellow('Failed to precompile $highlightedName:\n') +
-            result.stderr.join('\n'));
-  }
 }
 
 class AnalysisContextManager {
@@ -176,9 +142,23 @@ class AnalyzerErrorGroup implements Exception {
   String toString() => errors.join('\n');
 }
 
-Future<void> precompile(
-    String executablePath, String outputPath, String incrementalDillOutputPath,
-    {String packageConfigFile, String name}) async {
+/// Precompiles the Dart executable at [executablePath] to a kernel file at
+/// [outputPath].
+///
+/// This file is also cached at [incrementalDillOutputPath] which is used to
+/// initialize the compiler on future runs.
+///
+/// The [packageConfigPath] should point at the package config file to be used
+/// for `package:` uri resolution.
+///
+/// The [name] is used to describe the executable in logs and error messages.
+Future<void> precompile({
+  @required String executablePath,
+  @required String incrementalDillOutputPath,
+  @required String name,
+  @required String outputPath,
+  @required String packageConfigPath,
+}) async {
   ensureDir(p.dirname(outputPath));
   ensureDir(p.dirname(incrementalDillOutputPath));
   const platformDill = 'lib/_internal/vm_platform_strong.dill';
@@ -188,14 +168,13 @@ Future<void> precompile(
     incrementalDillOutputPath,
     platformDill,
     sdkRoot: sdkRoot,
-    packagesJson:
-        packageConfigFile ?? p.join('.dart_tool', 'package_config.json'),
+    packagesJson: packageConfigPath,
     printIncrementalDependencies: false,
   );
   try {
     var result = await client.compile();
 
-    final highlightedName = name = log.bold(name ?? executablePath.toString());
+    final highlightedName = log.bold(name);
     if (result?.errorCount == 0) {
       log.message('Precompiled $highlightedName.');
       await File(incrementalDillOutputPath).copy(outputPath);

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -197,7 +197,7 @@ Future<void> precompile(
     var result = await client.compile();
 
     final highlightedName = name = log.bold(name ?? executablePath.toString());
-    if (result.errorCount == 0) {
+    if (result?.errorCount == 0) {
       log.message('Precompiled $highlightedName.');
       await File(incrementalDillOutputPath).copy(outputPath);
     } else {
@@ -206,7 +206,7 @@ Future<void> precompile(
 
       throw ApplicationException(
           log.yellow('Failed to precompile $highlightedName:\n') +
-              result.compilerOutputLines.join('\n'));
+              (result?.compilerOutputLines?.join('\n') ?? ''));
     }
   } finally {
     client.kill();

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -181,7 +181,7 @@ Future<void> precompile(
     {String packageConfigFile, String name}) async {
   ensureDir(p.dirname(outputPath));
   ensureDir(p.dirname(incrementalDillOutputPath));
-  const platformDill = 'lib/_internal/vm_platform_strong.dill';
+  final platformDill = p.join('lib', '_internal', 'vm_platform_strong.dill');
   final sdkRoot =
       Directory(p.relative(p.join(Platform.resolvedExecutable, '..', '..')))
           .uri;
@@ -190,7 +190,8 @@ Future<void> precompile(
     incrementalDillOutputPath,
     platformDill,
     sdkRoot: sdkRoot.path,
-    packagesJson: packageConfigFile ?? '.dart_tool/package_config.json',
+    packagesJson:
+        packageConfigFile ?? p.join('.dart_tool', 'package_config.json'),
     printIncrementalDependencies: false,
   );
   try {

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -179,6 +179,8 @@ class AnalyzerErrorGroup implements Exception {
 Future<void> precompile(
     String executablePath, String outputPath, String incrementalDillOutputPath,
     {String packageConfigFile, String name}) async {
+  ensureDir(p.dirname(outputPath));
+  ensureDir(p.dirname(incrementalDillOutputPath));
   const platformDill = 'lib/_internal/vm_platform_strong.dill';
   final sdkRoot =
       Directory(p.relative(p.join(Platform.resolvedExecutable, '..', '..')))

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -181,7 +181,7 @@ Future<void> precompile(
     {String packageConfigFile, String name}) async {
   ensureDir(p.dirname(outputPath));
   ensureDir(p.dirname(incrementalDillOutputPath));
-  final platformDill = p.join('lib', '_internal', 'vm_platform_strong.dill');
+  const platformDill = 'lib/_internal/vm_platform_strong.dill';
   final sdkRoot = p.relative(p.dirname(p.dirname(Platform.resolvedExecutable)));
   var client = await FrontendServerClient.start(
     executablePath,

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -182,14 +182,12 @@ Future<void> precompile(
   ensureDir(p.dirname(outputPath));
   ensureDir(p.dirname(incrementalDillOutputPath));
   final platformDill = p.join('lib', '_internal', 'vm_platform_strong.dill');
-  final sdkRoot =
-      Directory(p.relative(p.join(Platform.resolvedExecutable, '..', '..')))
-          .uri;
+  final sdkRoot = p.relative(p.dirname(p.dirname(Platform.resolvedExecutable)));
   var client = await FrontendServerClient.start(
     executablePath,
     incrementalDillOutputPath,
     platformDill,
-    sdkRoot: sdkRoot.path,
+    sdkRoot: sdkRoot,
     packagesJson:
         packageConfigFile ?? p.join('.dart_tool', 'package_config.json'),
     printIncrementalDependencies: false,

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -354,9 +354,9 @@ class Entrypoint {
   Future<void> _precompileExecutable(Executable executable) async {
     final package = executable.package;
     await dart.precompile(
-        resolveExecutable(executable),
-        pathOfExecutable(executable),
-        incrementalDillPathOfExecutable(executable),
+        executablePath: resolveExecutable(executable),
+        outputPath: pathOfExecutable(executable),
+        incrementalDillOutputPath: incrementalDillPathOfExecutable(executable),
         packageConfigFile: packageConfigFile,
         name:
             '$package:${p.basenameWithoutExtension(executable.relativePath)}');

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -347,7 +347,6 @@ class Entrypoint {
   Future<void> precompileExecutable(Executable executable) async {
     return await log.progress('Precompiling executable', () async {
       ensureDir(p.dirname(pathOfExecutable(executable)));
-      ensureDir(p.dirname(incrementalDillPathOfExecutable(executable)));
       return waitAndPrintErrors([_precompileExecutable(executable)]);
     });
   }

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -357,7 +357,7 @@ class Entrypoint {
         executablePath: resolveExecutable(executable),
         outputPath: pathOfExecutable(executable),
         incrementalDillOutputPath: incrementalDillPathOfExecutable(executable),
-        packageConfigFile: packageConfigFile,
+        packageConfigPath: packageConfigFile,
         name:
             '$package:${p.basenameWithoutExtension(executable.relativePath)}');
   }

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -70,7 +70,7 @@ Future<int> runExecutable(
 
   entrypoint.migrateCache();
 
-  var snapshotPath = entrypoint.snapshotPathOfExecutable(executable);
+  var snapshotPath = entrypoint.pathOfExecutable(executable);
 
   // Don't compile snapshots for mutable packages, since their code may
   // change later on.
@@ -325,7 +325,7 @@ Future<String> getExecutableForCommand(
     if (!allowSnapshot || entrypoint.packageGraph.isPackageMutable(package)) {
       return p.relative(path, from: root);
     } else {
-      final snapshotPath = entrypoint.snapshotPathOfExecutable(executable);
+      final snapshotPath = entrypoint.pathOfExecutable(executable);
       if (!fileExists(snapshotPath)) {
         await warningsOnlyUnlessTerminal(
           () => entrypoint.precompileExecutable(executable),

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -588,8 +588,7 @@ To recompile executables, first run `global deactivate ${dep.name}`.
         deleteEntry(file);
         _createBinStub(
             entrypoint.root, p.basenameWithoutExtension(file), binStubScript,
-            overwrite: true,
-            snapshot: entrypoint.snapshotPathOfExecutable(executable));
+            overwrite: true, snapshot: entrypoint.pathOfExecutable(executable));
       }
     }
   }
@@ -639,7 +638,7 @@ To recompile executables, first run `global deactivate ${dep.name}`.
         executable,
         script,
         overwrite: overwriteBinStubs,
-        snapshot: entrypoint.snapshotPathOfExecutable(
+        snapshot: entrypoint.pathOfExecutable(
           exec.Executable.adaptProgramName(package.name, script),
         ),
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   cli_util: ^0.3.0
   collection: ^1.15.0
   crypto: ^3.0.0
+  frontend_server_client: ^2.0.0
   http: ^0.13.0
   http_multi_server: ^3.0.0
   http_retry: ^0.2.0


### PR DESCRIPTION
Opening for discussion, I wanted to try this out to see if we can speed up the rebuilds of pub executables - it does appear to be much faster (basically immediate if there is no change).  Surprisingly, it is almost twice as fast on the initial precompile as well for me. I think that probably means that the vm snapshot functionality is doing something additional - I don't know what the implications of using kernel instead might be.

Specifically this:

- Creates a new dir `.dart_tool/pub/incremental` where it stores the previous dill outputs for each executable.
- Uses the frontend server to compile to that directory (which will use those files automatically to initialize from).
- Copies the output from there to the actual executable path if successful.

Previous snapshot behavior:
![snapshot](https://user-images.githubusercontent.com/984921/115426985-e189f780-a1b5-11eb-9176-e13b2000429a.png)

New fe server behavior, first build:
![kernel_first](https://user-images.githubusercontent.com/984921/115427048-f36b9a80-a1b5-11eb-8917-c433db46d2bc.png)

New behavior, pub get and run again (no changes):
![kernel_incremental](https://user-images.githubusercontent.com/984921/115427058-f6668b00-a1b5-11eb-8b12-1251b04b808d.png)

Note that in the rebuild case with no changes, it didn't actually log the time at all which I believe means it was <1 second.

cc @mit-mit 

