### PR TITLE
Update the repository specification

### DIFF
--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -100,7 +100,7 @@ The `dart pub` client will in many cases to display error messages when given a
 response as follows:
 
 ```http
-HTTP/1.1 4XX OK
+HTTP/1.1 4XX Bad Request
 Content-Type: application/vnd.pub.v2+json
 {
   "error": {
@@ -126,11 +126,12 @@ as follows:
 
 Tokens can be added to `dart pub` client using the command:
 
- *  `dart pub token add <hosted-url>`.
+ * `dart pub token add <hosted-url>`
 
 This command will prompt the user for the `<token>` on stdin, reducing the risk
-that the `<token>` is accidentally stored in shell history. For further details
-on token management see: `dart pub token --help`.
+that the `<token>` is accidentally stored in shell history. For security reasons
+authentication can only be used when `<hosted-url>` uses HTTPS. For further
+details on token management see: `dart pub token --help`.
 
 
 ### Missing Authentication or Invalid Token
@@ -156,7 +157,8 @@ When receiving a `401` response the `dart pub` client shall:
  * Inform the user that authentication is required,
  * Print the `<message>` provided by the server.
 
-The `<message>` allows a custom _package server_ to how a token may be obtained.
+The `<message>` allows a custom _package server_ to inform the user how a token
+may be obtained.
 For example, a server might specify a URL from which tokens can be created, as
 illustrated below:
 
@@ -245,9 +247,9 @@ server, this could work in many different ways.
 }
 ```
 
-To fetch the package archive an HTTP `GET` request _following redirects must be
-made to the URL given as `archive_url`. The response (after following redirects)
-must be a gzipped TAR archive.
+To fetch the package archive an HTTP `GET` request **following redirects** must
+be made to the URL given as `archive_url`.
+The response (after following redirects) must be a gzipped TAR archive.
 
 The `archive_url` may be temporary and is allowed to include query-string
 parameters. This allows for the server to return signed-URLs for S3, GCS or
@@ -337,7 +339,7 @@ The client shall then issue a `GET` request to `<finalize-upload-url>`. As with
 accepts the uploaded package the server should respond:
 
 ```http
-HTTP/1.1 200 OK
+HTTP/1.1 200 Ok
 Content-Type: application/vnd.pub.v2+json
 {
   "success": {
@@ -355,7 +357,7 @@ inform the user about this in the `<message>`.
 
 If the server does not want to accept the uploaded package, it can respond:
 ```http
-HTTP/1.1 400 OK
+HTTP/1.1 400 Bad Request
 Content-Type: application/vnd.pub.v2+json
 {
   "error": {

--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -1,39 +1,216 @@
 Hosted Pub Repository Specification Version 2
 =============================================
-
-This document specifies the REST API that a hosted pub package repository must
+This document specifies the REST API that a hosted pub _package repository_ must
 implement.
 
-A hosted pub package repository is a server from which packages can be
-downloaded, the default public pub server is `'https://pub.dartlang.org'`.
-This can be overwritten in the `dependencies` of a `pubspec.yaml` or specified
-with the environment variable `PUB_HOSTED_URL`. In the rest of this document we
-shall refer to the base URL as `PUB_HOSTED_URL`.
+A package repository is a server from which packages can be downloaded,
+the default package repository is `'https://pub.dartlang.org'`, with public
+interface hosted at [pub.dev](https://pub.dev).
+
+## Hosted URL
+A custom package repository is identified by a _hosted-url_, like
+`https://pub.dartlang.org` or `https://some-server.com/prefix/pub/`.
+The _hosted-url_ always includes protocol `http://` or `https://`.
+For the purpose of this specification the _hosted-url_ should always be
+normalized such that it doesn't end with a slash (`/`). As all URL end-points
+described in this specification includes slash prefix.
+
+For the remainder of this specification the placeholder `<hosted-url>` will be
+used in place of a _hosted-url_ such as:
+ * `https://pub.dartlang.org`
+ * `https://some-server.com/prefix/pub`
+ * `https://pub.other-server.com/prefix`
+ * `http://localhost:8080`
+
+A _hosted-url_ is **not allowed** to contain:
+ * [_user-info_](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1),
+   example: `https://user:passwd@host.com`.
+ * [query-string](https://datatracker.ietf.org/doc/html/rfc3986#section-3.4),
+   example: `https://host.com/?key=value`.
+ * [fragment](https://datatracker.ietf.org/doc/html/rfc3986#section-3.5),
+   example: `https://host.com/#fragment`.
+
+
+## Custom Package Repository in `pubspec.yaml`
+A package be published to a custom _package repository_ by overwriting the
+`publish_to` key in `pubspec.yaml`, illustrated as follows:
+```yaml
+name: mypkg
+version: 1.0.0
+publish_to: <hosted-url>
+```
+
+When taking dependency upon a package from a custom _package repository_ the
+dependency must be specified as follows:
+```yaml
+name: myapp
+dependencies:
+  mypkg:
+    version: ^1.0.0
+    hosted:
+      url: <hosted-url>
+      name: mypkg
+```
+
 
 ## Forward Compatibility
-To ensure forward compatibility API requests should carry an
-`Accept: application/vnd.pub.v2+json` header. As future versions of the API
-may have different responses.
+The `dart pub` client will always include an `Accept` header specifying the API
+version requested, as follows:
 
-## Fetching Packages
+ * `Accept: application/vnd.pub.v2+json`
 
-The following API end-points MUST be supported by a hosted pub package
-repository.
+To ensure forward compatibility all API requests should include an `Accept`
+header which specifies the version of the API being used. This allows future
+versions of the API to change responses.
 
-**Optional headers** used for popularity metrics.
+Clients are strongly encouraged to specify an `Accept` header. But for
+compatiblity will probably want to assume API version `2`,
+if no `Accept` header is specified.
 
-* `X-Pub-OS: windows | macos | linux | ...`
-* `X-Pub-Command: get | upgrade | ...`
-* `X-Pub-Session-ID: <UUID>`
-* `X-Pub-Reason: direct | dev`
-* `X-Pub-Environment: ...`
-* `User-Agent: my-pub-bot/1.2.3 (+https://github.com/organization/<repository)`
 
-Adding a custom `User-Agent` that allows _pub repository operators_ to identify calls from a specific client, and a URL allowing operators to reach owner of the client is always good practice.
+## Metadata headers
+The `dart pub` client will attach a `User-Agent` header as follows:
 
-### List all versions of a package
+ * `User-Agent: Dart pub <sdk-version>`
 
-**GET** `<PUB_HOSTED_URL>/api/packages/<PACKAGE>`
+Custom clients are strongly encouraged to specify a custom `User-Agent` that
+allows _package repository operators_ to identify which client a request is
+coming from. Including a URL allowing operators to reach owners/authors of the
+client is good practice.
+
+ * `User-Agent: my-pub-bot/1.2.3 (+https://github.com/organization/<repository)`
+
+The `User-Agent` header also allows package repository to determine how many
+different clients would be affected by an API change.
+
+
+## Retrying with Exponential Backoff
+The `dart pub` client will retry failed requests with
+[exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff).
+This aims to increase robustness against intermittent network issues, while not
+overloading servers that are partially failing.
+
+Clients are strongly encouraged to employ exponential backoff starting at 200ms,
+400ms, etc. stopping after 5-7 retries. Excessive can have negative impact on
+servers and network performance.
+
+
+## Rejecting Requests
+The `dart pub` client will in many cases to display error messages when given a
+response as follows:
+
+```http
+HTTP/1.1 4XX OK
+Content-Type: application/vnd.pub.v2+json
+{
+  "error": {
+    "code": "<code>",
+    "message": "<message>",
+  },
+}
+```
+
+The `<message>` is intended to be a brief human readable explanation of what
+when wrong and why the request failed. The `<code>` is a text string intended to
+allow clients to handle special cases without using regular expression to
+parse the `<message>`.
+
+
+## Authentication
+The `dart pub` client allows users to save an opaque `<token>` for each
+`<hosted-url>`. When the `dart pub` client makes a request to a `<hosted-url>`
+for which it has a `<token>` stored, it will attach an `Authorization` header
+as follows: 
+
+ * `Authorization: Bearer <token>`
+
+Tokens can be added to `dart pub` client using the command:
+
+ *  `dart pub token add <hosted-url>`.
+
+This command will prompt the user for the `<token>` on stdin, reducing the risk
+that the `<token>` is accidentally stored in shell history. For further details
+on token management see: `dart pub token --help`.
+
+
+### Missing Authentication or Invalid Token
+If the server requires authentication and the request does not carry an
+`Authorization` header, or the token in the `Authorization` header is invalid
+or expired, the server must respond:
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer realm="pub", message="<message>"
+```
+
+If the `dart pub` client receives a `401` response and the `dart pub` client has
+a token for the given `<hosted-url>`, then the `dart pub` client knows for sure
+that the token it has stored for the given `<hosted-url>` is invalid.
+Hence, the `dart pub` client shall remove the token from local configuration.
+Hence, a server shall not send `401` in case where a token is valid, but does
+not have permissions to access the package in question.
+
+When receiving a `401` response the `dart pub` client shall:
+ * Abort the current operation (exiting non-zero),
+ * Delete any token it may have stored for the given `<hosted-url>`,
+ * Inform the user that authentication is required,
+ * Print the `<message>` provided by the server.
+
+The `<message>` allows a custom _package server_ to how a token may be obtained.
+For example, a server might specify a URL from which tokens can be created, as
+illustrated below:
+
+```http
+GET /packages/mypkg HTTP/1.1
+HOST: pub.example.com
+User-Agent: Dart pub 2.15.0
+Accept: application/vnd.pub.v2+json
+
+
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer realm="pub", message="Obtain a token from https://pub.example.com/manage-tokens"
+```
+
+The `dart pub` will display the `message` in the terminal, so the user can
+discover that they need to navigate to `https://pub.example.com/manage-tokens`. 
+Once the user opens this URL in the browser, the server is then free to ask the
+user to sign-in using any browser-based authentication mechanism. Once signed-in
+the server can allow the user to create a token and tell the user to copy/paste
+this into stdin for `dart pub token add pub.example.com`.
+
+Package server authors are advised to consider security practices such as:
+ * Prevent a token from being returned again after its initial creation.
+ * Associate names with tokens (so users can remember what computer they
+   create the token for).
+ * Record last used date-time for each token.
+ * Expire tokens not frequently used.
+ * Token rotation through forced expiration.
+
+
+### Insufficient Permissions
+
+If the server requires authorization and the request carries an `Authorization`
+header with a valid token, but this token authenticates the client as a user
+that does not have permissions to access the given resource the server must
+respond:
+
+```http
+HTTP/1.1 403 Forbidden
+WWW-Authenticate: Bearer realm="pub", message="<message>"
+```
+
+This behaves the same as `401` with the exception that the token will not be
+automatically deleted from local configuration by the `dart pub` client. This
+makes sense if the token is valid, but doesn't have sufficient permissions.
+
+The `<message>` allows a custom package repository to indicate how sufficient
+permissions can be granted. Depending on how permissions are managed on the
+server, this could work in many different ways.
+
+
+## List all versions of a package
+
+**GET** `<hosted-url>/api/packages/<package>`
 
 **Headers:**
 * `Accept: application/vnd.pub.v2+json`
@@ -43,12 +220,12 @@ Adding a custom `User-Agent` that allows _pub repository operators_ to identify 
 
 ```js
 {
-  "name": "<PACKAGE>",
-  "isDiscontinued": true || false, /* optional field, missing if false */
-  "replacedBy": "<PACKAGE>", /* optional field, if isDiscontinued == true */
+  "name": "<package>",
+  "isDiscontinued": true || false, /* optional field, false if omitted */
+  "replacedBy": "<package>", /* optional field, if isDiscontinued == true */
   "latest": {
-    "version": "<VERSION>",
-    "isRetracted": true || false, /* optional field, missing if false */
+    "version": "<version>",
+    "isRetracted": true || false, /* optional field, false if omitted */
     "archive_url": "https://.../archive.tar.gz",
     "pubspec": {
       /* pubspec contents as JSON object */
@@ -56,8 +233,8 @@ Adding a custom `User-Agent` that allows _pub repository operators_ to identify 
   },
   "versions": [
     {
-      "version": "<VERSION>",
-      "isRetracted": true || false, /* optional field, missing if false */
+      "version": "<package>",
+      "isRetracted": true || false, /* optional field, false if omitted */
       "archive_url": "https://.../archive.tar.gz",
       "pubspec": {
         /* pubspec contents as JSON object */
@@ -68,16 +245,144 @@ Adding a custom `User-Agent` that allows _pub repository operators_ to identify 
 }
 ```
 
-To fetch the package archive an HTTP `GET` request _following retries_ must be
+To fetch the package archive an HTTP `GET` request _following redirects must be
 made to the URL given as `archive_url`. The response (after following redirects)
 must be a gzipped TAR archive.
 
-### (Deprecated) Inspect a specific version of a package
+The `archive_url` may be temporary and is allowed to include query-string
+parameters. This allows for the server to return signed-URLs for S3, GCS or
+other blob storage service. If temporary URLs are returned it is wise to not set
+expiration to less than 25 minutes (to allow for retries and clock drift).
+
+If `<hosted-url>` for the server returning `archive_url` is a prefix of
+`archive_url`, then the `Authorization: Bearer <token>` is also included when
+`archive_url` is requested. Example: if `https://pub.example.com/path` returns
+an `archive_url = 'https://pub.example.com/path/...'` then the request for
+`https://pub.example.com/path/...` will include `Authorization` header.
+This would however, not be case if the same server returned
+`archive_url = 'https://pub.example.com/blob/...'`.
+
+
+## Publishing Packages
+
+**GET** `<hosted-url>/api/packages/versions/new`
+
+**Headers:**
+* `Accept: application/vnd.pub.v2+json`
+* `Authorization: Bearer <token>` (required)
+
+**Response**
+* `Content-Type: application/vnd.pub.v2+json`
+
+```js
+{
+  "url": "<multipart-upload-url>",
+  "fields": {
+    "<field-1>": "<value-1>",
+    "<field-2>": "<value-2>",
+    ...,
+    "<field-N>": "<value-N>",
+  },
+}
+```
+
+To publish a package a HTTP `GET` request for
+`<hosted-url>/api/packages/versions/new` is made. This request returns an
+`<multipart-upload-url>` and a dictionary of fields. To upload the package
+archive a multi-part `POST` request is made to `<multipart-upload-url>` with
+fields and the field `file` containing the gzipped tar archive.
+
+```http
+POST <path(multipart-upload-url)> HTTP/1.1
+Host: <host(multipart-upload-url)>
+Content-Length: <length>
+Content-Type: multipart/form-data; boundary=<boundary>
+
+--<boundary>
+Content-Disposition: form-data; name="<urlencode(field-1)>"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: binary
+
+<value-1>
+--<boundary>
+Content-Disposition: form-data; name="<urlencode(field-2)>"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: binary
+
+<value-2>
+...
+--<boundary>
+Content-Disposition: form-data; name="<urlencode(field-N)>"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: binary
+
+<value-N>
+--<boundary>
+Content-Type: application/octet-stream
+Content-Disposition: form-data; name="file"; filename="package.tar.gz"
+
+<gzipped archieve>
+```
+
+The above `POST` request to `<multipart-upload-url>` should respond as follows:
+
+```http
+HTTP/1.1 204 No Content
+Location: <finalize-upload-url>
+```
+
+The client shall then issue a `GET` request to `<finalize-upload-url>`. As with
+`archive_url` the client will only attach an `Authorization` if the
+`<hosted-url>` is a prefix of `<finalize-upload-url>`. If the server wants to
+accepts the uploaded package the server should respond:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.pub.v2+json
+{
+  "success": {
+    "message": "<message>",
+  },
+}
+```
+
+The server is allowed to consider the publishing incomplete until the `GET`
+request for `<finalize-upload-url>` has been issued. Once this request has
+succeeded the package is considered successfully published. If the server has
+caches that need to expire before newly published packages becomes available,
+or it has other out-of-band approvals that need to be given it's reasonable to
+inform the user about this in the `<message>`.
+
+If the server does not want to accept the uploaded package, it can respond:
+```http
+HTTP/1.1 400 OK
+Content-Type: application/vnd.pub.v2+json
+{
+  "error": {
+    "code": "<code>",
+    "message": "<message>",
+  },
+}
+```
+
+This can be used to forbid git-dependencies in published packages, limit the
+archive size, or enforce any other repository specific constraints.
+
+This upload flow allows for archives to be uploaded directly to a signed POST
+URL for S3, GCS or similar blob storage service. Both the
+`<multipart-upload-url>` and `<finalize-upload-url>` is allowed to contain
+query-string parameters, and both of these URLs need only be temporary.
+
+
+------------
+
+## (Deprecated) Inspect a specific version of a package
+
 
 **Deprecated** as of Dart 2.8, use "List all versions of a package" instead.
 Servers should still support this end-point for compatibility with older `pub` clients.
 
-**GET** `<PUB_HOSTED_URL>/api/packages/<PACKAGE>/versions/<VERSION>`
+**GET** `<hosted-url>/api/packages/<package>/versions/<version>`
 
 **Headers:**
 * `Accept: application/vnd.pub.v2+json`
@@ -95,12 +400,13 @@ Servers should still support this end-point for compatibility with older `pub` c
 }
 ```
 
-### (Deprecated) Download a specific version of a package
+
+## (Deprecated) Download a specific version of a package
 
 **Deprecated** as of Dart 2.8, use the `archive_url` returned from the "List all versions of a package".
 Servers should still support this end-point for compatibility with older `pub` clients.
 
-**GET** `<PUB_HOSTED_URL>/packages/<PACKAGE>/versions/<VERSION>.tar.gz`
+**GET** `<hosted-url>/packages/<package>/versions/<version>.tar.gz`
 
 **Headers**
 * `Accept: application/octet-stream` (optional)
@@ -111,7 +417,3 @@ Servers should still support this end-point for compatibility with older `pub` c
 **Important:** The server MAY redirect the client to a different URL, clients
 MUST support redirects.
 
-## Publishing Packages
-
-The API for authenticating and publishing packages is not formalized yet, see
-[#1381](https://github.com/dart-lang/pub/issues/1381).

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -632,6 +632,15 @@ class BoundHostedSource extends CachedSource {
   /// `$server/packages/$package/versions/$version.tar.gz` where server comes
   /// from `id.description`.
   Future _download(PackageId id, String destPath) async {
+    // We never want to use a cached `archive_url`, so we never attempt to load
+    // the version listing from cache. Besides in most cases we already have
+    // downloaded a fresh copy of the version listing response in the in-memory
+    // cache, so looking in the file-system is pointless.
+    //
+    // We avoid using cached `archive_url` values because the `archive_url` for
+    // a custom package server may include a temporary signature in the
+    // query-string as is the case with signed S3 URLs. And we wish to allow for
+    // such URLs to be used.
     final versions = await _scheduler.schedule(id.toRef());
     final versionInfo = versions[id];
     final packageName = id.name;


### PR DESCRIPTION
 * Documented authentication with `dart token add <hosted-url>`
 * Documented publishing with `dart pub publish`
 * Clean-up language centering on `<hosted-url>` and "package repository"
 * Removed discussion of meta-data only specific to `pub.dev`
 * Mentioned `hosted` in `pubspec.yaml`
 * Added notes on temporary URL usage and leavering GCS, S3 or similar blob storage service.

/cc: @isoos, @themisir, please see if you agree with this characterization of the repository specification.