### PR TITLE
Use source.hasMultipleVersions to decide when to show version constraint.

### DIFF
--- a/lib/src/package_name.dart
+++ b/lib/src/package_name.dart
@@ -9,9 +9,7 @@ import 'package:pub_semver/pub_semver.dart';
 
 import 'package.dart';
 import 'source.dart';
-import 'source/git.dart';
 import 'source/hosted.dart';
-import 'source/path.dart';
 import 'utils.dart';
 
 /// The equality to use when comparing the feature sets of two package names.
@@ -246,9 +244,7 @@ class PackageRange extends PackageName {
   bool get _showVersionConstraint {
     if (isRoot) return false;
     if (!constraint.isAny) return true;
-    if (source is PathSource) return false;
-    if (source is GitSource) return false;
-    return true;
+    return source.hasMultipleVersions;
   }
 
   /// Returns a new [PackageRange] with [features] merged with [this.features].

--- a/test/sdk_test.dart
+++ b/test/sdk_test.dart
@@ -120,7 +120,7 @@ void main() {
           'foo': {'sdk': 'unknown'}
         }).create();
         await pubCommand(command, error: equalsIgnoringWhitespace("""
-              Because myapp depends on foo any from sdk which doesn't exist
+              Because myapp depends on foo from sdk which doesn't exist
                 (unknown SDK "unknown"), version solving failed.
             """), exitCode: exit_codes.UNAVAILABLE);
       });
@@ -130,7 +130,7 @@ void main() {
           'foo': {'sdk': 'flutter'}
         }).create();
         await pubCommand(command, error: equalsIgnoringWhitespace("""
-              Because myapp depends on foo any from sdk which doesn't exist (the
+              Because myapp depends on foo from sdk which doesn't exist (the
                 Flutter SDK is not available), version solving failed.
 
               Flutter users should run `flutter pub get` instead of `dart pub
@@ -145,7 +145,7 @@ void main() {
         await pubCommand(command,
             environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')},
             error: equalsIgnoringWhitespace("""
-              Because myapp depends on bar any from sdk which doesn't exist
+              Because myapp depends on bar from sdk which doesn't exist
                 (could not find package bar in the Flutter SDK), version solving
                 failed.
             """),
@@ -157,7 +157,7 @@ void main() {
           'bar': {'sdk': 'dart'}
         }).create();
         await pubCommand(command, error: equalsIgnoringWhitespace("""
-              Because myapp depends on bar any from sdk which doesn't exist
+              Because myapp depends on bar from sdk which doesn't exist
                 (could not find package bar in the Dart SDK), version solving
                 failed.
             """), exitCode: exit_codes.UNAVAILABLE);

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -636,12 +636,12 @@ void badSource() {
     await expectResolves(error: equalsIgnoringWhitespace('''
       Because foo <1.0.1 depends on bar from unknown source "bad", foo <1.0.1 is
         forbidden.
-      And because foo >=1.0.1 <1.0.2 depends on baz any from bad, foo <1.0.2
-        requires baz any from bad.
+      And because foo >=1.0.1 <1.0.2 depends on baz from bad, foo <1.0.2
+        requires baz from bad.
       And because baz comes from unknown source "bad" and foo >=1.0.2 depends on
-        bang any from bad, every version of foo requires bang any from bad.
-      So, because bang comes from unknown source "bad" and myapp depends on foo
-        any, version solving failed.
+        bang from bad, every version of foo requires bang from bad.
+      So, because bang comes from unknown source "bad" and myapp depends on foo,
+        version solving failed.
     '''), tries: 3);
   });
 

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -640,7 +640,7 @@ void badSource() {
         requires baz from bad.
       And because baz comes from unknown source "bad" and foo >=1.0.2 depends on
         bang from bad, every version of foo requires bang from bad.
-      So, because bang comes from unknown source "bad" and myapp depends on foo,
+      So, because bang comes from unknown source "bad" and myapp depends on foo any,
         version solving failed.
     '''), tries: 3);
   });


### PR DESCRIPTION
- reduces cross-linking a slight bit
- future-proofing new sources