### PR TITLE
Always precompile scripts before running them

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -300,7 +300,7 @@ class Entrypoint {
   ///
   /// Except globally activated packages they should precompile executables from
   /// the package itself if they are immutable.
-  List<Executable> get builtExecutables {
+  List<Executable> get _builtExecutables {
     if (isGlobal) {
       if (isCached) {
         return root.executablePaths
@@ -311,9 +311,6 @@ class Entrypoint {
       }
     }
     final r = root.immediateDependencies.keys.expand((packageName) {
-      if (packageGraph.isPackageMutable(packageName)) {
-        return <Executable>[];
-      }
       final package = packageGraph.packages[packageName];
       return package.executablePaths
           .map((path) => Executable(packageName, path));
@@ -321,11 +318,11 @@ class Entrypoint {
     return r;
   }
 
-  /// Precompiles all [builtExecutables].
+  /// Precompiles all [_builtExecutables].
   Future<void> precompileExecutables({Iterable<String> changed}) async {
     migrateCache();
 
-    final executables = builtExecutables;
+    final executables = _builtExecutables;
 
     if (executables.isEmpty) return;
 

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -80,8 +80,7 @@ Future<int> runExecutable(
   // Also we don't snapshot if we have non-default arguments to the VM, as
   // these would be inconsistent if another set of settings are given in a
   // later invocation.
-  var useSnapshot =
-      !entrypoint.packageGraph.isPackageMutable(package) && vmArgs.isEmpty;
+  var useSnapshot = vmArgs.isEmpty;
 
   var executablePath = entrypoint.resolveExecutable(executable);
   if (!fileExists(executablePath)) {
@@ -99,7 +98,7 @@ Future<int> runExecutable(
     // automatically.
     entrypoint.assertUpToDate();
 
-    if (!fileExists(snapshotPath)) {
+    if (!fileExists(snapshotPath) || entrypoint.packageGraph.isPackageMutable(package)) {
       await recompile(executable);
     }
     executablePath = snapshotPath;
@@ -324,11 +323,11 @@ Future<String> getExecutableForCommand(
       throw CommandResolutionFailedException(
           'Could not find `bin${p.separator}$command.dart` in package `$package`.');
     }
-    if (!allowSnapshot || entrypoint.packageGraph.isPackageMutable(package)) {
+    if (!allowSnapshot) {
       return p.relative(path, from: root);
     } else {
       final snapshotPath = entrypoint.pathOfExecutable(executable);
-      if (!fileExists(snapshotPath)) {
+      if (!fileExists(snapshotPath) || entrypoint.packageGraph.isPackageMutable(package)) {
         await warningsOnlyUnlessTerminal(
           () => entrypoint.precompileExecutable(executable),
         );

--- a/test/embedding/get_executable_for_command_test.dart
+++ b/test/embedding/get_executable_for_command_test.dart
@@ -148,11 +148,11 @@ Future<void> main() async {
     ]).create();
     final dir = d.path(appPath);
 
-    await testGetExecutable('myapp', dir, result: 'bin${separator}myapp.dart');
+    await testGetExecutable('myapp', dir, result: p.join('.dart_tool', 'pub', 'bin', 'myapp', 'myapp.dart-$_currentVersion.snapshot'));
     await testGetExecutable('myapp:myapp', dir,
-        result: 'bin${separator}myapp.dart');
-    await testGetExecutable(':myapp', dir, result: 'bin${separator}myapp.dart');
-    await testGetExecutable(':tool', dir, result: 'bin${separator}tool.dart');
+        result: p.join('.dart_tool', 'pub', 'bin', 'myapp', 'myapp.dart-$_currentVersion.snapshot'));
+    await testGetExecutable(':myapp', dir, result: p.join('.dart_tool', 'pub', 'bin', 'myapp', 'myapp.dart-$_currentVersion.snapshot'));
+    await testGetExecutable(':tool', dir, result: p.join('.dart_tool', 'pub', 'bin', 'myapp', 'tool.dart-$_currentVersion.snapshot'));
     await testGetExecutable('foo', dir,
         allowSnapshot: false,
         result: endsWith('foo-1.0.0${separator}bin${separator}foo.dart'));

--- a/test/global/activate/activate_path_after_hosted_test.dart
+++ b/test/global/activate/activate_path_after_hosted_test.dart
@@ -36,7 +36,7 @@ void main() {
 
     // Should now run the path one.
     var pub = await pubRun(global: true, args: ['foo']);
-    expect(pub.stdout, emits('path'));
+    expect(pub.stdout, emitsThrough('path'));
     await pub.shouldExit();
   });
 }

--- a/test/global/activate/path_package_test.dart
+++ b/test/global/activate/path_package_test.dart
@@ -52,7 +52,7 @@ void main() {
 
     await runPub(
         args: ['global', 'run', 'foo'],
-        output: 'ok',
+        output: endsWith('ok'),
         workingDirectory: p.current);
   });
 

--- a/test/global/run/package_api_test.dart
+++ b/test/global/run/package_api_test.dart
@@ -39,7 +39,7 @@ main() async {
 
     var pub = await pubRun(global: true, args: ['foo:script']);
 
-    expect(pub.stdout, emits('null'));
+    expect(pub.stdout, emitsThrough('null'));
 
     var packageConfigPath = p.join(d.sandbox, cachePath,
         'global_packages/foo/.dart_tool/package_config.json');
@@ -83,7 +83,7 @@ main() async {
 
     var pub = await pubRun(global: true, args: ['myapp:script']);
 
-    expect(pub.stdout, emits('null'));
+    expect(pub.stdout, emitsThrough('null'));
 
     var packageConfigPath =
         p.join(d.sandbox, 'myapp/.dart_tool/package_config.json');

--- a/test/global/run/reflects_changes_to_local_package_test.dart
+++ b/test/global/run/reflects_changes_to_local_package_test.dart
@@ -21,7 +21,7 @@ void main() {
     await d.file('foo/bin/foo.dart', "main() => print('changed');").create();
 
     var pub = await pubRun(global: true, args: ['foo']);
-    expect(pub.stdout, emits('changed'));
+    expect(pub.stdout, emitsThrough('changed'));
     await pub.shouldExit();
   });
 }

--- a/test/global/run/runs_path_script_test.dart
+++ b/test/global/run/runs_path_script_test.dart
@@ -19,7 +19,7 @@ void main() {
     await runPub(args: ['global', 'activate', '--source', 'path', '../foo']);
 
     var pub = await pubRun(global: true, args: ['foo']);
-    expect(pub.stdout, emits('ok'));
+    expect(pub.stdout, emitsThrough('ok'));
     await pub.shouldExit();
   });
 }

--- a/test/global/run/runs_script_without_packages_file_test.dart
+++ b/test/global/run/runs_script_without_packages_file_test.dart
@@ -28,7 +28,7 @@ void main() {
         'global_packages/foo/.dart_tool/package_config.json'));
 
     var pub = await pubRun(global: true, args: ['foo:script']);
-    expect(pub.stdout, emits('ok'));
+    expect(pub.stdout, emitsThrough('ok'));
     await pub.shouldExit();
   });
 
@@ -46,7 +46,7 @@ void main() {
         'global_packages/foo/.dart_tool/package_config.json'));
 
     var pub = await pubRun(global: true, args: ['foo']);
-    expect(pub.stdout, emits('ok'));
+    expect(pub.stdout, emitsThrough('ok'));
     await pub.shouldExit();
   });
 }

--- a/test/goldens/directory_option.txt
+++ b/test/goldens/directory_option.txt
@@ -52,6 +52,8 @@ Resolving dependencies...
 No dependencies changed in myapp.
 
 $ pub run -C myapp bin/app.dart
+Building package executable...
+Built test_pkg:app.
 Hi
 
 $ pub publish -C myapp --dry-run

--- a/test/must_pub_get_test.dart
+++ b/test/must_pub_get_test.dart
@@ -56,7 +56,7 @@ void main() {
     });
     writeTextFile(packageConfig, json.encode(contents));
 
-    await runPub(args: ['run', 'bin/script.dart'], output: 'hello!');
+    await runPub(args: ['run', 'bin/script.dart'], output: endsWith('hello!'));
   });
   group('requires the user to run pub get first if', () {
     group("there's no lockfile", () {

--- a/test/run/allows_dart_extension_test.dart
+++ b/test/run/allows_dart_extension_test.dart
@@ -28,8 +28,8 @@ void main() {
 
     await pubGet();
     var pub = await pubRun(args: ['script.dart']);
-    expect(pub.stdout, emits('stdout output'));
-    expect(pub.stderr, emits('stderr output'));
+    expect(pub.stdout, emitsThrough('stdout output'));
+    expect(pub.stderr, emitsThrough('stderr output'));
     await pub.shouldExit(123);
   });
 }

--- a/test/run/app_can_read_from_stdin_test.dart
+++ b/test/run/app_can_read_from_stdin_test.dart
@@ -32,7 +32,7 @@ void main() {
     await pubGet();
     var pub = await pubRun(args: ['bin/script']);
 
-    await expectLater(pub.stdout, emits('started'));
+    await expectLater(pub.stdout, emitsThrough('started'));
     pub.stdin.writeln('first');
     await expectLater(pub.stdout, emits('between'));
     pub.stdin.writeln('second');
@@ -59,7 +59,7 @@ void main() {
     await pubGet();
     var pub = await pubRun(args: ['bin/script']);
 
-    await expectLater(pub.stdout, emits('started'));
+    await expectLater(pub.stdout, emitsThrough('started'));
     pub.stdin.writeln('first');
     await expectLater(pub.stdout, emits('first'));
     pub.stdin.writeln('second');

--- a/test/run/dartdev/app_can_read_from_stdin_test.dart
+++ b/test/run/dartdev/app_can_read_from_stdin_test.dart
@@ -32,7 +32,7 @@ void main() {
     await pubGet();
     var pub = await pubRunFromDartDev(args: ['myapp:script']);
 
-    await expectLater(pub.stdout, emits('started'));
+    await expectLater(pub.stdout, emitsThrough('started'));
     pub.stdin.writeln('first');
     await expectLater(pub.stdout, emits('between'));
     pub.stdin.writeln('second');
@@ -59,7 +59,7 @@ void main() {
     await pubGet();
     var pub = await pubRunFromDartDev(args: ['myapp:script']);
 
-    await expectLater(pub.stdout, emits('started'));
+    await expectLater(pub.stdout, emitsThrough('started'));
     pub.stdin.writeln('first');
     await expectLater(pub.stdout, emits('first'));
     pub.stdin.writeln('second');

--- a/test/run/dartdev/forwards_signal_posix_test.dart
+++ b/test/run/dartdev/forwards_signal_posix_test.dart
@@ -45,7 +45,7 @@ void main() {
     await pubGet();
     var pub = await pubRunFromDartDev(args: ['myapp:script']);
 
-    await expectLater(pub.stdout, emits('ready'));
+    await expectLater(pub.stdout, emitsThrough('ready'));
     for (var signal in _catchableSignals) {
       pub.signal(signal);
       await expectLater(pub.stdout, emits(signal.toString()));

--- a/test/run/dartdev/loads_package_imports_in_a_dependency_test.dart
+++ b/test/run/dartdev/loads_package_imports_in_a_dependency_test.dart
@@ -31,7 +31,7 @@ main() => print(value);
 
     await pubGet();
     var pub = await pubRunFromDartDev(args: ['foo:bar']);
-    expect(pub.stdout, emits('foobar'));
+    expect(pub.stdout, emitsThrough('foobar'));
     await pub.shouldExit();
   });
 }

--- a/test/run/dartdev/package_api_test.dart
+++ b/test/run/dartdev/package_api_test.dart
@@ -37,7 +37,7 @@ void main() {
     await pubGet();
     var pub = await pubRunFromDartDev(args: ['myapp:script']);
 
-    expect(pub.stdout, emits('null'));
+    expect(pub.stdout, emitsThrough('null'));
     expect(
         pub.stdout,
         emits(p

--- a/test/run/dartdev/passes_along_arguments_test.dart
+++ b/test/run/dartdev/passes_along_arguments_test.dart
@@ -29,7 +29,7 @@ void main() {
     var pub = await pubRunFromDartDev(
         args: ['myapp:args', '--verbose', '-m', '--', 'help']);
 
-    expect(pub.stdout, emits('--verbose -m -- help'));
+    expect(pub.stdout, emitsThrough('--verbose -m -- help'));
     await pub.shouldExit();
   });
 }

--- a/test/run/dartdev/runs_from_a_dependency_override_after_dependency_test.dart
+++ b/test/run/dartdev/runs_from_a_dependency_override_after_dependency_test.dart
@@ -28,7 +28,7 @@ void main() {
     await pubGet(args: ['--precompile']);
 
     var pub = await pubRunFromDartDev(args: ['foo:bar']);
-    expect(pub.stdout, emits('foobar'));
+    expect(pub.stdout, emitsThrough('foobar'));
     await pub.shouldExit();
 
     await d.dir('foo', [
@@ -48,7 +48,7 @@ void main() {
     await pubGet();
 
     pub = await pubRunFromDartDev(args: ['foo:bar']);
-    expect(pub.stdout, emits('different'));
+    expect(pub.stdout, emitsThrough('different'));
     await pub.shouldExit();
   });
 }

--- a/test/run/dartdev/runs_named_app_in_dependency_test.dart
+++ b/test/run/dartdev/runs_named_app_in_dependency_test.dart
@@ -24,7 +24,7 @@ void main() {
 
     await pubGet();
     var pub = await pubRunFromDartDev(args: ['foo:bar']);
-    expect(pub.stdout, emits('foobar'));
+    expect(pub.stdout, emitsThrough('foobar'));
     await pub.shouldExit();
   });
 }

--- a/test/run/dartdev/runs_named_app_in_dev_dependency_test.dart
+++ b/test/run/dartdev/runs_named_app_in_dev_dependency_test.dart
@@ -27,7 +27,7 @@ void main() {
 
     await pubGet();
     var pub = await pubRunFromDartDev(args: ['foo:bar']);
-    expect(pub.stdout, emits('foobar'));
+    expect(pub.stdout, emitsThrough('foobar'));
     await pub.shouldExit();
   });
 }

--- a/test/run/dartdev/runs_shorthand_app_in_dependency_test.dart
+++ b/test/run/dartdev/runs_shorthand_app_in_dependency_test.dart
@@ -27,7 +27,7 @@ void main() {
 
     await pubGet();
     var pub = await pubRunFromDartDev(args: ['foo']);
-    expect(pub.stdout, emits('foo'));
+    expect(pub.stdout, emitsThrough('foo'));
     await pub.shouldExit();
   });
 }

--- a/test/run/forwards_signal_posix_test.dart
+++ b/test/run/forwards_signal_posix_test.dart
@@ -49,7 +49,7 @@ void main() {
     await pubGet();
     var pub = await pubRun(args: ['bin/script']);
 
-    await expectLater(pub.stdout, emits('ready'));
+    await expectLater(pub.stdout, emitsThrough('ready'));
     for (var signal in _catchableSignals) {
       pub.signal(signal);
       await expectLater(pub.stdout, emits(signal.toString()));

--- a/test/run/includes_parent_directories_of_entrypoint_test.dart
+++ b/test/run/includes_parent_directories_of_entrypoint_test.dart
@@ -35,7 +35,7 @@ void main() {
 
     await pubGet();
     var pub = await pubRun(args: [path.join('tool', 'a', 'b', 'app')]);
-    expect(pub.stdout, emits('a b'));
+    expect(pub.stdout, emitsThrough('a b'));
     await pub.shouldExit();
   });
 }

--- a/test/run/loads_package_imports_in_a_dependency_test.dart
+++ b/test/run/loads_package_imports_in_a_dependency_test.dart
@@ -31,7 +31,7 @@ main() => print(value);
 
     await pubGet();
     var pub = await pubRun(args: ['foo:bar']);
-    expect(pub.stdout, emits('foobar'));
+    expect(pub.stdout, emitsThrough('foobar'));
     await pub.shouldExit();
   });
 }

--- a/test/run/package_api_test.dart
+++ b/test/run/package_api_test.dart
@@ -37,7 +37,7 @@ void main() {
     await pubGet();
     var pub = await pubRun(args: ['bin/script']);
 
-    expect(pub.stdout, emits('null'));
+    expect(pub.stdout, emitsThrough('null'));
     expect(
         pub.stdout,
         emits(p
@@ -65,7 +65,7 @@ void main() {
 
     var pub = await pubRun(args: ['foo:script']);
 
-    expect(pub.stdout, emits('Building package executable...'));
+    expect(pub.stdout, emitsThrough('Building package executable...'));
     expect(pub.stdout, emits('Built foo:script.'));
     expect(pub.stdout, emits('null'));
     expect(

--- a/test/run/passes_along_arguments_test.dart
+++ b/test/run/passes_along_arguments_test.dart
@@ -28,7 +28,7 @@ void main() {
     // isn't trying to look at them.
     var pub = await pubRun(args: ['bin/args', '--verbose', '-m', '--', 'help']);
 
-    expect(pub.stdout, emits('--verbose -m -- help'));
+    expect(pub.stdout, emitsThrough('--verbose -m -- help'));
     await pub.shouldExit();
   });
 }

--- a/test/run/runs_app_in_directory_in_entrypoint_test.dart
+++ b/test/run/runs_app_in_directory_in_entrypoint_test.dart
@@ -22,11 +22,11 @@ void main() {
 
     await pubGet();
     var pub = await pubRun(args: [path.join('tool', 'app')]);
-    expect(pub.stdout, emits('tool'));
+    expect(pub.stdout, emitsThrough('tool'));
     await pub.shouldExit();
 
     pub = await pubRun(args: [path.join('tool', 'sub', 'app')]);
-    expect(pub.stdout, emits('sub'));
+    expect(pub.stdout, emitsThrough('sub'));
     await pub.shouldExit();
   });
 }

--- a/test/run/runs_app_in_entrypoint_test.dart
+++ b/test/run/runs_app_in_entrypoint_test.dart
@@ -28,7 +28,7 @@ void main() {
 
     await pubGet();
     var pub = await pubRun(args: ['bin/script']);
-    expect(pub.stdout, emits('stdout output'));
+    expect(pub.stdout, emitsThrough('stdout output'));
     expect(pub.stderr, emits('stderr output'));
     await pub.shouldExit(123);
   });

--- a/test/run/runs_from_a_dependency_override_after_dependency_test.dart
+++ b/test/run/runs_from_a_dependency_override_after_dependency_test.dart
@@ -28,7 +28,7 @@ void main() {
     await pubGet(args: ['--precompile']);
 
     var pub = await pubRun(args: ['foo:bar']);
-    expect(pub.stdout, emits('foobar'));
+    expect(pub.stdout, emitsThrough('foobar'));
     await pub.shouldExit();
 
     await d.dir('foo', [
@@ -48,7 +48,7 @@ void main() {
     await pubGet();
 
     pub = await pubRun(args: ['foo:bar']);
-    expect(pub.stdout, emits('different'));
+    expect(pub.stdout, emitsThrough('different'));
     await pub.shouldExit();
   });
 }

--- a/test/run/runs_named_app_in_dependency_test.dart
+++ b/test/run/runs_named_app_in_dependency_test.dart
@@ -24,7 +24,7 @@ void main() {
 
     await pubGet();
     var pub = await pubRun(args: ['foo:bar']);
-    expect(pub.stdout, emits('foobar'));
+    expect(pub.stdout, emitsThrough('foobar'));
     await pub.shouldExit();
   });
 }

--- a/test/run/runs_named_app_in_dev_dependency_test.dart
+++ b/test/run/runs_named_app_in_dev_dependency_test.dart
@@ -27,7 +27,7 @@ void main() {
 
     await pubGet();
     var pub = await pubRun(args: ['foo:bar']);
-    expect(pub.stdout, emits('foobar'));
+    expect(pub.stdout, emitsThrough('foobar'));
     await pub.shouldExit();
   });
 }

--- a/test/run/runs_shorthand_app_in_dependency_test.dart
+++ b/test/run/runs_shorthand_app_in_dependency_test.dart
@@ -27,7 +27,7 @@ void main() {
 
     await pubGet();
     var pub = await pubRun(args: ['foo']);
-    expect(pub.stdout, emits('foo'));
+    expect(pub.stdout, emitsThrough('foo'));
     await pub.shouldExit();
   });
 }


### PR DESCRIPTION
Closes https://github.com/dart-lang/pub/issues/3073

The idea is that since we have incremental compilation, its worth actually compiling the scripts and running that compiled script. For mutable packages we still always re-compile before each run, but it will be much faster to do so, as each build will be incremental.

This makes running pub executables from source much faster, and it also means you will get some more immediate feedback (the `Building package executable...` message). Previously it was just a blank screen for several seconds (depending on size of the app).

Note that this does mean we will always emit some log messages about building scripts for each run. This could break some scripts that rely on the stdout of pub executables. This was always the case for the first run of an immutable package ran with `pub run`, but would come up more often now. We could consider moving that output to `stderr`, or suppressing it, but I do think it is actually nice, when running interactively.