### PR TITLE
Handle build-versions when reformatting ranges

### DIFF
--- a/lib/src/solver/reformat_ranges.dart
+++ b/lib/src/solver/reformat_ranges.dart
@@ -88,6 +88,7 @@ Pair<Version, bool> _reformatMax(List<PackageId> versions, VersionRange range) {
   if (range.max == null) return null;
   if (range.includeMax) return null;
   if (range.max.isPreRelease) return null;
+  if (range.max.build.isNotEmpty) return null;
   if (range.min != null &&
       range.min.isPreRelease &&
       equalsIgnoringPreRelease(range.min, range.max)) {

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -31,6 +31,8 @@ void main() {
   group('override', override);
   group('downgrade', downgrade);
   group('features', features, skip: true);
+
+  group('regressions', regressions);
 }
 
 void basicGraph() {
@@ -3013,4 +3015,23 @@ Future expectResolves(
   }
 
   expect(ids, isEmpty, reason: 'Expected no additional packages.');
+}
+
+void regressions() {
+  test('reformatRanges with a build', () async {
+    await servePackages((b) {
+      b.serve('integration_test', '1.0.1',
+          deps: {'vm_service': '>= 4.2.0 <6.0.0'});
+      b.serve('integration_test', '1.0.2+2',
+          deps: {'vm_service': '>= 4.2.0 <7.0.0'});
+
+      b.serve('vm_service', '7.3.0');
+    });
+    await d.appDir({'integration_test': '^1.0.2'}).create();
+    await expectResolves(
+      error: contains(
+        'Because no versions of integration_test match >=1.0.2 <1.0.2+2',
+      ),
+    );
+  });
 }


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub/issues/3098
This brings the logic of reformat_ranges in line with the special logic in pub_semver's VersionRange at: https://github.com/dart-lang/pub_semver/blob/master/lib/src/version_range.dart#L75 . That logic was fixed in https://github.com/dart-lang/pub_semver/commit/ffdf9fe2af6e279310ccf4bfa96040b04e58d313 but never fixed here.
