### PR TITLE
fix grammar in .gitignore error message

### DIFF
--- a/lib/src/validator/gitignore.dart
+++ b/lib/src/validator/gitignore.dart
@@ -60,7 +60,7 @@ class GitignoreValidator extends Validator {
 
       if (ignoredFilesCheckedIn.isNotEmpty) {
         warnings.add('''
-${ignoredFilesCheckedIn.length} checked in ${pluralize('file', ignoredFilesCheckedIn.length)} are ignored by a `.gitignore`.
+${ignoredFilesCheckedIn.length} checked in ${pluralize('file', ignoredFilesCheckedIn.length)} ${ignoredFilesCheckedIn.length == 1 ? 'is' : 'are'} ignored by a `.gitignore`.
 Previous versions of Pub would include those in the published package.
 
 Consider adjusting your `.gitignore` files to not ignore those files, and if you do not wish to


### PR DESCRIPTION
```
1 checked in file are ignored by a `.gitignore`.
```

(OLD) vs (NEW)

```
1 checked in file is ignored by a `.gitignore`.
```