### PR TITLE
Don't ignore 'packages/' over the root-dir

### DIFF
--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -279,7 +279,7 @@ class Package {
             : (fileExists(gitIgnore) ? gitIgnore : null);
 
         final rules = [
-          if (dir == '.') ..._basicIgnoreRules,
+          if (dir == beneath) ..._basicIgnoreRules,
           if (ignoreFile != null) readTextFile(ignoreFile),
         ];
         return rules.isEmpty

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -254,6 +254,23 @@ void main() {
       });
     });
 
+    test("Don't ignore packages/ before the package root", () async {
+      await d.dir(appPath, [
+        d.dir('packages', [
+          d.dir('app', [
+            d.appPubspec(),
+            d.dir('packages', [d.file('a.txt')]),
+          ]),
+        ]),
+      ]).create();
+
+      createEntrypoint(p.join(appPath, 'packages', 'app'));
+
+      expect(entrypoint.root.listFiles(), {
+        p.join(root, 'pubspec.yaml'),
+      });
+    });
+
     group('with a submodule', () {
       setUp(() async {
         await d.git('submodule', [


### PR DESCRIPTION
Fixes:  https://github.com/dart-lang/pub/issues/3152

The issue was that we have a legacy ignore rule (always ignore folders named `packages`. After we started interpreting gitignores from the git-root we would no longer venture into `packages/url_launcher` at all.

We should consider if we want to keep the legacy rule. Dart has not created packages/ for a loong time - and it is a pretty generic name bound to come up somewhere else.