### PR TITLE
Support publishing to a hosted-url with a /path

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -91,7 +91,7 @@ class LishCommand extends PubCommand {
 
     try {
       await log.progress('Uploading', () async {
-        var newUri = server.resolve('/api/packages/versions/new');
+        var newUri = server.resolve('api/packages/versions/new');
         var response = await client.get(newUri, headers: pubApiHeaders);
         var parameters = parseJsonResponse(response);
 

--- a/test/lish/upload_form_fields_has_a_non_string_value_test.dart
+++ b/test/lish/upload_form_fields_has_a_non_string_value_test.dart
@@ -24,7 +24,7 @@ void main() {
       'url': 'http://example.com/upload',
       'fields': {'field': 12}
     };
-    handleUploadForm(globalServer, body);
+    handleUploadForm(globalServer, body: body);
     expect(pub.stderr, emits('Invalid server response:'));
     expect(pub.stderr, emits(jsonEncode(body)));
     await pub.shouldExit(1);

--- a/test/lish/upload_form_fields_is_not_a_map_test.dart
+++ b/test/lish/upload_form_fields_is_not_a_map_test.dart
@@ -21,7 +21,7 @@ void main() {
     await confirmPublish(pub);
 
     var body = {'url': 'http://example.com/upload', 'fields': 12};
-    handleUploadForm(globalServer, body);
+    handleUploadForm(globalServer, body: body);
     expect(pub.stderr, emits('Invalid server response:'));
     expect(pub.stderr, emits(jsonEncode(body)));
     await pub.shouldExit(1);

--- a/test/lish/upload_form_is_missing_fields_test.dart
+++ b/test/lish/upload_form_is_missing_fields_test.dart
@@ -21,7 +21,7 @@ void main() {
     await confirmPublish(pub);
 
     var body = {'url': 'http://example.com/upload'};
-    handleUploadForm(globalServer, body);
+    handleUploadForm(globalServer, body: body);
     expect(pub.stderr, emits('Invalid server response:'));
     expect(pub.stderr, emits(jsonEncode(body)));
     await pub.shouldExit(1);

--- a/test/lish/upload_form_is_missing_url_test.dart
+++ b/test/lish/upload_form_is_missing_url_test.dart
@@ -24,7 +24,7 @@ void main() {
       'fields': {'field1': 'value1', 'field2': 'value2'}
     };
 
-    handleUploadForm(globalServer, body);
+    handleUploadForm(globalServer, body: body);
     expect(pub.stderr, emits('Invalid server response:'));
     expect(pub.stderr, emits(jsonEncode(body)));
     await pub.shouldExit(1);

--- a/test/lish/upload_form_url_is_not_a_string_test.dart
+++ b/test/lish/upload_form_url_is_not_a_string_test.dart
@@ -25,7 +25,7 @@ void main() {
       'fields': {'field1': 'value1', 'field2': 'value2'}
     };
 
-    handleUploadForm(globalServer, body);
+    handleUploadForm(globalServer, body: body);
     expect(pub.stderr, emits('Invalid server response:'));
     expect(pub.stderr, emits(jsonEncode(body)));
     await pub.shouldExit(1);

--- a/test/lish/utils.dart
+++ b/test/lish/utils.dart
@@ -9,8 +9,8 @@ import 'package:test/test.dart';
 
 import '../test_pub.dart';
 
-void handleUploadForm(PackageServer server, [Map? body]) {
-  server.expect('GET', '/api/packages/versions/new', (request) {
+void handleUploadForm(PackageServer server, {Map? body, String path = ''}) {
+  server.expect('GET', '$path/api/packages/versions/new', (request) {
     expect(
         request.headers, containsPair('authorization', 'Bearer access token'));
 

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -373,11 +373,12 @@ Future<PubProcess> startPublish(
   List<String>? args,
   String authMethod = 'oauth2',
   Map<String, String>? environment,
+  String path = '',
 }) async {
   var tokenEndpoint = Uri.parse(server.url).resolve('/token').toString();
   args = ['lish', ...?args];
   return await startPub(args: args, tokenEndpoint: tokenEndpoint, environment: {
-    'PUB_HOSTED_URL': server.url,
+    'PUB_HOSTED_URL': server.url + path,
     '_PUB_TEST_AUTH_METHOD': authMethod,
     if (environment != null) ...environment,
   });


### PR DESCRIPTION
We had a slash to much when publishing to custom hosted pub servers with a `/path` in the _hosted-url_.

I'm pretty sure that if the URL doesn't have any path segments then it doesn't matter if we do:
 * `server.resolve('/api/packages/versions/new');` (wrong),
 * `server.resolve('api/packages/versions/new');`

So this change should only affect cases where `PUB_HOSTED_URL` or `publish_to` contains path-segments.

------------------------------

This is not the prettiest of tests, but that might be subject for cleanup another day.