### PR TITLE
Expose the pub top-level as a command

### DIFF
--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -5,6 +5,7 @@
 // @dart=2.10
 
 import 'package:args/command_runner.dart';
+import 'src/command_runner.dart';
 import 'src/pub_embeddable_command.dart';
 export 'src/executable.dart'
     show getExecutableForCommand, CommandResolutionFailedException;
@@ -12,3 +13,7 @@ export 'src/executable.dart'
 /// Returns a [Command] for pub functionality that can be used by an embedding
 /// CommandRunner.
 Command<int> pubCommand() => PubEmbeddableCommand();
+
+/// Support for the `pub` toplevel command.
+@Deprecated('Use [pubCommand] instead.')
+CommandRunner<int> deprecatedpubCommand() => PubCommandRunner();


### PR DESCRIPTION
This will allow the dart command to expose the exact command - which can then be forwarded to by the `pub` script in the sdk removing the need for a separate snapshot.