### PR TITLE
Fix analyze errors

### DIFF
--- a/lib/src/feature.dart
+++ b/lib/src/feature.dart
@@ -4,8 +4,6 @@
 
 // @dart=2.10
 
-import 'dart:collection';
-
 import 'package:collection/collection.dart';
 import 'package:pub_semver/pub_semver.dart';
 

--- a/lib/src/lock_file.dart
+++ b/lib/src/lock_file.dart
@@ -4,7 +4,6 @@
 
 // @dart=2.10
 
-import 'dart:collection';
 import 'dart:convert';
 
 import 'package:collection/collection.dart' hide mapMap;

--- a/lib/src/pub_embeddable_command.dart
+++ b/lib/src/pub_embeddable_command.dart
@@ -5,7 +5,6 @@
 // @dart=2.10
 
 import 'command.dart';
-import 'command.dart' show PubCommand;
 import 'command/add.dart';
 import 'command/build.dart';
 import 'command/cache.dart';


### PR DESCRIPTION
Fixes analyzer warnings that causes CI pipeline to fail:

```
Run dart analyze --fatal-infos
Analyzing pub...

   info - lib/src/feature.dart:7:8 - The import of 'dart:collection' is unnecessary as all of the used elements are also provided by the import of 'package:collection/collection.dart'. Try removing the import directive. - unnecessary_import
   info - lib/src/lock_file.dart:7:8 - The import of 'dart:collection' is unnecessary as all of the used elements are also provided by the import of 'package:collection/collection.dart'. Try removing the import directive. - unnecessary_import
   info - lib/src/pub_embeddable_command.dart:8:8 - The import of 'command.dart' is unnecessary as all of the used elements are also provided by the import of 'command.dart'. Try removing the import directive. - unnecessary_import

3 issues found.
Error: Process completed with exit code 1.
```