### PR TITLE
Avoid race condition for hosted source on package extraction

### DIFF
--- a/lib/src/command/cache_repair.dart
+++ b/lib/src/command/cache_repair.dart
@@ -23,6 +23,8 @@ class CacheRepairCommand extends PubCommand {
 
   @override
   Future<void> runProtected() async {
+    // Delete any eventual temp-files left in the cache.
+    cache.deleteTempDir();
     // Repair every cached source.
     final repairResults = (await Future.wait(
             cache.sources.all.map(cache.source).map((source) async {

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -361,51 +361,52 @@ bool dirExists(String dir) => Directory(dir).existsSync();
 /// when we try to delete or move something while it's being scanned. To
 /// mitigate that, on Windows, this will retry the operation a few times if it
 /// fails.
-void _attempt(String description, void Function() operation) {
+///
+/// For some operations it makes sense to handle ERROR_DIR_NOT_EMPTY
+/// differently. They can passe [ignoreEmptyDir] = `true`.
+void _attempt(String description, void Function() operation,
+    {bool ignoreEmptyDir = false}) {
   if (!Platform.isWindows) {
     operation();
     return;
   }
 
   String? getErrorReason(FileSystemException error) {
+    // ERROR_ACCESS_DENIED
     if (error.osError?.errorCode == 5) {
       return 'access was denied';
     }
 
+    // ERROR_SHARING_VIOLATION
     if (error.osError?.errorCode == 32) {
       return 'it was in use by another process';
     }
 
-    if (error.osError?.errorCode == 145) {
+    // ERROR_DIR_NOT_EMPTY
+    if (!ignoreEmptyDir && error.osError?.errorCode == 145) {
       return 'of dart-lang/sdk#25353';
     }
 
     return null;
   }
 
-  for (var i = 0; i < 2; i++) {
+  for (var i = 0; i < 3; i++) {
     try {
       operation();
-      return;
     } on FileSystemException catch (error) {
       var reason = getErrorReason(error);
       if (reason == null) rethrow;
 
-      log.io('Pub failed to $description because $reason. '
-          'Retrying in 50ms.');
-      sleep(Duration(milliseconds: 50));
+      if (i < 2) {
+        log.io('Pub failed to $description because $reason. '
+            'Retrying in 50ms.');
+        sleep(Duration(milliseconds: 50));
+      } else {
+        fail('Pub failed to $description because $reason.\n'
+            'This may be caused by a virus scanner or having a file\n'
+            'in the directory open in another application.');
+      }
     }
-  }
-
-  try {
-    operation();
-  } on FileSystemException catch (error) {
-    var reason = getErrorReason(error);
-    if (reason == null) rethrow;
-
-    fail('Pub failed to $description because $reason.\n'
-        'This may be caused by a virus scanner or having a file\n'
-        'in the directory open in another application.');
   }
 }
 
@@ -451,14 +452,19 @@ void cleanDir(String dir) {
 void renameDir(String from, String to) {
   _attempt('rename directory', () {
     log.io('Renaming directory $from to $to.');
-    try {
-      Directory(from).renameSync(to);
-    } on IOException {
-      // Ensure that [to] isn't left in an inconsistent state. See issue 12436.
-      if (entryExists(to)) deleteEntry(to);
-      rethrow;
-    }
-  });
+    Directory(from).renameSync(to);
+  }, ignoreEmptyDir: true);
+}
+
+bool isDirectoryNotEmptyException(FileSystemException e) {
+  final errorCode = e.osError?.errorCode;
+  return
+      // https://man7.org/linux/man-pages/man3/errno.3.html
+      (Platform.isLinux && errorCode == 39) ||
+          // https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
+          (Platform.isWindows && errorCode == 145) ||
+          // Seems undocumented, found by observation.
+          (Platform.isMacOS && errorCode == 66);
 }
 
 /// Creates a new symlink at path [symlink] that points to [target].

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -459,11 +459,17 @@ void renameDir(String from, String to) {
 bool isDirectoryNotEmptyException(FileSystemException e) {
   final errorCode = e.osError?.errorCode;
   return
-      // https://man7.org/linux/man-pages/man3/errno.3.html
+      // On Linux rename will fail with ENOTEMPTY if directory exists:
+      // https://man7.org/linux/man-pages/man2/rename.2.html
+      // #define	ENOTEMPTY	39	/* Directory not empty */
+      // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/asm-generic/errno.h#n20
       (Platform.isLinux && errorCode == 39) ||
+          // On Windows this may fail with ERROR_DIR_NOT_EMPTY
           // https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
           (Platform.isWindows && errorCode == 145) ||
-          // Seems undocumented, found by observation.
+          // On MacOS rename will fail with ENOTEMPTY if directory exists.
+          // #define ENOTEMPTY       66              /* Directory not empty */
+          // https://github.com/apple-oss-distributions/xnu/blob/bb611c8fecc755a0d8e56e2fa51513527c5b7a0e/bsd/sys/errno.h#L190
           (Platform.isMacOS && errorCode == 66);
 }
 

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -363,7 +363,7 @@ bool dirExists(String dir) => Directory(dir).existsSync();
 /// fails.
 ///
 /// For some operations it makes sense to handle ERROR_DIR_NOT_EMPTY
-/// differently. They can passe [ignoreEmptyDir] = `true`.
+/// differently. They can pass [ignoreEmptyDir] = `true`.
 void _attempt(String description, void Function() operation,
     {bool ignoreEmptyDir = false}) {
   if (!Platform.isWindows) {

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -383,7 +383,7 @@ void _attempt(String description, void Function() operation,
     }
 
     // ERROR_DIR_NOT_EMPTY
-    if (!ignoreEmptyDir && error.osError?.errorCode == 145) {
+    if (!ignoreEmptyDir && isDirectoryNotEmptyException(error)) {
       return 'of dart-lang/sdk#25353';
     }
 

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -393,6 +393,7 @@ void _attempt(String description, void Function() operation,
   for (var i = 0; i < 3; i++) {
     try {
       operation();
+      break;
     } on FileSystemException catch (error) {
       var reason = getErrorReason(error);
       if (reason == null) rethrow;

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -820,10 +820,11 @@ class BoundHostedSource extends CachedSource {
       // another pub process has installed the same package version while we
       // downloaded.
       try {
+        log.fine(// Do not land.
+            '!!!pub cache: ${tree.fromFiles(io.Directory(systemCache.rootDir).listSync(recursive: true).map((e) => e.path).toList(), showAllChildren: true)}');
+
         renameDir(tempDir, destPath);
       } on io.FileSystemException catch (e) {
-        log.error(// Do not land.
-            '!!!pub cache: ${tree.fromFiles(listDir(systemCache.rootDir, recursive: true, includeHidden: true), showAllChildren: true)}');
         tryDeleteEntry(tempDir);
         if (!isDirectoryNotEmptyException(e)) {
           rethrow;

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -705,6 +705,7 @@ class BoundHostedSource extends CachedSource {
           packages.map((package) async {
             var id = source.idFor(package.name, package.version, url: url);
             try {
+              deleteEntry(package.dir);
               await _download(id, package.dir);
               return RepairResult(id, success: true);
             } catch (error, stackTrace) {
@@ -820,9 +821,6 @@ class BoundHostedSource extends CachedSource {
       // another pub process has installed the same package version while we
       // downloaded.
       try {
-        log.fine(// Do not land.
-            '!!!pub cache: ${tree.fromFiles(io.Directory(systemCache.rootDir).listSync(recursive: true).map((e) => e.path).toList(), showAllChildren: true)}');
-
         renameDir(tempDir, destPath);
       } on io.FileSystemException catch (e) {
         tryDeleteEntry(tempDir);

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -13,7 +13,6 @@ import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:stack_trace/stack_trace.dart';
 
-import '../ascii_tree.dart' as tree;
 import '../authentication/client.dart';
 import '../exceptions.dart';
 import '../http.dart';

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -13,6 +13,7 @@ import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:stack_trace/stack_trace.dart';
 
+import '../ascii_tree.dart' as tree;
 import '../authentication/client.dart';
 import '../exceptions.dart';
 import '../http.dart';
@@ -821,6 +822,8 @@ class BoundHostedSource extends CachedSource {
       try {
         renameDir(tempDir, destPath);
       } on io.FileSystemException catch (e) {
+        log.error(// Do not land.
+            '!!!pub cache: ${tree.fromFiles(listDir(systemCache.rootDir, recursive: true, includeHidden: true), showAllChildren: true)}');
         tryDeleteEntry(tempDir);
         if (!isDirectoryNotEmptyException(e)) {
           rethrow;

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -821,7 +821,7 @@ class BoundHostedSource extends CachedSource {
       try {
         renameDir(tempDir, destPath);
       } on io.FileSystemException catch (e) {
-        deleteEntry(tempDir);
+        tryDeleteEntry(tempDir);
         if (!isDirectoryNotEmptyException(e)) {
           rethrow;
         }


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub/issues/1178

The basic idea is that if two pub processes are in a race to install a package-version, we let the first one win, and just ignore the failure to install the second one.