### PR TITLE
Fix broken simplification of prerelease constraints

### DIFF
--- a/lib/src/package_name.dart
+++ b/lib/src/package_name.dart
@@ -268,8 +268,7 @@ class PackageRange extends PackageName {
     if (!range.includeMin) return this;
     if (range.includeMax) return this;
     if (range.min == null) return this;
-    if (range.max == range.min.nextBreaking.firstPreRelease ||
-        (range.min.isPreRelease && range.max == range.min.nextBreaking)) {
+    if (range.max == range.min.nextBreaking.firstPreRelease) {
       return withConstraint(VersionConstraint.compatibleWith(range.min));
     } else {
       return this;


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub/issues/3057
Fixes: https://github.com/dart-lang/pub/pull/3038
Fixes: https://github.com/dart-lang/pub/issues/3028

I am not sure what was exactly meant by having the case `(range.min.isPreRelease && range.max == range.min.nextBreaking)` but it seems not. quite right. 

`>=0.9.0-1 < 0.10.0` would get translated to `^0.9.0-1`. But `^0.9.0-1` in pub_semver is the same as `>=0.9.0-1 < 0.10.0-0`, and that is what gets captured by the first part of the condition: `range.max == range.min.nextBreaking.firstPreRelease`.
