### PR TITLE
Downgraded does_not_include_dot_file.dart to 2.10

### DIFF
--- a/test/lish/does_not_include_dot_file.dart
+++ b/test/lish/does_not_include_dot_file.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// @dart=2.10
+
 import 'dart:convert';
 
 import 'package:shelf/shelf.dart' as shelf;


### PR DESCRIPTION
All other tests files contains `@dart=2.10` annotation expect does_not_include_dot_file.dart file.