### PR TITLE
Remove duplicate global invocation on Windows

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -750,7 +750,7 @@ To recompile executables, first run `global deactivate ${dep.name}`.
         assert(p.isAbsolute(snapshot));
         invocation = '''
 if exist "$snapshot" (
-  dart "$snapshot" %*
+  call dart "$snapshot" %*
   rem The VM exits with code 253 if the snapshot version is out-of-date.
   rem If it is, we need to delete it and run "pub global" manually.
   if not errorlevel 253 (

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -756,6 +756,7 @@ if exist "$snapshot" (
   if not errorlevel 253 (
     goto error
   )
+  dart pub global run ${package.name}:$script %*
 ) else (
   dart pub global run ${package.name}:$script %*
 )

--- a/test/global/binstubs/binstub_runs_executable_test.dart
+++ b/test/global/binstubs/binstub_runs_executable_test.dart
@@ -31,6 +31,7 @@ void main() {
         environment: getEnvironment());
 
     expect(process.stdout, emits('ok [arg1, arg2]'));
+    expect(process.stdout, neverEmits('ok [arg1, arg2]'));
     await process.shouldExit();
   });
 

--- a/test/global/binstubs/runs_once_even_when_dart_is_batch_test.dart
+++ b/test/global/binstubs/runs_once_even_when_dart_is_batch_test.dart
@@ -1,0 +1,55 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// @dart=2.10
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test(
+      'runs only once even when dart on path is a batch file (as in flutter/bin)',
+      () async {
+    await servePackages((builder) {
+      builder.serve(
+        'foo',
+        '1.0.0',
+        contents: [
+          d.dir('bin', [d.file('script.dart', 'main(args) => print(args);')]),
+        ],
+        pubspec: {
+          'executables': {'script': 'script'},
+        },
+      );
+    });
+
+    await runPub(args: ['global', 'activate', 'foo']);
+
+    await d.dir(
+      'bin',
+      [
+        d.file('dart.bat', '''
+@echo off
+${Platform.resolvedExecutable} %*
+'''),
+      ],
+    ).create();
+
+    var process =
+        await Process.run(p.join(d.sandbox, cachePath, 'bin', 'script.bat'), [
+      'hi'
+    ], environment: {
+      'PATH': [p.join(d.sandbox, 'bin'), p.dirname(Platform.resolvedExecutable)]
+          .join(';'),
+      ...getPubTestEnvironment(),
+    });
+    expect((process.stdout as String).trim(), '[hi]');
+    expect(process.exitCode, 0);
+  }, skip: !Platform.isWindows);
+}


### PR DESCRIPTION
~~In the Batch file defined in `_createBinStub`, the script attempts to call the package using the dart snapshot. If it fails, the Batch script uses `dart pub global` directly. However, the `dart pub global` command is still present even when using the snapshot works. This PR removes the second call so that package is only run once. This is especially important/urgent because a lot of executable packages focus on project management, and make sensitive changes to the files in a user's project. Having those changes run twice can cause errant behavior.~~

**EDIT**: Adding a `call` before the dart command in the generated binstub fixes an error where, if the user has `flutter\bin\dart.bat` ahead of `flutter\bin\cache\dart-sdk\bin\dart.exe` in their PATH, the script gets called twice. I tried tracking down the cause but couldn't. All I know is that _something_ happens in flutter's `dart.bat` that _really_ messes with the binstub, and won't even let the simple `goto error` statement run properly. Using `call` fixes that... somehow.

Fixes #2934 