### PR TITLE
Revert "Use the frontend server to compile pub executables"

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,5 +70,5 @@ jobs:
           cat "$_TESTS_FILE.${{ matrix.shard }}"
         shell: bash
       - name: Run tests
-        run: dart test --use-data-isolate-strategy --preset travis $(cat $_TESTS_FILE.${{ matrix.shard }})
+        run: dart test --preset travis $(cat $_TESTS_FILE.${{ matrix.shard }})
         shell: bash

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -18,8 +18,6 @@ import 'package:analyzer/dart/analysis/session.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/error/error.dart';
 import 'package:cli_util/cli_util.dart';
-import 'package:frontend_server_client/frontend_server_client.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import 'exceptions.dart';
@@ -38,6 +36,41 @@ bool isEntrypoint(CompilationUnit dart) {
         node.name.name == 'main' &&
         node.functionExpression.parameters.parameters.length <= 2;
   });
+}
+
+/// Snapshots the Dart executable at [executablePath] to a snapshot at
+/// [snapshotPath].
+///
+/// If [packageConfigFile] is passed, it's used to resolve `package:` URIs in
+/// the executable. Otherwise, a `packages/` directory or a package spec is
+/// inferred from the executable's location.
+///
+/// If [name] is passed, it is used to describe the executable in logs and error
+/// messages.
+Future snapshot(
+  String executablePath,
+  String snapshotPath, {
+  String packageConfigFile,
+  String name,
+}) async {
+  final args = [
+    if (packageConfigFile != null) '--packages=$packageConfigFile',
+    '--snapshot=$snapshotPath',
+    p.toUri(executablePath).toString()
+  ];
+
+  final result = await runProcess(Platform.executable, args);
+  final highlightedName = name = log.bold(name ?? executablePath.toString());
+  if (result.success) {
+    log.message('Precompiled $highlightedName.');
+  } else {
+    // Don't leave partial results.
+    deleteEntry(snapshotPath);
+
+    throw ApplicationException(
+        log.yellow('Failed to precompile $highlightedName:\n') +
+            result.stderr.join('\n'));
+  }
 }
 
 class AnalysisContextManager {
@@ -147,53 +180,4 @@ class AnalyzerErrorGroup implements Exception {
 
   @override
   String toString() => errors.join('\n');
-}
-
-/// Precompiles the Dart executable at [executablePath] to a kernel file at
-/// [outputPath].
-///
-/// This file is also cached at [incrementalDillOutputPath] which is used to
-/// initialize the compiler on future runs.
-///
-/// The [packageConfigPath] should point at the package config file to be used
-/// for `package:` uri resolution.
-///
-/// The [name] is used to describe the executable in logs and error messages.
-Future<void> precompile({
-  @required String executablePath,
-  @required String incrementalDillOutputPath,
-  @required String name,
-  @required String outputPath,
-  @required String packageConfigPath,
-}) async {
-  ensureDir(p.dirname(outputPath));
-  ensureDir(p.dirname(incrementalDillOutputPath));
-  const platformDill = 'lib/_internal/vm_platform_strong.dill';
-  final sdkRoot = p.relative(p.dirname(p.dirname(Platform.resolvedExecutable)));
-  var client = await FrontendServerClient.start(
-    executablePath,
-    incrementalDillOutputPath,
-    platformDill,
-    sdkRoot: sdkRoot,
-    packagesJson: packageConfigPath,
-    printIncrementalDependencies: false,
-  );
-  try {
-    var result = await client.compile();
-
-    final highlightedName = log.bold(name);
-    if (result?.errorCount == 0) {
-      log.message('Precompiled $highlightedName.');
-      await File(incrementalDillOutputPath).copy(outputPath);
-    } else {
-      // Don't leave partial results.
-      deleteEntry(outputPath);
-
-      throw ApplicationException(
-          log.yellow('Failed to precompile $highlightedName:\n') +
-              (result?.compilerOutputLines?.join('\n') ?? ''));
-    }
-  } finally {
-    client.kill();
-  }
 }

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -72,7 +72,7 @@ Future<int> runExecutable(
 
   entrypoint.migrateCache();
 
-  var snapshotPath = entrypoint.pathOfExecutable(executable);
+  var snapshotPath = entrypoint.snapshotPathOfExecutable(executable);
 
   // Don't compile snapshots for mutable packages, since their code may
   // change later on.
@@ -327,7 +327,7 @@ Future<String> getExecutableForCommand(
     if (!allowSnapshot || entrypoint.packageGraph.isPackageMutable(package)) {
       return p.relative(path, from: root);
     } else {
-      final snapshotPath = entrypoint.pathOfExecutable(executable);
+      final snapshotPath = entrypoint.snapshotPathOfExecutable(executable);
       if (!fileExists(snapshotPath)) {
         await warningsOnlyUnlessTerminal(
           () => entrypoint.precompileExecutable(executable),

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -590,7 +590,8 @@ To recompile executables, first run `global deactivate ${dep.name}`.
         deleteEntry(file);
         _createBinStub(
             entrypoint.root, p.basenameWithoutExtension(file), binStubScript,
-            overwrite: true, snapshot: entrypoint.pathOfExecutable(executable));
+            overwrite: true,
+            snapshot: entrypoint.snapshotPathOfExecutable(executable));
       }
     }
   }
@@ -640,7 +641,7 @@ To recompile executables, first run `global deactivate ${dep.name}`.
         executable,
         script,
         overwrite: overwriteBinStubs,
-        snapshot: entrypoint.pathOfExecutable(
+        snapshot: entrypoint.snapshotPathOfExecutable(
           exec.Executable.adaptProgramName(package.name, script),
         ),
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   cli_util: ^0.3.0
   collection: ^1.15.0
   crypto: ^3.0.1
-  frontend_server_client: ^2.0.0
   http: ^0.13.3
   http_multi_server: ^3.0.1
   meta: ^1.3.0


### PR DESCRIPTION
Reverts dart-lang/pub#2968, @jakemac53 apparently we don't have `frontend_server_client` in the Dart SDK :see_no_evil: 

I'm reverting this for now, so I can merge and land other fixes.