### PR TITLE
Refactor notices/hints for solver conflicts.

### DIFF
--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -11,7 +11,6 @@ import 'package:stack_trace/stack_trace.dart';
 import 'package:yaml/yaml.dart';
 
 import 'dart.dart';
-import 'sdk.dart';
 
 /// An exception class for exceptions that are intended to be seen by the user.
 ///
@@ -89,14 +88,16 @@ class ConfigException extends ApplicationException {
 /// that other code in pub can use this to show a more detailed explanation of
 /// why the package was being requested.
 class PackageNotFoundException extends WrappedException {
-  /// If this failure was caused by an SDK being unavailable, this is that SDK.
-  final Sdk? missingSdk;
+  /// A hint indicating an action the user could take to resolve this problem.
+  ///
+  /// This will be printed after the package resolution conflict.
+  final String? hint;
 
   PackageNotFoundException(
     String message, {
     Object? innerError,
     StackTrace? innerTrace,
-    this.missingSdk,
+    this.hint,
   }) : super(message, innerError, innerTrace);
 
   @override

--- a/lib/src/solver/failure.dart
+++ b/lib/src/solver/failure.dart
@@ -7,7 +7,6 @@ import 'package:collection/collection.dart';
 import '../exceptions.dart';
 import '../log.dart' as log;
 import '../package_name.dart';
-import '../sdk.dart';
 import '../utils.dart';
 import 'incompatibility.dart';
 import 'incompatibility_cause.dart';
@@ -93,39 +92,22 @@ class _Writer {
   String write() {
     var buffer = StringBuffer();
 
-    // SDKs whose version constraints weren't matched.
-    var sdkConstraintCauses = <Sdk>{};
-
-    // SDKs implicated in any way in the solve failure.
-    var sdkCauses = <Sdk>{};
-
-    for (var incompatibility in _root.externalIncompatibilities) {
-      var cause = incompatibility.cause;
-      if (cause is PackageNotFoundCause) {
-        var sdk = cause.sdk;
-        if (sdk != null) {
-          sdkCauses.add(sdk);
-        }
-      } else if (cause is SdkCause) {
-        sdkCauses.add(cause.sdk);
-        sdkConstraintCauses.add(cause.sdk);
-      }
-    }
-
     // If the failure was caused in part by unsatisfied SDK constraints,
     // indicate the actual versions so we don't have to list them (possibly
     // multiple times) in the main body of the error message.
     //
     // Iterate through [sdks] to ensure that SDKs versions are printed in a
     // consistent order
-    var wroteLine = false;
-    for (var sdk in sdks.values) {
-      if (!sdkConstraintCauses.contains(sdk)) continue;
-      if (!sdk.isAvailable) continue;
-      wroteLine = true;
-      buffer.writeln('The current ${sdk.name} SDK version is ${sdk.version}.');
+    final notices = _root.externalIncompatibilities
+        .where((c) => c.cause.notice != null)
+        .map((c) => c.cause.notice)
+        .whereNotNull()
+        .toSet()
+        .sortedBy((n) => n);
+    for (final n in notices) {
+      buffer.writeln(n);
     }
-    if (wroteLine) buffer.writeln();
+    if (notices.isNotEmpty) buffer.writeln();
 
     if (_root.cause is ConflictCause) {
       _visit(_root, const {});
@@ -159,15 +141,22 @@ class _Writer {
       buffer.writeln(wordWrap(message, prefix: ' ' * (padding + 2)));
     }
 
-    // Iterate through [sdks] to ensure that SDKs versions are printed in a
-    // consistent order
-    for (var sdk in sdks.values) {
-      if (!sdkCauses.contains(sdk)) continue;
-      if (sdk.isAvailable) continue;
-      if (sdk.installMessage == null) continue;
+    // Iterate through all hints, these are intended to be actionable, such as:
+    //  * How to install an SDK, and,
+    //  * How to provide authentication.
+    // Hence, it makes sense to show these at the end of the explanation, as the
+    // user will ideally see these before reading the actual conflict and
+    // understand how to fix the issue.
+    _root.externalIncompatibilities
+        .where((c) => c.cause.hint != null)
+        .map((c) => c.cause.hint)
+        .whereNotNull()
+        .toSet()
+        .sortedBy((hint) => hint) // sort hints for consistent ordering.
+        .forEach((hint) {
       buffer.writeln();
-      buffer.writeln(sdk.installMessage);
-    }
+      buffer.writeln(hint);
+    });
 
     return buffer.toString();
   }

--- a/lib/src/solver/incompatibility_cause.dart
+++ b/lib/src/solver/incompatibility_cause.dart
@@ -10,6 +10,8 @@ import 'incompatibility.dart';
 
 /// The reason an [Incompatibility]'s terms are incompatible.
 abstract class IncompatibilityCause {
+  const IncompatibilityCause._();
+
   /// The incompatibility represents the requirement that the root package
   /// exists.
   static const IncompatibilityCause root = _Cause('root');
@@ -27,11 +29,26 @@ abstract class IncompatibilityCause {
 
   /// The incompatibility indicates that the package has an unknown source.
   static const IncompatibilityCause unknownSource = _Cause('unknown source');
+
+  /// Human readable notice / information providing context for this
+  /// incompatibility.
+  ///
+  /// This may be multiple lines, and will be printed before the explanation.
+  /// This is used highlight information that is useful for understanding the
+  /// why this conflict happened.
+  String? get notice => null;
+
+  /// Human readable hint indicating how this incompatibility may be resolved.
+  ///
+  /// This may be multiple lines, and will be printed after the explanation.
+  /// This should only be included if it is actionable and likely to resolve the
+  /// issue for the user.
+  String? get hint => null;
 }
 
 /// The incompatibility was derived from two existing incompatibilities during
 /// conflict resolution.
-class ConflictCause implements IncompatibilityCause {
+class ConflictCause extends IncompatibilityCause {
   /// The incompatibility that was originally found to be in conflict, from
   /// which the target incompatibility was derived.
   final Incompatibility conflict;
@@ -40,14 +57,14 @@ class ConflictCause implements IncompatibilityCause {
   /// from which the target incompatibility was derived.
   final Incompatibility other;
 
-  ConflictCause(this.conflict, this.other);
+  ConflictCause(this.conflict, this.other) : super._();
 }
 
 /// A class for stateless [IncompatibilityCause]s.
-class _Cause implements IncompatibilityCause {
+class _Cause extends IncompatibilityCause {
   final String _name;
 
-  const _Cause(this._name);
+  const _Cause(this._name) : super._();
 
   @override
   String toString() => _name;
@@ -55,7 +72,7 @@ class _Cause implements IncompatibilityCause {
 
 /// The incompatibility represents a package's SDK constraint being
 /// incompatible with the current SDK.
-class SdkCause implements IncompatibilityCause {
+class SdkCause extends IncompatibilityCause {
   /// The union of all the incompatible versions' constraints on the SDK.
   // TODO(zarah): Investigate if this can be non-nullable
   final VersionConstraint? constraint;
@@ -63,20 +80,41 @@ class SdkCause implements IncompatibilityCause {
   /// The SDK with which the package was incompatible.
   final Sdk sdk;
 
-  SdkCause(this.constraint, this.sdk);
+  @override
+  String? get notice {
+    // If the SDK is not available, then we have an actionable [hint] printed
+    // after the explanation. So we don't need to state that the SDK is not
+    // available.
+    if (!sdk.isAvailable) {
+      return null;
+    }
+    // If the SDK is available and we have an incompatibility, then the user has
+    // the wrong SDK version (one that is not compatible with any solution).
+    // Thus, it makes sense to highlight the current SDK version.
+    return 'The current ${sdk.name} SDK version is ${sdk.version}.';
+  }
+
+  @override
+  String? get hint {
+    // If the SDK is available, then installing it won't help
+    if (sdk.isAvailable) {
+      return null;
+    }
+    // Return an install message for the SDK, if there is an install message.
+    return sdk.installMessage;
+  }
+
+  SdkCause(this.constraint, this.sdk) : super._();
 }
 
 /// The incompatibility represents a package that couldn't be found by its
 /// source.
-class PackageNotFoundCause implements IncompatibilityCause {
+class PackageNotFoundCause extends IncompatibilityCause {
   /// The exception indicating why the package couldn't be found.
   final PackageNotFoundException exception;
 
-  /// If the incompatibility was caused by an SDK being unavailable, this is
-  /// that SDK.
-  ///
-  /// Otherwise `null`.
-  Sdk? get sdk => exception.missingSdk;
+  PackageNotFoundCause(this.exception) : super._();
 
-  PackageNotFoundCause(this.exception);
+  @override
+  String? get hint => exception.hint;
 }

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -970,7 +970,9 @@ class _OfflineHostedSource extends BoundHostedSource {
     // If there are no versions in the cache, report a clearer error.
     if (versions.isEmpty) {
       throw PackageNotFoundException(
-          'could not find package ${ref.name} in cache');
+        'could not find package ${ref.name} in cache',
+        hint: 'Try again without --offline!',
+      );
     }
 
     return versions;
@@ -986,7 +988,9 @@ class _OfflineHostedSource extends BoundHostedSource {
   @override
   Future<Pubspec> describeUncached(PackageId id) {
     throw PackageNotFoundException(
-        '${id.name} ${id.version} is not available in your system cache');
+      '${id.name} ${id.version} is not available in cache',
+      hint: 'Try again without --offline!',
+    );
   }
 
   @override

--- a/lib/src/source/sdk.dart
+++ b/lib/src/source/sdk.dart
@@ -101,8 +101,10 @@ class BoundSdkSource extends BoundSource {
     if (sdk == null) {
       throw PackageNotFoundException('unknown SDK "$identifier"');
     } else if (!sdk.isAvailable) {
-      throw PackageNotFoundException('the ${sdk.name} SDK is not available',
-          missingSdk: sdk);
+      throw PackageNotFoundException(
+        'the ${sdk.name} SDK is not available',
+        hint: sdk.installMessage,
+      );
     }
 
     var path = sdk.packagePath(package.name);

--- a/test/hosted/offline_test.dart
+++ b/test/hosted/offline_test.dart
@@ -82,6 +82,8 @@ void main() {
           error: equalsIgnoringWhitespace("""
             Because myapp depends on foo any which doesn't exist (could not find
               package foo in cache), version solving failed.
+
+            Try again without --offline!
           """));
     });
 
@@ -118,6 +120,8 @@ void main() {
           error: equalsIgnoringWhitespace("""
             Because myapp depends on foo any which doesn't exist (could not find
               package foo in cache), version solving failed.
+
+            Try again without --offline!
           """));
     });
 

--- a/test/package_config_file_test.dart
+++ b/test/package_config_file_test.dart
@@ -119,6 +119,8 @@ void main() {
           args: ['--offline'], error: equalsIgnoringWhitespace("""
             Because myapp depends on foo any which doesn't exist (could not find
               package foo in cache), version solving failed.
+
+            Try again without --offline!
           """), exitCode: exit_codes.UNAVAILABLE);
 
       await d.dir(appPath, [

--- a/test/packages_file_test.dart
+++ b/test/packages_file_test.dart
@@ -73,6 +73,8 @@ void main() {
           args: ['--offline'], error: equalsIgnoringWhitespace("""
             Because myapp depends on foo any which doesn't exist (could not find
               package foo in cache), version solving failed.
+
+            Try again without --offline!
           """), exitCode: exit_codes.UNAVAILABLE);
 
       await d.dir(appPath, [d.nothing('.packages')]).validate();


### PR DESCRIPTION
Untangled a lot of type assertions and digging into details of the
incompatibility when printing the incompatibility. Notably, we introduce
a concept of notices and hints.

Notices are messages that an `IncompatibilityCause` can have, they are
human readable messages printed before the incompatibility explanation.
This allows `SdkCause` to point out the current version of an SDK that
is causing a conflict (if the SDK is available).

Hints are messages that an `IncompatibilityCause` can have, they are
human readable message with actionable hints to be printed after the
incompatibility explanation. This allows `PackageNotFoundCause` to hint
that trying without `--offline` might work.

Hints are printed after the incompatibility explanation because they
actionable, they don't serve to explain what went wrong. They are
intended to be actionable, hence, it's preferable the user sees these as
one of the first things.


------------------------

This is an initial step to being able to improve the errors that results from things like missing credentials, etc..