### PR TITLE
Fix --verbose doc, and accept verboseness setting from embedder

### DIFF
--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -18,8 +18,12 @@ export 'src/pub_embeddable_command.dart' show PubAnalytics;
 ///
 /// If [analytics] is given, pub will use that analytics instance to send
 /// statistics about resolutions.
-Command<int> pubCommand({PubAnalytics? analytics}) =>
-    PubEmbeddableCommand(analytics);
+///
+/// [isVerbose] should return `true` (after argument resolution) if the
+/// embedding top-level is in verbose mode.
+Command<int> pubCommand(
+        {PubAnalytics? analytics, required bool Function() isVerbose}) =>
+    PubEmbeddableCommand(analytics, isVerbose);
 
 /// Support for the `pub` toplevel command.
 @Deprecated('Use [pubCommand] instead.')

--- a/lib/src/pub_embeddable_command.dart
+++ b/lib/src/pub_embeddable_command.dart
@@ -58,11 +58,13 @@ class PubEmbeddableCommand extends PubCommand implements PubTopLevel {
   @override
   final PubAnalytics? analytics;
 
-  PubEmbeddableCommand(this.analytics) : super() {
+  final bool Function() isVerbose;
+
+  PubEmbeddableCommand(this.analytics, this.isVerbose) : super() {
     argParser.addFlag('trace',
         help: 'Print debugging information when an error occurs.');
     argParser.addFlag('verbose',
-        abbr: 'v', negatable: false, help: 'Shortcut for "--verbosity=all".');
+        abbr: 'v', negatable: false, help: 'Print detailed logging.');
     argParser.addOption(
       'directory',
       abbr: 'C',
@@ -101,12 +103,15 @@ class PubEmbeddableCommand extends PubCommand implements PubTopLevel {
   }
 
   @override
-  bool get captureStackChains => argResults['verbose'];
+  bool get captureStackChains => _isVerbose;
 
   @override
-  Verbosity get verbosity =>
-      argResults['verbose'] ? Verbosity.all : Verbosity.normal;
+  Verbosity get verbosity => _isVerbose ? Verbosity.all : Verbosity.normal;
 
   @override
-  bool get trace => argResults['verbose'];
+  bool get trace => _isVerbose;
+
+  bool get _isVerbose {
+    return argResults['verbose'] || isVerbose();
+  }
 }

--- a/test/embedding/embedding_test.dart
+++ b/test/embedding/embedding_test.dart
@@ -221,6 +221,13 @@ main() {
     // Don't write the logs to file on a normal run.
     expect(File(logFile).existsSync(), isFalse);
   });
+
+  test('`embedding --verbose pub` is verbose', () async {
+    await servePackages();
+    final buffer = StringBuffer();
+    await runEmbeddingToBuffer(['--verbose', 'pub', 'logout'], buffer);
+    expect(buffer.toString(), contains('FINE: Pub 0.1.2+3'));
+  });
 }
 
 String _filter(String input) {

--- a/tool/test-bin/pub_command_runner.dart
+++ b/tool/test-bin/pub_command_runner.dart
@@ -42,7 +42,9 @@ class Runner extends CommandRunner<int> {
             dependencyKindCustomDimensionName: 'cd1')
         : null;
     addCommand(
-        pubCommand(analytics: analytics)..addSubcommand(ThrowingCommand()));
+        pubCommand(analytics: analytics, isVerbose: () => _options['verbose'])
+          ..addSubcommand(ThrowingCommand()));
+    argParser.addFlag('verbose');
   }
 
   @override


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub/issues/3272

When this is rolled in the embedder can provide an `isVerbose` to enable this:
```
$ dart --verbose pub get
```