### PR TITLE
New binstubs for global activate using `dart pub`

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -756,9 +756,9 @@ if exist "$snapshot" (
   if not errorlevel 253 (
     goto error
   )
-  pub global run ${package.name}:$script %*
+  dart pub global run ${package.name}:$script %*
 ) else (
-  pub global run ${package.name}:$script %*
+  dart pub global run ${package.name}:$script %*
 )
 goto eof
 :error
@@ -766,7 +766,7 @@ exit /b %errorlevel%
 :eof
 ''';
       } else {
-        invocation = 'pub global run ${package.name}:$script %*';
+        invocation = 'dart pub global run ${package.name}:$script %*';
       }
       var batch = '''
 @echo off
@@ -792,13 +792,13 @@ if [ -f $snapshot ]; then
   if [ \$exit_code != 253 ]; then	
     exit \$exit_code	
   fi	
-  pub global run ${package.name}:$script "\$@"
+  dart pub global run ${package.name}:$script "\$@"
 else
-  pub global run ${package.name}:$script "\$@"
+  dart pub global run ${package.name}:$script "\$@"
 fi
 ''';
       } else {
-        invocation = 'pub global run ${package.name}:$script "\$@"';
+        invocation = 'dart pub global run ${package.name}:$script "\$@"';
       }
       var bash = '''
 #!/usr/bin/env sh


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/3000, downside is that if you want to downgrade from Dart 2.14.x to Dart 2.9.x, then packages activated with `dart pub global activate <package>` won't work anymore.

Upside is that now `dart pub global activate <package>` will work for users who have installed Dart from the Flutter SDK.

----

It's still be messy if you have two Dart SDK installations as Flutter in some configurations still use a different `PUB_CACHE`.