### PR TITLE
fail CI on info level issues; fix directives sorting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,7 @@ jobs:
         run: dart format --output=none --set-exit-if-changed .
         if: always() && steps.install.outcome == 'success'
       - name: Analyze code
-        run: dart analyze
+        run: dart analyze --fatal-infos
         if: always() && steps.install.outcome == 'success'
 
   # Run tests on a matrix consisting of three dimensions:

--- a/lib/src/rate_limited_scheduler.dart
+++ b/lib/src/rate_limited_scheduler.dart
@@ -8,8 +8,8 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:meta/meta.dart';
-import 'package:pool/pool.dart';
 import 'package:pedantic/pedantic.dart';
+import 'package:pool/pool.dart';
 
 /// Handles rate-limited scheduling of tasks.
 ///

--- a/test/add/common/add_test.dart
+++ b/test/add/common/add_test.dart
@@ -3,12 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
+
 import 'dart:io' show File;
 
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/cache/add/bad_version_test.dart
+++ b/test/cache/add/bad_version_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/cache/add/missing_package_arg_test.dart
+++ b/test/cache/add/missing_package_arg_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/cache/add/package_not_found_test.dart
+++ b/test/cache/add/package_not_found_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/cache/add/unexpected_arguments_test.dart
+++ b/test/cache/add/unexpected_arguments_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/cache/clean_test.dart
+++ b/test/cache/clean_test.dart
@@ -4,10 +4,9 @@
 
 // @dart=2.10
 
+import 'package:path/path.dart' as path;
 import 'package:pub/src/io.dart';
 import 'package:test/test.dart';
-
-import 'package:path/path.dart' as path;
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/cache/list_test.dart
+++ b/test/cache/list_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/cache/repair/git_test.dart
+++ b/test/cache/repair/git_test.dart
@@ -4,11 +4,10 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/cache/repair/handles_corrupted_global_lockfile_test.dart
+++ b/test/cache/repair/handles_corrupted_global_lockfile_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/cache/repair/handles_failure_test.dart
+++ b/test/cache/repair/handles_failure_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/dependency_override_test.dart
+++ b/test/dependency_override_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
+
+import 'package:test/test.dart';
 
 import 'descriptor.dart' as d;
 import 'test_pub.dart';

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -7,12 +7,12 @@
 /// Pub-specific test descriptors.
 import 'dart:convert';
 
+import 'package:meta/meta.dart';
 import 'package:oauth2/oauth2.dart' as oauth2;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/language_version.dart';
 import 'package:pub/src/package_config.dart';
 import 'package:test_descriptor/test_descriptor.dart';
-import 'package:meta/meta.dart';
-import 'package:path/path.dart' as p;
 
 import 'descriptor/git.dart';
 import 'descriptor/packages.dart';
@@ -21,6 +21,7 @@ import 'descriptor/yaml.dart';
 import 'test_pub.dart';
 
 export 'package:test_descriptor/test_descriptor.dart';
+
 export 'descriptor/git.dart';
 export 'descriptor/packages.dart';
 export 'descriptor/tar.dart';

--- a/test/descriptor/tar.dart
+++ b/test/descriptor/tar.dart
@@ -8,8 +8,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
-import 'package:pub/src/log.dart' as log;
 import 'package:pub/src/io.dart';
+import 'package:pub/src/log.dart' as log;
 import 'package:test_descriptor/test_descriptor.dart';
 
 /// Describes a tar file and its contents.

--- a/test/directory_option_test.dart
+++ b/test/directory_option_test.dart
@@ -7,8 +7,9 @@
 import 'dart:convert';
 
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
 import 'package:shelf/shelf.dart' as shelf;
+import 'package:test/test.dart';
+
 import 'descriptor.dart';
 import 'golden_file.dart';
 import 'test_pub.dart';

--- a/test/downgrade/dry_run_does_not_apply_changes_test.dart
+++ b/test/downgrade/dry_run_does_not_apply_changes_test.dart
@@ -5,9 +5,8 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/embedding/get_executable_for_command_test.dart
+++ b/test/embedding/get_executable_for_command_test.dart
@@ -6,10 +6,10 @@
 
 import 'dart:io';
 
-import 'package:test/test.dart';
-import 'package:pub/pub.dart';
 import 'package:path/path.dart' show separator;
 import 'package:path/path.dart' as p;
+import 'package:pub/pub.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/get/flutter_constraint_upper_bound_ignored_test.dart
+++ b/test/get/flutter_constraint_upper_bound_ignored_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/get/git/check_out_test.dart
+++ b/test/get/git/check_out_test.dart
@@ -6,11 +6,11 @@
 
 import 'dart:io';
 
-import 'package:pub/src/io.dart';
-import 'package:test/test.dart';
 import 'package:path/path.dart' as p;
+import 'package:pub/src/io.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/git/check_out_transitive_test.dart
+++ b/test/get/git/check_out_transitive_test.dart
@@ -5,8 +5,8 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/git/check_out_unfetched_revision_of_cached_repo_test.dart
+++ b/test/get/git/check_out_unfetched_revision_of_cached_repo_test.dart
@@ -5,9 +5,8 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
-
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/git/dependency_name_match_pubspec_test.dart
+++ b/test/get/git/dependency_name_match_pubspec_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/git/doesnt_fetch_if_nothing_changes_test.dart
+++ b/test/get/git/doesnt_fetch_if_nothing_changes_test.dart
@@ -5,9 +5,8 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
-
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/git/git_not_installed_test.dart
+++ b/test/get/git/git_not_installed_test.dart
@@ -4,13 +4,13 @@
 
 // @dart=2.10
 
+@TestOn('linux')
 import 'dart:io';
 
-@TestOn('linux')
-import 'package:test/test.dart';
-import 'package:test_descriptor/test_descriptor.dart' show sandbox;
 import 'package:path/path.dart' as p;
 import 'package:pub/src/io.dart' show runProcess;
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' show sandbox;
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/git/lock_version_test.dart
+++ b/test/get/git/lock_version_test.dart
@@ -5,9 +5,8 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/git/locked_revision_without_repo_test.dart
+++ b/test/get/git/locked_revision_without_repo_test.dart
@@ -5,9 +5,8 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/git/path_test.dart
+++ b/test/get/git/path_test.dart
@@ -5,9 +5,8 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
-
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/git/require_pubspec_name_test.dart
+++ b/test/get/git/require_pubspec_name_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/hosted/get_test.dart
+++ b/test/get/hosted/get_test.dart
@@ -5,11 +5,10 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
-import 'package:yaml/yaml.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/hosted/stay_locked_test.dart
+++ b/test/get/hosted/stay_locked_test.dart
@@ -5,9 +5,8 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/hosted/unlock_if_version_doesnt_exist_test.dart
+++ b/test/get/hosted/unlock_if_version_doesnt_exist_test.dart
@@ -5,9 +5,8 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
-
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/hosted/warn_about_discontinued_test.dart
+++ b/test/get/hosted/warn_about_discontinued_test.dart
@@ -7,10 +7,9 @@
 import 'dart:convert';
 
 import 'package:path/path.dart' as p;
+import 'package:pub/src/io.dart';
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
-
-import 'package:pub/src/io.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/package_name_test.dart
+++ b/test/get/package_name_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/get/path/absolute_path_test.dart
+++ b/test/get/path/absolute_path_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/path/absolute_symlink_test.dart
+++ b/test/get/path/absolute_symlink_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/path/empty_pubspec_test.dart
+++ b/test/get/path/empty_pubspec_test.dart
@@ -4,10 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/path/no_pubspec_test.dart
+++ b/test/get/path/no_pubspec_test.dart
@@ -4,10 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/path/nonexistent_dir_test.dart
+++ b/test/get/path/nonexistent_dir_test.dart
@@ -4,10 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/path/path_is_file_test.dart
+++ b/test/get/path/path_is_file_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/path/relative_path_test.dart
+++ b/test/get/path/relative_path_test.dart
@@ -5,10 +5,9 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/lock_file.dart';
 import 'package:pub/src/source_registry.dart';
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/path/relative_symlink_test.dart
+++ b/test/get/path/relative_symlink_test.dart
@@ -9,9 +9,8 @@
 // support relative paths. So this test, by design, will not pass on Windows.
 // So just skip it.
 @TestOn('!windows')
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/path/shared_dependency_symlink_test.dart
+++ b/test/get/path/shared_dependency_symlink_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
+
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/get/preserve_lock_file_line_endings_test.dart
+++ b/test/get/preserve_lock_file_line_endings_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
+import 'package:path/path.dart' as path;
 import 'package:pub/src/entrypoint.dart';
 import 'package:test/test.dart';
-import 'package:path/path.dart' as path;
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/get/sdk_constraint_required_test.dart
+++ b/test/get/sdk_constraint_required_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/global/activate/constraint_with_path_test.dart
+++ b/test/global/activate/constraint_with_path_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/global/activate/empty_constraint_test.dart
+++ b/test/global/activate/empty_constraint_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/global/activate/missing_git_repo_test.dart
+++ b/test/global/activate/missing_git_repo_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/global/activate/missing_package_arg_test.dart
+++ b/test/global/activate/missing_package_arg_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/global/binstubs/explicit_and_no_executables_options_test.dart
+++ b/test/global/binstubs/explicit_and_no_executables_options_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/global/binstubs/missing_script_test.dart
+++ b/test/global/binstubs/missing_script_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/global/binstubs/outdated_binstub_runs_pub_global_test.dart
+++ b/test/global/binstubs/outdated_binstub_runs_pub_global_test.dart
@@ -7,8 +7,8 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:test_process/test_process.dart';
 import 'package:test/test.dart';
+import 'package:test_process/test_process.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/global/binstubs/unknown_explicit_executable_test.dart
+++ b/test/global/binstubs/unknown_explicit_executable_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/global/deactivate/missing_package_arg_test.dart
+++ b/test/global/deactivate/missing_package_arg_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/global/deactivate/path_package_test.dart
+++ b/test/global/deactivate/path_package_test.dart
@@ -4,10 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as p;
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/global/deactivate/unexpected_arguments_test.dart
+++ b/test/global/deactivate/unexpected_arguments_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/global/deactivate/unknown_package_test.dart
+++ b/test/global/deactivate/unknown_package_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/global/list_test.dart
+++ b/test/global/list_test.dart
@@ -4,10 +4,10 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as p;
 import 'package:pub/src/io.dart';
+
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/global/run/errors_if_outside_bin_test.dart
+++ b/test/global/run/errors_if_outside_bin_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/global/run/fails_if_sdk_constraint_is_unmet_test.dart
+++ b/test/global/run/fails_if_sdk_constraint_is_unmet_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/global/run/missing_executable_arg_test.dart
+++ b/test/global/run/missing_executable_arg_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/global/run/missing_path_package_test.dart
+++ b/test/global/run/missing_path_package_test.dart
@@ -5,10 +5,9 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/global/run/nonexistent_script_test.dart
+++ b/test/global/run/nonexistent_script_test.dart
@@ -4,10 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/global/run/runs_script_without_packages_file_test.dart
+++ b/test/global/run/runs_script_without_packages_file_test.dart
@@ -5,9 +5,8 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
-
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/global/run/unknown_package_test.dart
+++ b/test/global/run/unknown_package_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../test_pub.dart';
 

--- a/test/hosted/fail_gracefully_on_bad_version_listing_response_test.dart
+++ b/test/hosted/fail_gracefully_on_bad_version_listing_response_test.dart
@@ -6,10 +6,9 @@
 
 import 'dart:convert';
 
+import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
-
-import 'package:pub/src/exit_codes.dart' as exit_codes;
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/hosted/fail_gracefully_on_missing_package_test.dart
+++ b/test/hosted/fail_gracefully_on_missing_package_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/hosted/fail_gracefully_on_url_resolve_test.dart
+++ b/test/hosted/fail_gracefully_on_url_resolve_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/hosted/offline_test.dart
+++ b/test/hosted/offline_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/archives_and_uploads_a_package_test.dart
+++ b/test/lish/archives_and_uploads_a_package_test.dart
@@ -7,11 +7,10 @@
 import 'dart:convert';
 
 import 'package:path/path.dart' as p;
-import 'package:shelf/shelf.dart' as shelf;
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/io.dart';
+import 'package:shelf/shelf.dart' as shelf;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/does_not_include_dot_file.dart
+++ b/test/lish/does_not_include_dot_file.dart
@@ -6,10 +6,9 @@
 
 import 'dart:convert';
 
+import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
-
-import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:test_descriptor/test_descriptor.dart' as td;
 
 import '../descriptor.dart' as d;

--- a/test/lish/does_not_publish_if_private_test.dart
+++ b/test/lish/does_not_publish_if_private_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/does_not_publish_if_private_with_server_arg_test.dart
+++ b/test/lish/does_not_publish_if_private_with_server_arg_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/force_does_not_publish_if_private_test.dart
+++ b/test/lish/force_does_not_publish_if_private_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/force_does_not_publish_if_there_are_errors_test.dart
+++ b/test/lish/force_does_not_publish_if_there_are_errors_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/force_publishes_if_tests_are_no_warnings_or_errors_test.dart
+++ b/test/lish/force_publishes_if_tests_are_no_warnings_or_errors_test.dart
@@ -6,10 +6,9 @@
 
 import 'dart:convert';
 
+import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
-
-import 'package:pub/src/exit_codes.dart' as exit_codes;
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/force_publishes_if_there_are_warnings_test.dart
+++ b/test/lish/force_publishes_if_there_are_warnings_test.dart
@@ -6,10 +6,9 @@
 
 import 'dart:convert';
 
+import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
-
-import 'package:pub/src/exit_codes.dart' as exit_codes;
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/many_files_test.dart
+++ b/test/lish/many_files_test.dart
@@ -9,10 +9,9 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:path/path.dart' as p;
+import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
-
-import 'package:pub/src/exit_codes.dart' as exit_codes;
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/package_validation_has_a_warning_and_continues_test.dart
+++ b/test/lish/package_validation_has_a_warning_and_continues_test.dart
@@ -6,10 +6,9 @@
 
 import 'dart:convert';
 
+import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
-
-import 'package:pub/src/exit_codes.dart' as exit_codes;
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/package_validation_has_a_warning_and_is_canceled_test.dart
+++ b/test/lish/package_validation_has_a_warning_and_is_canceled_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/package_validation_has_an_error_test.dart
+++ b/test/lish/package_validation_has_an_error_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/preview_errors_if_private_test.dart
+++ b/test/lish/preview_errors_if_private_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/preview_package_validation_has_a_warning_test.dart
+++ b/test/lish/preview_package_validation_has_a_warning_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/preview_package_validation_has_no_warnings_test.dart
+++ b/test/lish/preview_package_validation_has_no_warnings_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/server_arg_does_not_override_private_test.dart
+++ b/test/lish/server_arg_does_not_override_private_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/server_arg_overrides_publish_to_url_test.dart
+++ b/test/lish/server_arg_overrides_publish_to_url_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/lish/uses_publish_to_url_test.dart
+++ b/test/lish/uses_publish_to_url_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/list_package_dirs/ignores_updated_pubspec_test.dart
+++ b/test/list_package_dirs/ignores_updated_pubspec_test.dart
@@ -4,10 +4,10 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
 import 'package:pub/src/io.dart';
+
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/list_package_dirs/includes_dev_dependencies_test.dart
+++ b/test/list_package_dirs/includes_dev_dependencies_test.dart
@@ -4,10 +4,10 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
 import 'package:pub/src/io.dart';
+
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/list_package_dirs/lists_dependency_directories_test.dart
+++ b/test/list_package_dirs/lists_dependency_directories_test.dart
@@ -4,10 +4,10 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
 import 'package:pub/src/io.dart';
+
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/list_package_dirs/lockfile_error_test.dart
+++ b/test/list_package_dirs/lockfile_error_test.dart
@@ -5,10 +5,9 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/list_package_dirs/missing_pubspec_test.dart
+++ b/test/list_package_dirs/missing_pubspec_test.dart
@@ -5,10 +5,9 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/list_package_dirs/no_lockfile_test.dart
+++ b/test/list_package_dirs/no_lockfile_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/list_package_dirs/pubspec_error_test.dart
+++ b/test/list_package_dirs/pubspec_error_test.dart
@@ -5,10 +5,9 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/must_pub_get_test.dart
+++ b/test/must_pub_get_test.dart
@@ -9,10 +9,9 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import 'descriptor.dart' as d;
 import 'test_pub.dart';

--- a/test/oauth2/utils.dart
+++ b/test/oauth2/utils.dart
@@ -8,11 +8,10 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:pub/src/utils.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
-
-import 'package:pub/src/utils.dart';
 
 import '../test_pub.dart';
 

--- a/test/package_config_file_test.dart
+++ b/test/package_config_file_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import 'package:test/test.dart';
 
 import 'descriptor.dart' as d;
 import 'test_pub.dart';

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -7,11 +7,10 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:pub/src/exceptions.dart';
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
+import 'package:pub/src/exceptions.dart';
 import 'package:pub/src/system_cache.dart';
+import 'package:test/test.dart';
 
 import 'descriptor.dart' as d;
 import 'test_pub.dart';

--- a/test/packages_file_test.dart
+++ b/test/packages_file_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import 'package:test/test.dart';
 
 import 'descriptor.dart' as d;
 import 'test_pub.dart';

--- a/test/pub_get_and_upgrade_test.dart
+++ b/test/pub_get_and_upgrade_test.dart
@@ -4,9 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+
+import 'package:test/test.dart';
 
 import 'descriptor.dart' as d;
 import 'test_pub.dart';

--- a/test/rate_limited_scheduler_test.dart
+++ b/test/rate_limited_scheduler_test.dart
@@ -6,9 +6,9 @@
 
 import 'dart:async';
 
-import 'package:test/test.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:pub/src/rate_limited_scheduler.dart';
+import 'package:test/test.dart';
 
 void main() {
   Map<String, Completer> threeCompleters() =>

--- a/test/real_version_test.dart
+++ b/test/real_version_test.dart
@@ -7,11 +7,10 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-import 'package:test_process/test_process.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/sdk.dart';
+import 'package:test/test.dart';
+import 'package:test_process/test_process.dart';
 
 void main() {
   // This test is a bit funny.

--- a/test/run/dartdev/errors_if_only_transitive_dependency_test.dart
+++ b/test/run/dartdev/errors_if_only_transitive_dependency_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/run/dartdev/errors_if_path_in_dependency_test.dart
+++ b/test/run/dartdev/errors_if_path_in_dependency_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/run/dartdev/nonexistent_dependency_test.dart
+++ b/test/run/dartdev/nonexistent_dependency_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/run/dartdev/nonexistent_script_in_dependency_test.dart
+++ b/test/run/dartdev/nonexistent_script_in_dependency_test.dart
@@ -4,10 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/run/errors_if_no_executable_is_given_test.dart
+++ b/test/run/errors_if_no_executable_is_given_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/run/errors_if_only_transitive_dependency_test.dart
+++ b/test/run/errors_if_only_transitive_dependency_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/run/errors_if_path_in_dependency_test.dart
+++ b/test/run/errors_if_path_in_dependency_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/run/forwards_signal_posix_test.dart
+++ b/test/run/forwards_signal_posix_test.dart
@@ -5,11 +5,11 @@
 // @dart=2.10
 
 // Windows doesn't support sending signals.
-@TestOn('!windows')
 // TODO(sigurdm): Test this when vm-args are provided.
 // This test doesn't work when we subprocess instead of an isolate
 // in `pub run`. Now signals only work as expected when sent to the process
 // group. And this seems hard to emulate in a test.
+@TestOn('!windows')
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/test/run/includes_parent_directories_of_entrypoint_test.dart
+++ b/test/run/includes_parent_directories_of_entrypoint_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/run/nonexistent_dependency_test.dart
+++ b/test/run/nonexistent_dependency_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/run/nonexistent_script_in_dependency_test.dart
+++ b/test/run/nonexistent_script_in_dependency_test.dart
@@ -4,10 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/run/nonexistent_script_test.dart
+++ b/test/run/nonexistent_script_test.dart
@@ -4,10 +4,9 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/run/runs_app_in_directory_in_entrypoint_test.dart
+++ b/test/run/runs_app_in_directory_in_entrypoint_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/sdk_test.dart
+++ b/test/sdk_test.dart
@@ -5,11 +5,9 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as p;
-
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import 'descriptor.dart' as d;
 import 'test_pub.dart';

--- a/test/upgrade/dry_run_does_not_apply_changes_test.dart
+++ b/test/upgrade/dry_run_does_not_apply_changes_test.dart
@@ -5,9 +5,8 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/io.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/upgrade/git/do_not_upgrade_if_unneeded_test.dart
+++ b/test/upgrade/git/do_not_upgrade_if_unneeded_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
+
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 

--- a/test/upgrade/git/do_not_upgrade_if_unneeded_test.dart
+++ b/test/upgrade/git/do_not_upgrade_if_unneeded_test.dart
@@ -3,9 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
-
-import 'package:test/test.dart';
 import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/upgrade/git/upgrade_to_incompatible_pubspec_test.dart
+++ b/test/upgrade/git/upgrade_to_incompatible_pubspec_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';

--- a/test/validator/changelog_test.dart
+++ b/test/validator/changelog_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
+
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/changelog.dart';

--- a/test/validator/changelog_test.dart
+++ b/test/validator/changelog_test.dart
@@ -3,12 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
-
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/changelog.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/compiled_dartdoc_test.dart
+++ b/test/validator/compiled_dartdoc_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
+
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/compiled_dartdoc.dart';

--- a/test/validator/compiled_dartdoc_test.dart
+++ b/test/validator/compiled_dartdoc_test.dart
@@ -3,12 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
-
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/compiled_dartdoc.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/dependency_override_test.dart
+++ b/test/validator/dependency_override_test.dart
@@ -3,12 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
-
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/dependency_override.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/dependency_override_test.dart
+++ b/test/validator/dependency_override_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
+
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/dependency_override.dart';

--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -10,11 +10,10 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/dependency.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/deprecated_fields_test.dart
+++ b/test/validator/deprecated_fields_test.dart
@@ -3,12 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
-
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/deprecated_fields.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/deprecated_fields_test.dart
+++ b/test/validator/deprecated_fields_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
+
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/deprecated_fields.dart';

--- a/test/validator/directory_test.dart
+++ b/test/validator/directory_test.dart
@@ -3,12 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
-
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/directory.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/directory_test.dart
+++ b/test/validator/directory_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
+
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/directory.dart';

--- a/test/validator/executable_test.dart
+++ b/test/validator/executable_test.dart
@@ -3,12 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
-
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/executable.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/executable_test.dart
+++ b/test/validator/executable_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
+
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/executable.dart';

--- a/test/validator/flutter_plugin_format_test.dart
+++ b/test/validator/flutter_plugin_format_test.dart
@@ -4,11 +4,10 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/flutter_plugin_format.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/language_version_test.dart
+++ b/test/validator/language_version_test.dart
@@ -4,11 +4,10 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/language_version.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/license_test.dart
+++ b/test/validator/license_test.dart
@@ -5,12 +5,11 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/io.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/license.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/name_test.dart
+++ b/test/validator/name_test.dart
@@ -5,12 +5,11 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/io.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/name.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/pubspec_field_test.dart
+++ b/test/validator/pubspec_field_test.dart
@@ -4,11 +4,10 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/pubspec_field.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/pubspec_test.dart
+++ b/test/validator/pubspec_test.dart
@@ -4,9 +4,8 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/validator/pubspec.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/pubspec_typo_test.dart
+++ b/test/validator/pubspec_typo_test.dart
@@ -3,12 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
-
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/pubspec_typo.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/pubspec_typo_test.dart
+++ b/test/validator/pubspec_typo_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // @dart=2.10
+
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/pubspec_typo.dart';

--- a/test/validator/readme_test.dart
+++ b/test/validator/readme_test.dart
@@ -4,13 +4,12 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
 import 'package:path/path.dart' as p;
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/io.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/readme.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/relative_version_numbering_test.dart
+++ b/test/validator/relative_version_numbering_test.dart
@@ -4,11 +4,10 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/relative_version_numbering.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/sdk_constraint_test.dart
+++ b/test/validator/sdk_constraint_test.dart
@@ -4,11 +4,10 @@
 
 // @dart=2.10
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/sdk_constraint.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/size_test.dart
+++ b/test/validator/size_test.dart
@@ -7,9 +7,8 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:test/test.dart';
-
 import 'package:pub/src/validator/size.dart';
+import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
 import '../test_pub.dart';

--- a/test/validator/strict_dependencies_test.dart
+++ b/test/validator/strict_dependencies_test.dart
@@ -5,11 +5,11 @@
 // @dart=2.10
 
 import 'package:path/path.dart' as path;
-import 'package:test/test.dart';
-
 import 'package:pub/src/entrypoint.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/strict_dependencies.dart';
+import 'package:test/test.dart';
+
 import '../descriptor.dart' as d;
 import '../test_pub.dart';
 import 'utils.dart';

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -8,12 +8,11 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:test/test.dart';
-
 import 'package:pub/src/lock_file.dart';
 import 'package:pub/src/pubspec.dart';
 import 'package:pub/src/source/hosted.dart';
 import 'package:pub/src/source_registry.dart';
+import 'package:test/test.dart';
 
 import 'descriptor.dart' as d;
 import 'test_pub.dart';


### PR DESCRIPTION
- fail CI on info level issues (dart analyze --fatal-infos)
- fix directives sorting (these were ~100 instances of this issue in the repo)
- fix a few `@TestOn` locations - this test annotation needs to be declared before any directives

