### PR TITLE
Rename timing category

### DIFF
--- a/lib/src/solver/result.dart
+++ b/lib/src/solver/result.dart
@@ -168,10 +168,10 @@ class SolveResult {
     analytics.sendTiming(
       'resolution',
       resolutionTime.inMilliseconds,
-      category: 'pub-get',
+      category: 'pubget',
     );
     log.fine(
-        'Sending analytics timing "pub-get" took ${resolutionTime.inMilliseconds} miliseconds');
+        'Sending analytics timing "pub get" took ${resolutionTime.inMilliseconds} miliseconds');
   }
 
   @override

--- a/test/embedding/embedding_test.dart
+++ b/test/embedding/embedding_test.dart
@@ -172,7 +172,7 @@ main() {
         'message': {
           'variableName': 'resolution',
           'time': isA<int>(),
-          'category': 'pub-get',
+          'category': 'pubget',
           'label': null
         }
       },


### PR DESCRIPTION
It seems the dash prevents the timings from showing up in the UI.