### PR TITLE
Fix a typo

### DIFF
--- a/lib/src/command/run.dart
+++ b/lib/src/command/run.dart
@@ -55,7 +55,7 @@ class RunCommand extends PubCommand {
   Future<void> runProtected() async {
     if (deprecated) {
       await log.warningsOnlyUnlessTerminal(() {
-        log.message('Deprecated. Use `dart run instead`');
+        log.message('Deprecated. Use `dart run` instead.');
       });
     }
     if (argResults['dart-dev-run']) {


### PR DESCRIPTION
I believe "instead" should be outside of the quotation.

> Use `dart run instead`
> Use `dart run` instead.