### PR TITLE
Generate GNU-style long file names in tar archives

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,6 +6,8 @@ analyzer:
     unused_local_variable: error
     dead_code: error
     todo: ignore
+  exclude:
+   - lib/src/third_party/**
 
 linter:
   rules:

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -955,7 +955,9 @@ ByteStream createTarGz(
     );
   }));
 
-  return ByteStream(tarContents.transform(tarWriter).transform(gzip.encoder));
+  return ByteStream(tarContents
+      .transform(tarWriterWith(format: OutputFormat.gnuLongName))
+      .transform(gzip.encoder));
 }
 
 /// Contains the results of invoking a [Process] and waiting for it to complete.

--- a/lib/src/third_party/tar/README.md
+++ b/lib/src/third_party/tar/README.md
@@ -4,4 +4,4 @@ Vendored elements from `package:tar` for use in creation and extration of
 tar-archives.
 
  * Repository: `https://github.com/simolus3/tar/`
- * Revision: `e8bf3e828e1c4c89774fab1b9083a6879ed5eae9`
+ * Revision: `b5c5a11d8969f458ccdeb8cf01615f692fed3e97`

--- a/lib/src/third_party/tar/src/reader.dart
+++ b/lib/src/third_party/tar/src/reader.dart
@@ -803,8 +803,8 @@ class PaxHeaders extends UnmodifiableMapBase<String, String> {
       // If we're seeing weird PAX Version 0.0 sparse keys, expect alternating
       // GNU.sparse.offset and GNU.sparse.numbytes headers.
       if (key == paxGNUSparseNumBytes || key == paxGNUSparseOffset) {
-        if ((sparseMap.length % 2 == 0 && key != paxGNUSparseOffset) ||
-            (sparseMap.length % 2 == 1 && key != paxGNUSparseNumBytes) ||
+        if ((sparseMap.length.isEven && key != paxGNUSparseOffset) ||
+            (sparseMap.length.isOdd && key != paxGNUSparseNumBytes) ||
             value.contains(',')) {
           error();
         }

--- a/lib/src/third_party/tar/tar.dart
+++ b/lib/src/third_party/tar/tar.dart
@@ -14,4 +14,4 @@ export 'src/exception.dart';
 export 'src/format.dart';
 export 'src/header.dart' show TarHeader;
 export 'src/reader.dart' show TarReader;
-export 'src/writer.dart' show tarWritingSink, tarWriter;
+export 'src/writer.dart';


### PR DESCRIPTION
- Upgrades tar (the changes have been reviewed by @jonasfj)
- Use the gnu style format in the tar writer
- Exclude tar sources from lints in this package

Closes #3001
