### PR TITLE
Shorthand syntax for hosted dependencies

### DIFF
--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -655,10 +655,8 @@ class Pubspec {
       VersionConstraint versionConstraint = VersionRange();
       var features = const <String, FeatureDependency>{};
       if (spec == null) {
-        descriptionNode = nameNode;
         sourceName = _sources.defaultSource.name;
       } else if (spec is String) {
-        descriptionNode = nameNode;
         sourceName = _sources.defaultSource.name;
         versionConstraint = _parseVersionConstraint(specNode);
       } else if (spec is Map) {
@@ -682,7 +680,6 @@ class Pubspec {
         } else if (sourceNames.isEmpty) {
           // Default to a hosted dependency if no source is specified.
           sourceName = 'hosted';
-          descriptionNode = nameNode;
         }
 
         sourceName ??= sourceNames.single;

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -821,6 +821,9 @@ class Pubspec {
     try {
       return fn();
     } on FormatException catch (e) {
+      // If we already have a pub exception with a span, re-use that
+      if (e is PubspecException) rethrow;
+
       var msg = 'Invalid $description';
       if (targetPackage != null) {
         msg = '$msg in the "$name" pubspec on the "$targetPackage" dependency';

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -702,7 +702,7 @@ class Pubspec {
         }
 
         return _sources[sourceName].parseRef(name, descriptionNode?.value,
-            containingPath: pubspecPath);
+            containingPath: pubspecPath, languageVersion: languageVersion);
       }, targetPackage: name);
 
       dependencies[name] =

--- a/lib/src/source.dart
+++ b/lib/src/source.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'package:pub_semver/pub_semver.dart';
 
 import 'exceptions.dart';
+import 'language_version.dart';
 import 'package_name.dart';
 import 'pubspec.dart';
 import 'system_cache.dart';
@@ -84,11 +85,16 @@ abstract class Source {
   /// appears. It may be `null` if the description is coming from some in-memory
   /// source (such as pulling down a pubspec from pub.dartlang.org).
   ///
+  /// [languageVersion] is the minimum Dart version parsed from the pubspec's
+  /// `environment` field. Source implementations may use this parameter to only
+  /// support specific syntax for some versions.
+  ///
   /// The description in the returned [PackageRef] need bear no resemblance to
   /// the original user-provided description.
   ///
   /// Throws a [FormatException] if the description is not valid.
-  PackageRef parseRef(String name, description, {String containingPath});
+  PackageRef parseRef(String name, description,
+      {String containingPath, LanguageVersion languageVersion});
 
   /// Parses a [PackageId] from a name and a serialized description.
   ///

--- a/lib/src/source.dart
+++ b/lib/src/source.dart
@@ -77,6 +77,8 @@ abstract class Source {
   /// should be interpreted. This will be called during parsing to validate that
   /// the given [description] is well-formed according to this source, and to
   /// give the source a chance to canonicalize the description.
+  /// For simple hosted dependencies like `foo:` or `foo: ^1.2.3`, the
+  /// [description] may also be `null`.
   ///
   /// [containingPath] is the path to the pubspec where this description
   /// appears. It may be `null` if the description is coming from some in-memory

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -13,6 +13,7 @@ import 'package:pub_semver/pub_semver.dart';
 
 import '../git.dart' as git;
 import '../io.dart';
+import '../language_version.dart';
 import '../log.dart' as log;
 import '../package.dart';
 import '../package_name.dart';
@@ -44,7 +45,8 @@ class GitSource extends Source {
   }
 
   @override
-  PackageRef parseRef(String name, description, {String containingPath}) {
+  PackageRef parseRef(String name, description,
+      {String containingPath, LanguageVersion languageVersion}) {
     dynamic url;
     dynamic ref;
     dynamic path;

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -173,15 +173,14 @@ class HostedSource extends Source {
   /// Ensures that [description] is a valid hosted package description.
   ///
   /// Simple hosted dependencies only consist of a plain string, which is
-  /// resolved against the default host.
+  /// resolved against the default host. In this case, [description] will be
+  /// null.
   ///
   /// Hosted dependencies may also specify a custom host from which the package
-  /// is fetched.
-  /// TODO
+  /// is fetched. There are two syntactic forms of those dependencies:
   ///
-  /// There are two valid formats. A plain string refers to a package with the
-  /// given name from the default host, while a map with keys "name" and "url"
-  /// refers to a package with the given name from the host at the given URL.
+  ///  1. With an url and an optional name in a map: `hosted: {url: <url>}`
+  ///  2. With a direct url: `hosted: <url>`
   @override
   PackageRef parseRef(String name, description,
       {String containingPath, LanguageVersion languageVersion}) {

--- a/lib/src/source/path.dart
+++ b/lib/src/source/path.dart
@@ -11,6 +11,7 @@ import 'package:pub_semver/pub_semver.dart';
 
 import '../exceptions.dart';
 import '../io.dart';
+import '../language_version.dart';
 import '../package_name.dart';
 import '../pubspec.dart';
 import '../source.dart';
@@ -64,7 +65,8 @@ class PathSource extends Source {
   /// original path but resolved relative to the containing path. The
   /// "relative" key will be `true` if the original path was relative.
   @override
-  PackageRef parseRef(String name, description, {String containingPath}) {
+  PackageRef parseRef(String name, description,
+      {String containingPath, LanguageVersion languageVersion}) {
     if (description is! String) {
       throw FormatException('The description must be a path string.');
     }

--- a/lib/src/source/sdk.dart
+++ b/lib/src/source/sdk.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../exceptions.dart';
+import '../language_version.dart';
 import '../package_name.dart';
 import '../pubspec.dart';
 import '../sdk.dart';
@@ -35,7 +36,8 @@ class SdkSource extends Source {
 
   /// Parses an SDK dependency.
   @override
-  PackageRef parseRef(String name, description, {String containingPath}) {
+  PackageRef parseRef(String name, description,
+      {String containingPath, LanguageVersion languageVersion}) {
     if (description is! String) {
       throw FormatException('The description must be an SDK name.');
     }

--- a/lib/src/source/unknown.dart
+++ b/lib/src/source/unknown.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 
 import 'package:pub_semver/pub_semver.dart';
 
+import '../language_version.dart';
 import '../package_name.dart';
 import '../pubspec.dart';
 import '../source.dart';
@@ -44,7 +45,8 @@ class UnknownSource extends Source {
   int hashDescription(description) => description.hashCode;
 
   @override
-  PackageRef parseRef(String name, description, {String containingPath}) =>
+  PackageRef parseRef(String name, description,
+          {String containingPath, LanguageVersion languageVersion}) =>
       PackageRef(name, this, description);
 
   @override

--- a/test/lock_file_test.dart
+++ b/test/lock_file_test.dart
@@ -4,6 +4,7 @@
 
 // @dart=2.10
 
+import 'package:pub/src/language_version.dart';
 import 'package:pub/src/lock_file.dart';
 import 'package:pub/src/package_name.dart';
 import 'package:pub/src/source.dart';
@@ -22,7 +23,8 @@ class FakeSource extends Source {
       throw UnsupportedError('Cannot download fake packages.');
 
   @override
-  PackageRef parseRef(String name, description, {String containingPath}) {
+  PackageRef parseRef(String name, description,
+      {String containingPath, LanguageVersion languageVersion}) {
     if (!description.endsWith(' desc')) throw FormatException('Bad');
     return PackageRef(name, this, description);
   }

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -365,6 +365,28 @@ dependencies:
         });
       });
 
+      test(
+        'reports helpful span when using new syntax with invalid environment',
+        () {
+          var pubspec = Pubspec.parse('''
+name: pkg
+environment:
+  sdk: invalid value
+dependencies:
+  foo:
+    hosted: https://example.org/pub/
+''', sources);
+
+          expect(
+            () => pubspec.dependencies,
+            throwsA(
+              isA<PubspecException>()
+                  .having((e) => e.span.text, 'span.text', 'invalid value'),
+            ),
+          );
+        },
+      );
+
       test('without a description', () {
         var pubspec = Pubspec.parse(
           '''

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -8,6 +8,7 @@ import 'package:pub/src/package_name.dart';
 import 'package:pub/src/pubspec.dart';
 import 'package:pub/src/sdk.dart';
 import 'package:pub/src/source.dart';
+import 'package:pub/src/source/hosted.dart';
 import 'package:pub/src/source_registry.dart';
 import 'package:pub/src/system_cache.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -292,6 +293,90 @@ dependencies:
           'Invalid description in the "pkg" pubspec on the "from_path" '
               'dependency: "non_local_path" is a relative path, but this isn\'t a '
               'local pubspec.');
+    });
+
+    group('source dependencies', () {
+      test('with url and name', () {
+        var pubspec = Pubspec.parse(
+          '''
+name: pkg
+dependencies:
+  foo:
+    hosted:
+      url: https://example.org/pub/
+      name: bar
+''',
+          sources,
+        );
+
+        var foo = pubspec.dependencies['foo'];
+        expect(foo.name, equals('foo'));
+        expect(foo.source, isA<HostedSource>());
+        expect(foo.source.serializeDescription(null, foo.description), {
+          'url': 'https://example.org/pub/',
+          'name': 'bar',
+        });
+      });
+
+      test('with url only', () {
+        var pubspec = Pubspec.parse(
+          '''
+name: pkg
+dependencies:
+  foo:
+    hosted:
+      url: https://example.org/pub/
+''',
+          sources,
+        );
+
+        var foo = pubspec.dependencies['foo'];
+        expect(foo.name, equals('foo'));
+        expect(foo.source, isA<HostedSource>());
+        expect(foo.source.serializeDescription(null, foo.description), {
+          'url': 'https://example.org/pub/',
+          'name': 'foo',
+        });
+      });
+
+      test('with url as string', () {
+        var pubspec = Pubspec.parse(
+          '''
+name: pkg
+dependencies:
+  foo:
+    hosted: https://example.org/pub/
+''',
+          sources,
+        );
+
+        var foo = pubspec.dependencies['foo'];
+        expect(foo.name, equals('foo'));
+        expect(foo.source, isA<HostedSource>());
+        expect(foo.source.serializeDescription(null, foo.description), {
+          'url': 'https://example.org/pub/',
+          'name': 'foo',
+        });
+      });
+
+      test('without a description', () {
+        var pubspec = Pubspec.parse(
+          '''
+name: pkg
+dependencies:
+  foo:
+''',
+          sources,
+        );
+
+        var foo = pubspec.dependencies['foo'];
+        expect(foo.name, equals('foo'));
+        expect(foo.source, isA<HostedSource>());
+        expect(foo.source.serializeDescription(null, foo.description), {
+          'url': 'https://pub.dartlang.org',
+          'name': 'foo',
+        });
+      });
     });
 
     group('git dependencies', () {


### PR DESCRIPTION
- Support two shorthand forms of non-default hosted dependencies:
  - by omitting its name: `foo: {hosted: {url: <url>}}`
  - by using a URL directly: `foo: {hosted: <url>}`
- Only allow the new syntax when adding a min SDK constraint of `2.15`

Closes #1806.