### PR TITLE
More tool/test.dart tweaks

### DIFF
--- a/test/deps/executables_test.dart
+++ b/test/deps/executables_test.dart
@@ -8,6 +8,7 @@ import 'package:pub/src/ascii_tree.dart' as tree;
 import 'package:pub/src/io.dart';
 import 'package:test/test.dart';
 
+import '../ascii_tree_test.dart';
 import '../descriptor.dart' as d;
 import '../golden_file.dart';
 import '../test_pub.dart';
@@ -17,8 +18,8 @@ const _invalidMain = 'main() {';
 
 Future<void> variations(String name) async {
   final buffer = StringBuffer();
-  buffer.writeln(
-      tree.fromFiles(listDir(d.sandbox, recursive: true), baseDir: d.sandbox));
+  buffer.writeln(stripColors(
+      tree.fromFiles(listDir(d.sandbox, recursive: true), baseDir: d.sandbox)));
 
   await pubGet();
   await runPubIntoBuffer(['deps', '--executables'], buffer);

--- a/tool/test.dart
+++ b/tool/test.dart
@@ -20,7 +20,7 @@ import 'package:pub/src/exceptions.dart';
 
 Future<void> main(List<String> args) async {
   Process testProcess;
-  ProcessSignal.sigint.watch().listen((signal) {
+  final sub = ProcessSignal.sigint.watch().listen((signal) {
     testProcess?.kill(signal);
   });
   final pubSnapshotFilename =
@@ -47,6 +47,7 @@ Future<void> main(List<String> args) async {
   } finally {
     try {
       await File(pubSnapshotFilename).delete();
+      await sub.cancel();
     } on Exception {
       // snapshot didn't exist.
     }


### PR DESCRIPTION
Followup to https://github.com/dart-lang/pub/pull/3091
Fixes two things that would fail when the tests were run interactively:

* The tool/test.dart script would hang listening for signals. Cancelling the subscription seems to work.
* A single test would call the tree-drawing code and get colors because we inherit the stdio. Strip those colors.