### PR TITLE
Tweak strict dependencies error message for `_validateBenchmarkTestTool`

### DIFF
--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -102,7 +102,7 @@ class StrictDependenciesValidator extends Validator {
     var directories = ['benchmark', 'test', 'tool'];
     for (var usage in _usagesBeneath(directories)) {
       if (!deps.contains(usage.package) && !devDeps.contains(usage.package)) {
-        warnings.add(usage.dependencyMissingMessage());
+        warnings.add(usage.dependenciesMissingMessage());
       }
     }
   }
@@ -148,10 +148,16 @@ class _Usage {
   String _toMessage(String message) =>
       errorMessage(message, _file, _contents, _directive);
 
-  /// Returns an error message saying the package is not listed in dependencies.
+  /// Returns an error message saying the package is not listed in `dependencies`.
   String dependencyMissingMessage() =>
       _toMessage('This package does not have $package in the `dependencies` '
           'section of `pubspec.yaml`.');
+
+  /// Returns an error message saying the package is not listed in `dependencies`
+  //  or `dev_dependencies`.
+  String dependenciesMissingMessage() =>
+      _toMessage('This package does not have $package in the `dependencies` '
+          'or `dev_dependencies` section of `pubspec.yaml`.');
 
   /// Returns an error message saying the package should be in `dependencies`.
   String dependencyMisplaceMessage() {

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -154,7 +154,7 @@ class _Usage {
           'section of `pubspec.yaml`.');
 
   /// Returns an error message saying the package is not listed in `dependencies`
-  //  or `dev_dependencies`.
+  ///  or `dev_dependencies`.
   String dependenciesMissingMessage() =>
       _toMessage('This package does not have $package in the `dependencies` '
           'or `dev_dependencies` section of `pubspec.yaml`.');

--- a/test/validator/strict_dependencies_test.dart
+++ b/test/validator/strict_dependencies_test.dart
@@ -192,7 +192,9 @@ linter:
         import 'package:silly_monkey/silly_monkey.dart';
       ''').create();
 
-      await expectValidation(strictDeps, errors: isNotEmpty);
+      await expectValidation(strictDeps, errors: [
+        matches('does not have silly_monkey in the `dependencies` section')
+      ]);
     });
 
     test('does not declare an "export" as a dependency', () async {
@@ -200,7 +202,9 @@ linter:
         export 'package:silly_monkey/silly_monkey.dart';
       ''').create();
 
-      await expectValidation(strictDeps, errors: isNotEmpty);
+      await expectValidation(strictDeps, errors: [
+        matches('does not have silly_monkey in the `dependencies` section')
+      ]);
     });
 
     test('has an invalid URI', () async {
@@ -242,7 +246,10 @@ linter:
             ]),
           ]).create();
 
-          await expectValidation(strictDeps, warnings: isNotEmpty);
+          await expectValidation(strictDeps, warnings: [
+            matches(
+                'does not have silly_monkey in the `dependencies` or `dev_dependencies` section')
+          ]);
         });
       }
     }


### PR DESCRIPTION
I saw this error today `* line 7, column 1 of test/dynamic_colors_plugin_test.dart: This package does not have meta in the dependencies section of pubspec.yaml.`, which isn't quite accurate. 

This PR differentiates the case when a dependency should be added to `dependencies` from the case where it should be added to either `dependencies` or `dev_dependencies`.

There are no tests currently checking the error message, but I could add a couple if needed.