### PR TITLE
fix: relative to the current directory rules

### DIFF
--- a/lib/src/ignore.dart
+++ b/lib/src/ignore.dart
@@ -285,8 +285,8 @@ class Ignore {
       }
       if (currentIsDir) {
         final ignore = ignoreForDir(normalizedCurrent);
-        ignoreStack
-            .add(ignore == null ? null : _IgnorePrefixPair(ignore, current));
+        ignoreStack.add(
+            ignore == null ? null : _IgnorePrefixPair(ignore, '$current/'));
         // Put all entities in current on the stack to be processed.
         toVisit.add(listDir(normalizedCurrent).map((x) => '/$x').toList());
         if (includeDirs) {

--- a/lib/src/ignore.dart
+++ b/lib/src/ignore.dart
@@ -25,7 +25,6 @@
 /// [Ignore.listFiles].
 ///
 /// [1]: https://git-scm.com/docs/gitignore
-
 import 'package:meta/meta.dart';
 
 /// A set of ignore rules representing a single ignore file.
@@ -148,7 +147,8 @@ class Ignore {
         path.endsWith('/') ? path.substring(0, path.length - 1) : path;
     return listFiles(
       beneath: pathWithoutSlash,
-      includeDirs: true, // because we are listing below pathWithoutSlash
+      includeDirs: true,
+      // because we are listing below pathWithoutSlash
       listDir: (dir) {
         // List the next part of path:
         if (dir == pathWithoutSlash) return [];
@@ -285,8 +285,10 @@ class Ignore {
       }
       if (currentIsDir) {
         final ignore = ignoreForDir(normalizedCurrent);
-        ignoreStack.add(
-            ignore == null ? null : _IgnorePrefixPair(ignore, current == '/' ? current : '$current/'));
+        ignoreStack.add(ignore == null
+            ? null
+            : _IgnorePrefixPair(
+                ignore, current == '/' ? current : '$current/'));
         // Put all entities in current on the stack to be processed.
         toVisit.add(listDir(normalizedCurrent).map((x) => '/$x').toList());
         if (includeDirs) {
@@ -309,13 +311,16 @@ class _IgnoreParseResult {
 
   // An invalid pattern is also considered empty.
   bool get empty => rule == null;
+
   bool get valid => exception == null;
 
   // For invalid patterns this contains a description of the problem.
   final FormatException? exception;
 
   _IgnoreParseResult(this.pattern, this.rule) : exception = null;
+
   _IgnoreParseResult.invalid(this.pattern, this.exception) : rule = null;
+
   _IgnoreParseResult.empty(this.pattern)
       : rule = null,
         exception = null;
@@ -540,7 +545,9 @@ _IgnoreParseResult _parseIgnorePattern(String pattern, bool ignoreCase) {
 class _IgnorePrefixPair {
   final Ignore ignore;
   final String prefix;
+
   _IgnorePrefixPair(this.ignore, this.prefix);
+
   @override
   String toString() {
     return '{${ignore._rules.map((r) => r.original)} $prefix}';

--- a/lib/src/ignore.dart
+++ b/lib/src/ignore.dart
@@ -286,7 +286,7 @@ class Ignore {
       if (currentIsDir) {
         final ignore = ignoreForDir(normalizedCurrent);
         ignoreStack.add(
-            ignore == null ? null : _IgnorePrefixPair(ignore, '$current/'));
+            ignore == null ? null : _IgnorePrefixPair(ignore, current == '/' ? current : '$current/'));
         // Put all entities in current on the stack to be processed.
         toVisit.add(listDir(normalizedCurrent).map((x) => '/$x').toList());
         if (includeDirs) {

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -423,6 +423,118 @@ void main() {
       p.join(root, 'pubignoredir', 'b.txt'),
     });
   });
+
+  group('nested ignores in exact directory', ()  {
+    setUp(ensureGit);
+
+    test('ignore directory in exact directory', () async {
+      final repo = d.git(appPath, [
+        d.dir('packages', [
+          d.dir('nested', [
+            d.file('.gitignore', '/bin/'),
+            d.appPubspec(),
+            d.dir('bin', [
+              d.file('run.dart'),
+            ]),
+          ]),
+        ]),
+      ]);
+      await repo.create();
+      createEntrypoint(p.join(appPath, 'packages', 'nested'));
+
+      expect(entrypoint!.root.listFiles(), {
+        p.join(root, 'pubspec.yaml'),
+      });
+    });
+
+    test('ignore directory in exact directory', () async {
+      final repo = d.git(appPath, [
+        d.dir('packages', [
+          d.dir('nested', [
+            d.file('.gitignore', '/bin/'),
+            d.appPubspec(),
+            d.file('bin'),
+          ]),
+        ]),
+      ]);
+      await repo.create();
+      createEntrypoint(p.join(appPath, 'packages', 'nested'));
+
+      expect(entrypoint!.root.listFiles(), {
+        p.join(root, 'pubspec.yaml'),
+        p.join(root, 'bin'),
+      });
+    });
+
+    test('ignore file on exact directory', () async {
+      final repo = d.git(appPath, [
+        d.dir('packages', [
+          d.dir('nested', [
+            d.appPubspec(),
+            d.dir('bin', [
+              d.file('.gitignore', '/run.dart'),
+              d.file('run.dart'),
+            ]),
+          ]),
+        ]),
+      ]);
+      await repo.create();
+      createEntrypoint(p.join(appPath, 'packages', 'nested'));
+
+      expect(entrypoint!.root.listFiles(), {
+        p.join(root, 'pubspec.yaml'),
+      });
+    });
+
+    test('not ignore files beneath exact directory', () async {
+      final repo = d.git(appPath, [
+        d.dir('packages', [
+          d.dir('nested', [
+            d.appPubspec(),
+            d.dir('bin', [
+              d.file('.gitignore', '/run.dart'),
+              d.file('run.dart'),
+              d.dir('nested_again', [
+                d.file('run.dart'),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]);
+      await repo.create();
+      createEntrypoint(p.join(appPath, 'packages', 'nested'));
+
+      expect(entrypoint!.root.listFiles(), {
+        p.join(root, 'pubspec.yaml'),
+        p.join(root, 'bin', 'nested_again', 'run.dart'),
+      });
+    });
+
+    test('disable ignore in exact directory', () async {
+      final repo = d.git(appPath, [
+        d.dir('packages', [
+          d.file('.gitignore', 'run.dart'),
+          d.dir('nested', [
+            d.appPubspec(),
+            d.dir('bin', [
+              d.file('.gitignore', '!/run.dart'),
+              d.file('run.dart'),
+              d.dir('nested_again', [
+                d.file('run.dart'),
+              ]),
+            ]),
+          ]),
+        ]),
+      ]);
+      await repo.create();
+      createEntrypoint(p.join(appPath, 'packages', 'nested'));
+
+      expect(entrypoint!.root.listFiles(), {
+        p.join(root, 'pubspec.yaml'),
+        p.join(root, 'bin', 'run.dart'),
+      });
+    });
+  });
 }
 
 void createEntrypoint([String? path]) {

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -424,75 +424,127 @@ void main() {
     });
   });
 
-  group('nested ignores in exact directory', ()  {
+  group('relative to current directory rules', () {
     setUp(ensureGit);
-
-    test('ignore directory in exact directory', () async {
-      final repo = d.git(appPath, [
-        d.dir('packages', [
-          d.dir('nested', [
-            d.file('.gitignore', '/bin/'),
-            d.appPubspec(),
-            d.dir('bin', [
-              d.file('run.dart'),
+    group('delimiter in the beginning', () {
+      test('ignore directory in exact directory', () async {
+        final repo = d.git(appPath, [
+          d.dir('packages', [
+            d.dir('nested', [
+              d.file('.gitignore', '/bin/'),
+              d.appPubspec(),
+              d.dir('bin', [
+                d.file('run.dart'),
+              ]),
             ]),
           ]),
-        ]),
-      ]);
-      await repo.create();
-      createEntrypoint(p.join(appPath, 'packages', 'nested'));
+        ]);
+        await repo.create();
+        createEntrypoint(p.join(appPath, 'packages', 'nested'));
 
-      expect(entrypoint!.root.listFiles(), {
-        p.join(root, 'pubspec.yaml'),
+        expect(entrypoint!.root.listFiles(), {
+          p.join(root, 'pubspec.yaml'),
+        });
       });
-    });
 
-    test('ignore directory in exact directory', () async {
-      final repo = d.git(appPath, [
-        d.dir('packages', [
-          d.dir('nested', [
-            d.file('.gitignore', '/bin/'),
-            d.appPubspec(),
-            d.file('bin'),
-          ]),
-        ]),
-      ]);
-      await repo.create();
-      createEntrypoint(p.join(appPath, 'packages', 'nested'));
-
-      expect(entrypoint!.root.listFiles(), {
-        p.join(root, 'pubspec.yaml'),
-        p.join(root, 'bin'),
-      });
-    });
-
-    test('ignore file on exact directory', () async {
-      final repo = d.git(appPath, [
-        d.dir('packages', [
-          d.dir('nested', [
-            d.appPubspec(),
-            d.dir('bin', [
-              d.file('.gitignore', '/run.dart'),
-              d.file('run.dart'),
+      test('ignore directory in exact directory', () async {
+        final repo = d.git(appPath, [
+          d.dir('packages', [
+            d.dir('nested', [
+              d.file('.gitignore', '/bin/'),
+              d.appPubspec(),
+              d.file('bin'),
             ]),
           ]),
-        ]),
-      ]);
-      await repo.create();
-      createEntrypoint(p.join(appPath, 'packages', 'nested'));
+        ]);
+        await repo.create();
+        createEntrypoint(p.join(appPath, 'packages', 'nested'));
 
-      expect(entrypoint!.root.listFiles(), {
-        p.join(root, 'pubspec.yaml'),
+        expect(entrypoint!.root.listFiles(), {
+          p.join(root, 'pubspec.yaml'),
+          p.join(root, 'bin'),
+        });
+      });
+
+      test('ignore file on exact directory', () async {
+        final repo = d.git(appPath, [
+          d.dir('packages', [
+            d.dir('nested', [
+              d.appPubspec(),
+              d.dir('bin', [
+                d.file('.gitignore', '/run.dart'),
+                d.file('run.dart'),
+              ]),
+            ]),
+          ]),
+        ]);
+        await repo.create();
+        createEntrypoint(p.join(appPath, 'packages', 'nested'));
+
+        expect(entrypoint!.root.listFiles(), {
+          p.join(root, 'pubspec.yaml'),
+        });
+      });
+
+      test('not ignore files beneath exact directory', () async {
+        final repo = d.git(appPath, [
+          d.dir('packages', [
+            d.dir('nested', [
+              d.appPubspec(),
+              d.dir('bin', [
+                d.file('.gitignore', '/run.dart'),
+                d.file('run.dart'),
+                d.dir('nested_again', [
+                  d.file('run.dart'),
+                ]),
+              ]),
+            ]),
+          ]),
+        ]);
+        await repo.create();
+        createEntrypoint(p.join(appPath, 'packages', 'nested'));
+
+        expect(entrypoint!.root.listFiles(), {
+          p.join(root, 'pubspec.yaml'),
+          p.join(root, 'bin', 'nested_again', 'run.dart'),
+        });
+      });
+
+      test('disable ignore in exact directory', () async {
+        final repo = d.git(appPath, [
+          d.dir('packages', [
+            d.file('.gitignore', 'run.dart'),
+            d.dir('nested', [
+              d.appPubspec(),
+              d.dir('bin', [
+                d.file('.gitignore', '!/run.dart'),
+                d.file('run.dart'),
+                d.dir('nested_again', [
+                  d.file('run.dart'),
+                ]),
+              ]),
+            ]),
+          ]),
+        ]);
+        await repo.create();
+        createEntrypoint(p.join(appPath, 'packages', 'nested'));
+
+        expect(entrypoint!.root.listFiles(), {
+          p.join(root, 'pubspec.yaml'),
+          p.join(root, 'bin', 'run.dart'),
+        });
       });
     });
+  });
 
-    test('not ignore files beneath exact directory', () async {
+  group('delimiter in the middle', () {
+    test('should work with route relative to current directory ', () async {
       final repo = d.git(appPath, [
         d.dir('packages', [
+          d.file('.gitignore', 'nested/bin/run.dart'),
           d.dir('nested', [
             d.appPubspec(),
             d.dir('bin', [
-              d.file('.gitignore', '/run.dart'),
               d.file('run.dart'),
               d.dir('nested_again', [
                 d.file('run.dart'),
@@ -510,14 +562,13 @@ void main() {
       });
     });
 
-    test('disable ignore in exact directory', () async {
+    test('should not have effect in nested folders', () async {
       final repo = d.git(appPath, [
         d.dir('packages', [
-          d.file('.gitignore', 'run.dart'),
+          d.file('.gitignore', 'bin/run.dart'),
           d.dir('nested', [
             d.appPubspec(),
             d.dir('bin', [
-              d.file('.gitignore', '!/run.dart'),
               d.file('run.dart'),
               d.dir('nested_again', [
                 d.file('run.dart'),
@@ -532,6 +583,7 @@ void main() {
       expect(entrypoint!.root.listFiles(), {
         p.join(root, 'pubspec.yaml'),
         p.join(root, 'bin', 'run.dart'),
+        p.join(root, 'bin', 'nested_again', 'run.dart'),
       });
     });
   });


### PR DESCRIPTION
fixes handling of  statements that should be handled against directory of "ignore" file


quote from https://git-scm.com/docs/gitignore#_pattern_format
> - The slash / is used as the directory separator. Separators may occur at the beginning, middle or end of the .gitignore search pattern.
> 
> - If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself. Otherwise the pattern may also match at any level below the .gitignore level.
