### PR TITLE
Do not allow: dart pub token remove --no-all

### DIFF
--- a/lib/src/command/token_remove.dart
+++ b/lib/src/command/token_remove.dart
@@ -23,7 +23,11 @@ class TokenRemoveCommand extends PubCommand {
   bool get isAll => argResults['all'];
 
   TokenRemoveCommand() {
-    argParser.addFlag('all', help: 'Remove all secret tokens.');
+    argParser.addFlag(
+      'all',
+      negatable: false,
+      help: 'Remove all secret tokens.',
+    );
   }
 
   @override


### PR DESCRIPTION
Just fixing another nit. So that instead of:
```
$ dart run pub token remove --help
The [hosted-url] for a package repository must be specified.

Usage: pub token remove
-h, --help        Print this usage information.
    --[no-]all    Remove all secret tokens.

Run "pub help" to see global options.
```

We have:
```
$dart run pub token remove --help
Remove secret token for package repository.

Usage: pub token remove
-h, --help    Print this usage information.
    --all     Remove all secret tokens.

Run "pub help" to see global options.
```

Maybe we should make some tests using `golden_file.dart` ?

/cc @themisir 