### PR TITLE
Use ignore files up to git root

### DIFF
--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -227,8 +227,9 @@ class Package {
     var root = dir;
     if (git.isInstalled) {
       try {
-        root = git
-            .runSync(['rev-parse', '--show-toplevel'], workingDir: dir).first;
+        root = p.normalize(
+          git.runSync(['rev-parse', '--show-toplevel'], workingDir: dir).first,
+        );
       } on git.GitException {
         // Not in a git folder.
       }

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -211,20 +211,37 @@ class Package {
   /// [recursive] is true, this will return all files beneath that path;
   /// otherwise, it will only return files one level beneath it.
   ///
-  /// This will take .pubignore and .gitignore files into account. For each
-  /// directory a .pubignore takes precedence over a .gitignore.
+  /// This will take .pubignore and .gitignore files into account.
+  ///
+  /// If [dir] is inside a git repository, all ignore files from the repo root
+  /// are considered.
+  ///
+  /// For each directory a .pubignore takes precedence over a .gitignore.
   ///
   /// Note that the returned paths won't always be beneath [dir]. To safely
   /// convert them to paths relative to the package root, use [relative].
   List<String> listFiles({String beneath, bool recursive = true}) {
     // An in-memory package has no files.
     if (dir == null) return [];
-    beneath = beneath == null ? '.' : p.toUri(p.normalize(beneath)).path;
+
+    var root = dir;
+    if (git.isInstalled) {
+      try {
+        root = git
+            .runSync(['rev-parse', '--show-toplevel'], workingDir: dir).first;
+      } on git.GitException {
+        // Not in a git folder.
+      }
+    }
+    beneath = p
+        .toUri(p.normalize(p.relative(p.join(dir, beneath ?? '.'), from: root)))
+        .path;
+    if (beneath == './') beneath = '.';
     String resolve(String path) {
       if (Platform.isWindows) {
-        return p.joinAll([dir, ...p.posix.split(path)]);
+        return p.joinAll([root, ...p.posix.split(path)]);
       }
-      return p.join(dir, path);
+      return p.join(root, path);
     }
 
     return Ignore.listFiles(
@@ -246,7 +263,7 @@ class Package {
                   '''Pub does not support publishing packages with non-resolving symlink: `${entity.path}` => `$target`.''');
             }
           }
-          final relative = p.relative(entity.path, from: this.dir);
+          final relative = p.relative(entity.path, from: root);
           if (Platform.isWindows) {
             return p.posix.joinAll(p.split(relative));
           }

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -224,23 +224,32 @@ void main() {
         "ignores files that are gitignored even if the package isn't "
         'the repo root', () async {
       await d.dir(appPath, [
-        d.dir('sub', [
-          d.appPubspec(),
-          d.file('.gitignore', '*.txt'),
-          d.file('file1.txt', 'contents'),
-          d.file('file2.text', 'contents'),
-          d.dir('subdir', [
-            d.file('subfile1.txt', 'subcontents'),
-            d.file('subfile2.text', 'subcontents')
-          ])
+        d.file('.gitignore', '*.bak'),
+        d.dir('rep', [
+          d.file('.gitignore', '*.gak'),
+          d.file('.pubignore', '*.hak'),
+          d.dir('sub', [
+            d.appPubspec(),
+            d.file('.gitignore', '*.txt'),
+            d.file('file1.txt', 'contents'),
+            d.file('file2.text', 'contents'),
+            d.file('file3.bak', 'contents'),
+            d.file('file4.gak', 'contents'),
+            d.file('file5.hak', 'contents'),
+            d.dir('subdir', [
+              d.file('subfile1.txt', 'subcontents'),
+              d.file('subfile2.text', 'subcontents'),
+            ])
+          ]),
         ])
       ]).create();
 
-      createEntrypoint(p.join(appPath, 'sub'));
+      createEntrypoint(p.join(appPath, 'rep', 'sub'));
 
       expect(entrypoint.root.listFiles(), {
         p.join(root, 'pubspec.yaml'),
         p.join(root, 'file2.text'),
+        p.join(root, 'file4.gak'),
         p.join(root, 'subdir', 'subfile2.text')
       });
     });


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub/issues/3102

We are still not taking all the same gitignores as git would into account (eg. https://stackoverflow.com/a/5724484) but this is hopefully good enough.