### PR TITLE
Migrate utils and dependencies to null-safety

### DIFF
--- a/lib/src/ascii_tree.dart
+++ b/lib/src/ascii_tree.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 /// A simple library for rendering tree-like structures in ASCII.
 import 'package:path/path.dart' as path;
 
@@ -60,7 +58,11 @@ import 'utils.dart';
 ///
 /// If [showAllChildren] is `false`, then directories with more than ten items
 /// will have their contents truncated. Defaults to `false`.
-String fromFiles(List<String> files, {String baseDir, bool showAllChildren}) {
+String fromFiles(
+  List<String> files, {
+  String? baseDir,
+  bool showAllChildren = false,
+}) {
   // Parse out the files into a tree of nested maps.
   var root = <String, Map>{};
   for (var file in files) {
@@ -100,14 +102,18 @@ String fromFiles(List<String> files, {String baseDir, bool showAllChildren}) {
 ///
 /// If [showAllChildren] is `false`, then directories with more than ten items
 /// will have their contents truncated. Defaults to `false`.
-String fromMap(Map<String, Map> map, {bool showAllChildren}) {
+String fromMap(Map<String, Map> map, {bool showAllChildren = false}) {
   var buffer = StringBuffer();
   _draw(buffer, '', null, map, showAllChildren: showAllChildren);
   return buffer.toString();
 }
 
 void _drawLine(
-    StringBuffer buffer, String prefix, bool isLastChild, String name) {
+  StringBuffer buffer,
+  String prefix,
+  bool isLastChild,
+  String? name,
+) {
   // Print lines.
   buffer.write(prefix);
   if (name != null) {
@@ -129,10 +135,13 @@ String _getPrefix(bool isRoot, bool isLast) {
 }
 
 void _draw(
-    StringBuffer buffer, String prefix, String name, Map<String, Map> children,
-    {bool showAllChildren, bool isLast = false}) {
-  showAllChildren ??= false;
-
+  StringBuffer buffer,
+  String prefix,
+  String? name,
+  Map<String, Map> children, {
+  bool showAllChildren = false,
+  bool isLast = false,
+}) {
   // Don't draw a line for the root node.
   if (name != null) _drawLine(buffer, prefix, isLast, name);
 
@@ -159,7 +168,7 @@ void _draw(
 
     // Elide the middle ones.
     buffer.write(prefix);
-    buffer.write(_getPrefix(name == null, isLast));
+    buffer.write(_getPrefix(false, isLast));
     buffer.writeln(log.gray('| (${childNames.length - 6} more...)'));
 
     // Show the last few.

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 /// A library for compiling Dart code and manipulating analyzer parse trees.
 import 'dart:async';
 import 'dart:io';
@@ -19,7 +17,6 @@ import 'package:analyzer/file_system/overlay_file_system.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:cli_util/cli_util.dart';
 import 'package:frontend_server_client/frontend_server_client.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import 'exceptions.dart';
@@ -36,7 +33,7 @@ bool isEntrypoint(CompilationUnit dart) {
   return dart.declarations.any((node) {
     return node is FunctionDeclaration &&
         node.name.name == 'main' &&
-        node.functionExpression.parameters.parameters.length <= 2;
+        (node.functionExpression.parameters?.parameters.length ?? 0) <= 2;
   });
 }
 
@@ -160,11 +157,11 @@ class AnalyzerErrorGroup implements Exception {
 ///
 /// The [name] is used to describe the executable in logs and error messages.
 Future<void> precompile({
-  @required String executablePath,
-  @required String incrementalDillOutputPath,
-  @required String name,
-  @required String outputPath,
-  @required String packageConfigPath,
+  required String executablePath,
+  required String incrementalDillOutputPath,
+  required String name,
+  required String outputPath,
+  required String packageConfigPath,
 }) async {
   ensureDir(p.dirname(outputPath));
   ensureDir(p.dirname(incrementalDillOutputPath));
@@ -191,7 +188,7 @@ Future<void> precompile({
 
       throw ApplicationException(
           log.yellow('Failed to build $highlightedName:\n') +
-              (result?.compilerOutputLines?.join('\n') ?? ''));
+              (result?.compilerOutputLines.join('\n') ?? ''));
     }
   } finally {
     client.kill();

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 import 'dart:io';
 import 'dart:isolate';
 
@@ -55,9 +53,9 @@ class WrappedException extends ApplicationException {
   final Object innerError;
 
   /// The stack chain for [innerError] if it exists.
-  final Chain innerChain;
+  final Chain? innerChain;
 
-  WrappedException(String message, this.innerError, [StackTrace innerTrace])
+  WrappedException(String message, this.innerError, [StackTrace? innerTrace])
       : innerChain = innerTrace == null ? null : Chain.forTrace(innerTrace),
         super(message);
 }
@@ -67,7 +65,7 @@ class WrappedException extends ApplicationException {
 /// This is usually used when an exception has already been printed using
 /// [log.exception].
 class SilentException extends WrappedException {
-  SilentException(innerError, [StackTrace innerTrace])
+  SilentException(innerError, [StackTrace? innerTrace])
       : super(innerError.toString(), innerError, innerTrace);
 }
 
@@ -92,10 +90,10 @@ class ConfigException extends ApplicationException {
 /// why the package was being requested.
 class PackageNotFoundException extends WrappedException {
   /// If this failure was caused by an SDK being unavailable, this is that SDK.
-  final Sdk missingSdk;
+  final Sdk? missingSdk;
 
   PackageNotFoundException(String message,
-      {innerError, StackTrace innerTrace, this.missingSdk})
+      {innerError, StackTrace? innerTrace, this.missingSdk})
       : super(message, innerError, innerTrace);
 
   @override

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -50,7 +50,7 @@ class FileException implements ApplicationException {
 /// A class for exceptions that wrap other exceptions.
 class WrappedException extends ApplicationException {
   /// The underlying exception that [this] is wrapping, if any.
-  final Object innerError;
+  final Object? innerError;
 
   /// The stack chain for [innerError] if it exists.
   final Chain? innerChain;
@@ -65,7 +65,7 @@ class WrappedException extends ApplicationException {
 /// This is usually used when an exception has already been printed using
 /// [log.exception].
 class SilentException extends WrappedException {
-  SilentException(innerError, [StackTrace? innerTrace])
+  SilentException(Object? innerError, [StackTrace? innerTrace])
       : super(innerError.toString(), innerError, innerTrace);
 }
 
@@ -92,9 +92,12 @@ class PackageNotFoundException extends WrappedException {
   /// If this failure was caused by an SDK being unavailable, this is that SDK.
   final Sdk? missingSdk;
 
-  PackageNotFoundException(String message,
-      {innerError, StackTrace? innerTrace, this.missingSdk})
-      : super(message, innerError, innerTrace);
+  PackageNotFoundException(
+    String message, {
+    Object? innerError,
+    StackTrace? innerTrace,
+    this.missingSdk,
+  }) : super(message, innerError, innerTrace);
 
   @override
   String toString() => "Package doesn't exist ($message).";

--- a/lib/src/log.dart
+++ b/lib/src/log.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 /// Message logging.
 import 'dart:async';
 import 'dart:convert';
@@ -38,12 +36,12 @@ const _MAX_TRANSCRIPT = 10000;
 
 /// The list of recorded log messages. Will only be recorded if
 /// [recordTranscript()] is called.
-Transcript<_Entry> _transcript;
+Transcript<_Entry>? _transcript;
 
 /// The currently-animated progress indicator, if any.
 ///
 /// This will also be in [_progresses].
-Progress _animatedProgress;
+Progress? _animatedProgress;
 
 final _cyan = getAnsi('\u001b[36m');
 final _green = getAnsi('\u001b[32m');
@@ -173,7 +171,7 @@ class Verbosity {
   const Verbosity._(this.name, this._loggers);
 
   final String name;
-  final Map<Level, void Function(_Entry entry)> _loggers;
+  final Map<Level, void Function(_Entry entry)?> _loggers;
 
   /// Returns whether or not logs at [level] will be printed.
   bool isLevelVisible(Level level) => _loggers[level] != null;
@@ -194,7 +192,7 @@ class _Entry {
 ///
 /// If [error] is passed, it's appended to [message]. If [trace] is passed, it's
 /// printed at log level fine.
-void error(message, [error, StackTrace trace]) {
+void error(message, [error, StackTrace? trace]) {
   message ??= '';
   if (error != null) {
     message = message.isEmpty ? '$error' : '$message: $error';
@@ -235,7 +233,7 @@ void write(Level level, message) {
   var logFn = verbosity._loggers[level];
   if (logFn != null) logFn(entry);
 
-  if (_transcript != null) _transcript.add(entry);
+  if (_transcript != null) _transcript!.add(entry);
 }
 
 /// Logs the spawning of an [executable] process with [arguments] at [IO]
@@ -277,7 +275,7 @@ void processResult(String executable, PubProcessResult result) {
 }
 
 /// Logs an exception.
-void exception(exception, [StackTrace trace]) {
+void exception(exception, [StackTrace? trace]) {
   if (exception is SilentException) return;
 
   var chain = trace == null ? Chain.current() : Chain.forTrace(trace);
@@ -326,7 +324,7 @@ void dumpTranscript() {
   if (_transcript == null) return;
 
   stderr.writeln('---- Log transcript ----');
-  _transcript.forEach((entry) {
+  _transcript!.forEach((entry) {
     _printToStream(stderr, entry, showLabel: true);
   }, (discarded) {
     stderr.writeln('---- ($discarded discarded) ----');
@@ -381,7 +379,7 @@ Future<T> spinner<T>(String message, Future<T> Function() callback,
 
 /// Stops animating the running progress indicator, if currently running.
 void _stopProgress() {
-  if (_animatedProgress != null) _animatedProgress.stopAnimating();
+  if (_animatedProgress != null) _animatedProgress!.stopAnimating();
   _animatedProgress = null;
 }
 
@@ -488,13 +486,13 @@ void _logToStderrWithLabel(_Entry entry) {
   _logToStream(stderr, entry, showLabel: true);
 }
 
-void _logToStream(IOSink sink, _Entry entry, {bool showLabel}) {
+void _logToStream(IOSink sink, _Entry entry, {required bool showLabel}) {
   if (json.enabled) return;
 
   _printToStream(sink, entry, showLabel: showLabel);
 }
 
-void _printToStream(IOSink sink, _Entry entry, {bool showLabel}) {
+void _printToStream(IOSink sink, _Entry entry, {required bool showLabel}) {
   _stopProgress();
 
   var firstLine = true;
@@ -535,11 +533,11 @@ class _JsonLogger {
     }
 
     // If the error came from a file, include the path.
-    if (error is SourceSpanException && error.span.sourceUrl != null) {
+    if (error is SourceSpanException && error.span?.sourceUrl != null) {
       // Normalize paths and make them absolute for backwards compatibility with
       // the protocol used by the analyzer.
       errorJson['path'] =
-          p.normalize(p.absolute(p.fromUri(error.span.sourceUrl)));
+          p.normalize(p.absolute(p.fromUri(error.span!.sourceUrl)));
     }
 
     if (error is FileException) {

--- a/lib/src/progress.dart
+++ b/lib/src/progress.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 import 'dart:async';
 import 'dart:io';
 
@@ -13,7 +11,7 @@ import 'utils.dart';
 /// A live-updating progress indicator for long-running log entries.
 class Progress {
   /// The timer used to write "..." during a progress log.
-  Timer _timer;
+  Timer? _timer;
 
   /// The [Stopwatch] used to track how long a progress log has been running.
   final _stopwatch = Stopwatch();
@@ -71,7 +69,7 @@ class Progress {
     // If we were animating, print one final update to show the user the final
     // time.
     if (_timer == null) return;
-    _timer.cancel();
+    _timer!.cancel();
     _timer = null;
     _update();
     stdout.writeln();
@@ -93,7 +91,7 @@ class Progress {
     // If we were animating, print one final update to show the user the final
     // time.
     if (_timer == null) return;
-    _timer.cancel();
+    _timer!.cancel();
     _timer = null;
   }
 
@@ -108,7 +106,7 @@ class Progress {
     // half-complete time indicator on the console.
     stdout.writeln('\b' * _timeLength);
     _timeLength = 0;
-    _timer.cancel();
+    _timer!.cancel();
     _timer = null;
   }
 

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 import 'dart:collection';
 
 import 'package:pub_semver/pub_semver.dart';
@@ -28,7 +26,7 @@ abstract class Sdk {
   bool get isAvailable;
 
   /// The SDK's version number, or `null` if the SDK is unavailable.
-  Version get version;
+  Version? get version;
 
   /// The version of pub that added support for this SDK.
   Version get firstPubVersion;
@@ -37,13 +35,13 @@ abstract class Sdk {
   ///
   /// This is printed after a version solve where the SDK wasn't found. It may
   /// be `null`, indicating that no such message should be printed.
-  String get installMessage;
+  String? get installMessage;
 
   /// Returns the path to the package [name] within this SDK.
   ///
   /// Returns `null` if the SDK isn't available or if it doesn't contain a
   /// package with the given name.
-  String packagePath(String name);
+  String? packagePath(String name);
 
   @override
   String toString() => name;

--- a/lib/src/sdk/dart.dart
+++ b/lib/src/sdk/dart.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -21,7 +19,7 @@ class DartSdk extends Sdk {
   @override
   bool get isAvailable => true;
   @override
-  String get installMessage => null;
+  String? get installMessage => null;
   @override
   Version get firstPubVersion => Version.none;
 
@@ -54,5 +52,5 @@ class DartSdk extends Sdk {
   String get rootDirectory => _rootDirectory;
 
   @override
-  String packagePath(String name) => null;
+  String? packagePath(String name) => null;
 }

--- a/lib/src/sdk/flutter.dart
+++ b/lib/src/sdk/flutter.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -23,7 +21,7 @@ class FlutterSdk extends Sdk {
   // We only consider the Flutter SDK to present if we find a root directory
   // and the root directory contains a valid 'version' file.
   static final bool _isAvailable = _rootDirectory != null && _version != null;
-  static final String _rootDirectory = () {
+  static final String? _rootDirectory = () {
     // If FLUTTER_ROOT is specified, then this always points to the Flutter SDK
     if (Platform.environment.containsKey('FLUTTER_ROOT')) {
       return Platform.environment['FLUTTER_ROOT'];
@@ -57,12 +55,12 @@ class FlutterSdk extends Sdk {
 
     return null;
   }();
-  static final Version _version = () {
+  static final Version? _version = () {
     if (_rootDirectory == null) return null;
 
     try {
       return Version.parse(
-        readTextFile(p.join(_rootDirectory, 'version')).trim(),
+        readTextFile(p.join(_rootDirectory!, 'version')).trim(),
       );
     } on IOException {
       return null; // I guess the file doesn't exist
@@ -76,23 +74,23 @@ class FlutterSdk extends Sdk {
       'Flutter users should run `flutter pub get` instead of `dart pub get`.';
 
   @override
-  Version get version {
+  Version? get version {
     if (!isAvailable) return null;
     return _version;
   }
 
   @override
-  String packagePath(String name) {
+  String? packagePath(String name) {
     if (!isAvailable) return null;
 
     // Flutter packages exist in both `$flutter/packages` and
     // `$flutter/bin/cache/pkg`. This checks both locations in order. If [name]
     // exists in neither place, it returns the `$flutter/packages` location
     // which is more human-readable for error messages.
-    var packagePath = p.join(_rootDirectory, 'packages', name);
+    var packagePath = p.join(_rootDirectory!, 'packages', name);
     if (dirExists(packagePath)) return packagePath;
 
-    var cachePath = p.join(_rootDirectory, 'bin', 'cache', 'pkg', name);
+    var cachePath = p.join(_rootDirectory!, 'bin', 'cache', 'pkg', name);
     if (dirExists(cachePath)) return cachePath;
 
     return null;

--- a/lib/src/sdk/fuchsia.dart
+++ b/lib/src/sdk/fuchsia.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -20,9 +18,8 @@ class FuchsiaSdk extends Sdk {
   @override
   Version get firstPubVersion => Version.parse('2.0.0-dev.51.0');
 
-  static final bool _isAvailable =
-      Platform.environment.containsKey('FUCHSIA_DART_SDK_ROOT');
-  static final String _rootDirectory =
+  static final bool _isAvailable = _rootDirectory != null;
+  static final String? _rootDirectory =
       Platform.environment['FUCHSIA_DART_SDK_ROOT'];
 
   @override
@@ -31,21 +28,21 @@ class FuchsiaSdk extends Sdk {
       'the root of the Fuchsia SDK for Dart.';
 
   @override
-  Version get version {
+  Version? get version {
     if (!_isAvailable) return null;
 
     _version ??=
-        Version.parse(readTextFile(p.join(_rootDirectory, 'version')).trim());
+        Version.parse(readTextFile(p.join(_rootDirectory!, 'version')).trim());
     return _version;
   }
 
-  Version _version;
+  Version? _version;
 
   @override
-  String packagePath(String name) {
+  String? packagePath(String name) {
     if (!isAvailable) return null;
 
-    var packagePath = p.join(_rootDirectory, 'packages', name);
+    var packagePath = p.join(_rootDirectory!, 'packages', name);
     if (dirExists(packagePath)) return packagePath;
 
     return null;

--- a/lib/src/solver/version_solver.dart
+++ b/lib/src/solver/version_solver.dart
@@ -334,6 +334,9 @@ class VersionSolver {
     var package = await minByAsync(unsatisfied, (package) async {
       return await _packageLister(package).countVersions(package.constraint);
     });
+    if (package == null) {
+      return null; // when unsatisfied.isEmpty
+    }
 
     PackageId version;
     try {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -125,11 +125,8 @@ Future<T> captureErrors<T>(Future<T> Function() callback,
     });
   } else {
     runZonedGuarded(wrappedCallback, (e, stackTrace) {
-      if (stackTrace == null) {
-        stackTrace = Chain.current();
-      } else {
-        stackTrace = Chain([Trace.from(stackTrace)]);
-      }
+      stackTrace = Chain([Trace.from(stackTrace)]);
+
       if (!completer.isCompleted) completer.completeError(e, stackTrace);
     });
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 /// Generic utility functions. Stuff that should possibly be in core.
 import 'dart:async';
 import 'dart:convert';
@@ -70,7 +68,7 @@ final random = math.Random.secure();
 ///
 /// If pub isn't attached to a terminal, uses an infinite line length and does
 /// not wrap text.
-final int _lineLength = () {
+final int? _lineLength = () {
   try {
     return stdout.terminalColumns;
   } on StdoutException {
@@ -168,8 +166,7 @@ StreamTransformer<T, T> onDoneTransformer<T>(void Function() onDone) {
 /// Pads [source] to [length] by adding [char]s at the beginning.
 ///
 /// If [char] is `null`, it defaults to a space.
-String _padLeft(String source, int length, [String char]) {
-  char ??= ' ';
+String _padLeft(String source, int length, [String char = ' ']) {
   if (source.length >= length) return source;
 
   return char * (length - source.length) + source;
@@ -180,7 +177,7 @@ String _padLeft(String source, int length, [String char]) {
 ///
 /// If [iter] does not have one item, name will be pluralized by adding "s" or
 /// using [plural], if given.
-String namedSequence(String name, Iterable iter, [String plural]) {
+String namedSequence(String name, Iterable iter, [String? plural]) {
   if (iter.length == 1) return '$name ${iter.single}';
 
   plural ??= '${name}s';
@@ -191,9 +188,8 @@ String namedSequence(String name, Iterable iter, [String plural]) {
 ///
 /// This converts each element of [iter] to a string and separates them with
 /// commas and/or [conjunction] (`"and"` by default) where appropriate.
-String toSentence(Iterable iter, {String conjunction}) {
+String toSentence(Iterable iter, {String conjunction = 'and'}) {
   if (iter.length == 1) return iter.first.toString();
-  conjunction ??= 'and';
   return iter.take(iter.length - 1).join(', ') + ' $conjunction ${iter.last}';
 }
 
@@ -201,7 +197,7 @@ String toSentence(Iterable iter, {String conjunction}) {
 ///
 /// By default, this just adds "s" to the end of [name] to get the plural. If
 /// [plural] is passed, that's used instead.
-String pluralize(String name, int number, {String plural}) {
+String pluralize(String name, int number, {String? plural}) {
   if (number == 1) return name;
   if (plural != null) return plural;
   return '${name}s';
@@ -267,11 +263,11 @@ Set<String> createDirectoryFilter(Iterable<String> dirs) {
 /// Returns the maximum value in [iter] by [compare].
 ///
 /// [compare] defaults to [Comparable.compare].
-T maxAll<T extends Comparable>(Iterable<T> iter, [int Function(T, T) compare]) {
-  compare ??= Comparable.compare;
-  return iter
-      .reduce((max, element) => compare(element, max) > 0 ? element : max);
-}
+T maxAll<T extends Comparable>(
+  Iterable<T> iter, [
+  int Function(T, T) compare = Comparable.compare,
+]) =>
+    iter.reduce((max, element) => compare(element, max) > 0 ? element : max);
 
 /// Returns the element of [values] for which [orderBy] returns the smallest
 /// value.
@@ -279,10 +275,12 @@ T maxAll<T extends Comparable>(Iterable<T> iter, [int Function(T, T) compare]) {
 /// Returns the first such value in case of ties.
 ///
 /// Starts all the [orderBy] invocations in parallel.
-Future<S> minByAsync<S, T>(
-    Iterable<S> values, Future<T> Function(S) orderBy) async {
-  int minIndex;
-  T minOrderBy;
+Future<S?> minByAsync<S, T>(
+  Iterable<S> values,
+  Future<T> Function(S) orderBy,
+) async {
+  int? minIndex;
+  T? minOrderBy;
   List valuesList = values.toList();
   final orderByResults = await Future.wait(values.map(orderBy));
   for (var i = 0; i < orderByResults.length; i++) {
@@ -292,6 +290,9 @@ Future<S> minByAsync<S, T>(
       minIndex = i;
       minOrderBy = elementOrderBy;
     }
+  }
+  if (minIndex == null) {
+    return null; // when [values] is empty!
   }
   return valuesList[minIndex];
 }
@@ -427,7 +428,7 @@ bool get canUseUnicode =>
 /// Prepends each line in [text] with [prefix].
 ///
 /// If [firstPrefix] is passed, the first line is prefixed with that instead.
-String prefixLines(String text, {String prefix = '| ', String firstPrefix}) {
+String prefixLines(String text, {String prefix = '| ', String? firstPrefix}) {
   var lines = text.split('\n');
   if (firstPrefix == null) {
     return lines.map((line) => '$prefix$line').join('\n');
@@ -504,7 +505,7 @@ String yamlToString(data) {
 
 /// Throw a [ApplicationException] with [message].
 @alwaysThrows
-void fail(String message, [innerError, StackTrace innerTrace]) {
+void fail(String message, [Object? innerError, StackTrace? innerTrace]) {
   if (innerError != null) {
     throw WrappedException(message, innerError, innerTrace);
   } else {
@@ -524,7 +525,7 @@ void dataError(String message) => throw DataException(message);
 /// `255` inclusive.
 ///
 /// If [bytes] is not provided, it is generated using `Random.secure`.
-String createUuid([List<int> bytes]) {
+String createUuid([List<int>? bytes]) {
   var rnd = math.Random.secure();
 
   // See http://www.cryptosys.net/pki/uuid-rfc4122.html for notes
@@ -548,18 +549,20 @@ String createUuid([List<int> bytes]) {
 /// of whitespace.
 ///
 /// If [prefix] is passed, it's added at the beginning of any wrapped lines.
-String wordWrap(String text, {String prefix}) {
+String wordWrap(String text, {String prefix = ''}) {
   // If there is no limit, don't wrap.
-  if (_lineLength == null) return text;
+  final lineLength = _lineLength;
+  if (lineLength == null) {
+    return text;
+  }
 
-  prefix ??= '';
   return text.split('\n').map((originalLine) {
     var buffer = StringBuffer();
     var lengthSoFar = 0;
     var firstLine = true;
     for (var word in originalLine.split(' ')) {
       var wordLength = _withoutColors(word).length;
-      if (wordLength > _lineLength) {
+      if (wordLength > lineLength) {
         if (lengthSoFar != 0) buffer.writeln();
         if (!firstLine) buffer.write(prefix);
         buffer.writeln(word);
@@ -568,7 +571,7 @@ String wordWrap(String text, {String prefix}) {
         if (!firstLine) buffer.write(prefix);
         buffer.write(word);
         lengthSoFar = wordLength + prefix.length;
-      } else if (lengthSoFar + 1 + wordLength > _lineLength) {
+      } else if (lengthSoFar + 1 + wordLength > lineLength) {
         buffer.writeln();
         buffer.write(prefix);
         buffer.write(word);
@@ -613,8 +616,8 @@ bool equalsIgnoringPreRelease(Version version1, Version version2) =>
 /// [value] are used as the values for the new map.
 Map<K2, V2> mapMap<K1, V1, K2, V2>(
   Map<K1, V1> map, {
-  K2 Function(K1, V1) key,
-  V2 Function(K1, V1) value,
+  K2 Function(K1, V1)? key,
+  V2 Function(K1, V1)? value,
 }) {
   key ??= (mapKey, _) => mapKey as K2;
   value ??= (_, mapValue) => mapValue as V2;

--- a/test/ascii_tree_test.dart
+++ b/test/ascii_tree_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 import 'package:pub/src/ascii_tree.dart' as tree;
 import 'package:test/test.dart';
 

--- a/test/error_group_test.dart
+++ b/test/error_group_test.dart
@@ -2,14 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 import 'dart:async';
 
 import 'package:pub/src/error_group.dart';
 import 'package:test/test.dart';
 
-ErrorGroup errorGroup;
+late ErrorGroup errorGroup;
 
 // TODO(nweiz): once there's a global error handler, we should test that it does
 // and does not get called at appropriate times. See issue 5958.
@@ -43,8 +41,8 @@ void main() {
   });
 
   group('with a single future', () {
-    Completer completer;
-    Future future;
+    late Completer completer;
+    late Future future;
 
     setUp(() {
       errorGroup = ErrorGroup();
@@ -152,10 +150,10 @@ void main() {
   });
 
   group('with multiple futures', () {
-    Completer completer1;
-    Completer completer2;
-    Future future1;
-    Future future2;
+    late Completer completer1;
+    late Completer completer2;
+    late Future future1;
+    late Future future2;
 
     setUp(() {
       errorGroup = ErrorGroup();
@@ -212,8 +210,8 @@ void main() {
   });
 
   group('with a single stream', () {
-    StreamController controller;
-    Stream stream;
+    late StreamController controller;
+    late Stream stream;
 
     setUp(() {
       errorGroup = ErrorGroup();
@@ -289,8 +287,8 @@ void main() {
   });
 
   group('with a single single-subscription stream', () {
-    StreamController controller;
-    Stream stream;
+    late StreamController controller;
+    late Stream stream;
 
     setUp(() {
       errorGroup = ErrorGroup();
@@ -338,10 +336,10 @@ void main() {
   });
 
   group('with multiple streams', () {
-    StreamController controller1;
-    StreamController controller2;
-    Stream stream1;
-    Stream stream2;
+    late StreamController controller1;
+    late StreamController controller2;
+    late Stream stream1;
+    late Stream stream2;
 
     setUp(() {
       errorGroup = ErrorGroup();
@@ -411,10 +409,10 @@ void main() {
   });
 
   group('with a stream and a future', () {
-    StreamController controller;
-    Stream stream;
-    Completer completer;
-    Future future;
+    late StreamController controller;
+    late Stream stream;
+    late Completer completer;
+    late Future future;
 
     setUp(() {
       errorGroup = ErrorGroup();

--- a/test/transcript_test.dart
+++ b/test/transcript_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 import 'package:pub/src/transcript.dart';
 import 'package:test/test.dart';
 

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.10
-
 import 'dart:async';
 
 import 'package:pub/src/utils.dart';


### PR DESCRIPTION
I couldn't stop myself... let's see if tests pass... We should probably move to `package:yaml_edit` and migrate `ignore.dart` next...
After that I think it's going to be hard to identify things we migrate alone.