### PR TITLE
Gitignore validator should not follow symlink dirs

### DIFF
--- a/lib/src/validator/gitignore.dart
+++ b/lib/src/validator/gitignore.dart
@@ -46,8 +46,10 @@ class GitignoreValidator extends Validator {
         beneath: beneath,
         listDir: (dir) {
           var contents = Directory(resolve(dir)).listSync();
-          return contents.map((entity) =>
-              p.posix.joinAll(p.split(p.relative(entity.path, from: root))));
+          return contents
+              .where((e) => !(e is Link && dirExists(e.targetSync())))
+              .map((entity) => p.posix
+                  .joinAll(p.split(p.relative(entity.path, from: root))));
         },
         ignoreForDir: (dir) {
           final gitIgnore = resolve('$dir/.gitignore');

--- a/lib/src/validator/gitignore.dart
+++ b/lib/src/validator/gitignore.dart
@@ -47,7 +47,7 @@ class GitignoreValidator extends Validator {
         listDir: (dir) {
           var contents = Directory(resolve(dir)).listSync();
           return contents
-              .where((e) => !(e is Link && dirExists(e.targetSync())))
+              .where((e) => !(linkExists(e.path) && dirExists(e.path)))
               .map((entity) => p.posix
                   .joinAll(p.split(p.relative(entity.path, from: root))));
         },

--- a/test/validator/gitignore_test.dart
+++ b/test/validator/gitignore_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:test/test.dart';
@@ -80,6 +82,24 @@ void main() {
               'Consider adjusting your `.gitignore` files to not ignore those files'),
         ]),
         exit_codes.DATA,
+        workingDirectory: packageRoot);
+  });
+
+  test('Should not follow symlinks', () async {
+    await d.git('myapp', [
+      ...d.validPackage.contents,
+    ]).create();
+    final packageRoot = p.join(d.sandbox, 'myapp');
+    await pubGet(
+        environment: {'_PUB_TEST_SDK_VERSION': '1.12.0'},
+        workingDirectory: packageRoot);
+
+    Link(p.join(packageRoot, '.abc', 'itself')).createSync(
+      packageRoot,
+      recursive: true,
+    );
+
+    await expectValidation(contains('Package has 0 warnings.'), 0,
         workingDirectory: packageRoot);
   });
 }


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub/issues/3172 