### PR TITLE
fix: ignored directory symlinks

### DIFF
--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -247,7 +247,18 @@ class Package {
     return Ignore.listFiles(
       beneath: beneath,
       listDir: (dir) {
-        var contents = Directory(resolve(dir)).listSync();
+        final resolvedDir = resolve(dir);
+        if (linkExists(resolvedDir)) {
+          try {
+            Link(resolvedDir).resolveSymbolicLinksSync();
+          } on FileSystemException catch (_) {
+            final target = Link(resolvedDir).targetSync();
+            throw DataException(
+                '''Pub does not support publishing packages with non-resolving symlink: `$path` => `$target`.''');
+          }
+        }
+
+        var contents = Directory(resolvedDir).listSync();
         if (!recursive) {
           contents = contents.where((entity) => entity is! Directory).toList();
         }

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -247,7 +247,7 @@ class Package {
     return Ignore.listFiles(
       beneath: beneath,
       listDir: (dir) {
-        var contents = Directory(resolve(dir)).listSync(followLinks: false);
+        var contents = Directory(resolve(dir)).listSync();
         if (!recursive) {
           contents = contents.where((entity) => entity is! Directory).toList();
         }

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -321,7 +321,14 @@ class Package {
               );
       },
       isDir: (dir) => dirExists(resolve(dir)),
-    ).map(resolve).map((path) {
+    ).map((relative) {
+      if (_listParentDirs(relative).any(symlinkPaths.contains)) {
+        throw DataException(
+            '''Pub does not support publishing packages with directory symlinks: `$path`''');
+      }
+
+      final path = resolve(relative);
+
       if (linkExists(path)) {
         final target = Link(path).targetSync();
         if (!fileExists(path)) {
@@ -329,14 +336,7 @@ class Package {
               '''Pub does not support publishing packages with non-resolving symlink: `$path` => `$target`.''');
         }
       }
-      var relative = p.relative(path, from: root);
-      if (Platform.isWindows) {
-        relative = p.posix.joinAll(p.split(relative));
-      }
-      if (_listParentDirs(relative).any(symlinkPaths.contains)) {
-        throw DataException(
-            '''Pub does not support publishing packages with directory symlinks: `$path`''');
-      }
+
       return path;
     }).toList();
   }

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -322,7 +322,9 @@ class Package {
       },
       isDir: (dir) => dirExists(resolve(dir)),
     ).map((relative) {
-      if (_listParentDirs(relative).any(symlinkPaths.contains)) {
+      final parentSymlinkDir = _listParentDirs(relative).firstWhereOrNull(symlinkPaths.contains);
+      if (parentSymlinkDir != null) {
+        final path = resolve(parentSymlinkDir);
         throw DataException(
             '''Pub does not support publishing packages with directory symlinks: `$path`''');
       }

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -249,7 +249,13 @@ class Package {
       listDir: (dir) {
         var contents = Directory(resolve(dir)).listSync(followLinks: false);
         if (!recursive) {
-          contents = contents.where((entity) => entity is! Directory).toList();
+          contents = contents
+              .where(
+                (entity) =>
+                    entity is! Directory &&
+                    !(linkExists(entity.path) && dirExists(entity.path)),
+              )
+              .toList();
         }
         return contents.map((entity) {
           var relative = p.relative(entity.path, from: root);

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -249,13 +249,7 @@ class Package {
       listDir: (dir) {
         var contents = Directory(resolve(dir)).listSync(followLinks: false);
         if (!recursive) {
-          contents = contents
-              .where(
-                (entity) =>
-                    entity is! Directory &&
-                    !(linkExists(entity.path) && dirExists(entity.path)),
-              )
-              .toList();
+          contents = contents.where((entity) => entity is! Directory).toList();
         }
         return contents.map((entity) {
           var relative = p.relative(entity.path, from: root);

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -247,7 +247,7 @@ class Package {
     return Ignore.listFiles(
       beneath: beneath,
       listDir: (dir) {
-        var contents = Directory(resolve(dir)).listSync();
+        var contents = Directory(resolve(dir)).listSync(followLinks: false);
         if (!recursive) {
           contents = contents.where((entity) => entity is! Directory).toList();
         }

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -319,7 +319,7 @@ class Package {
         final target = Link(path).targetSync();
         if (!fileExists(path)) {
           throw DataException(
-              '''Pub does not support publishing packages with non-resolving symlink: `${path}` => `$target`.''');
+              '''Pub does not support publishing packages with non-resolving symlink: `$path` => `$target`.''');
         }
       }
       return path;

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -250,17 +250,6 @@ class Package {
           contents = contents.where((entity) => entity is! Directory).toList();
         }
         return contents.map((entity) {
-          if (linkExists(entity.path)) {
-            final target = Link(entity.path).targetSync();
-            if (dirExists(entity.path)) {
-              throw DataException(
-                  '''Pub does not support publishing packages with directory symlinks: `${entity.path}`.''');
-            }
-            if (!fileExists(entity.path)) {
-              throw DataException(
-                  '''Pub does not support publishing packages with non-resolving symlink: `${entity.path}` => `$target`.''');
-            }
-          }
           final relative = p.relative(entity.path, from: root);
           if (Platform.isWindows) {
             return p.posix.joinAll(p.split(relative));
@@ -325,7 +314,16 @@ class Package {
               );
       },
       isDir: (dir) => dirExists(resolve(dir)),
-    ).map(resolve).toList();
+    ).map(resolve).map((path) {
+      if (linkExists(path)) {
+        final target = Link(path).targetSync();
+        if (!fileExists(path)) {
+          throw DataException(
+              '''Pub does not support publishing packages with non-resolving symlink: `${path}` => `$target`.''');
+        }
+      }
+      return path;
+    }).toList();
   }
 }
 

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -328,7 +328,8 @@ class Package {
       },
       isDir: (dir) => dirExists(resolve(dir)),
     ).map((relative) {
-      final parentSymlinkDir = _listParentDirs(relative).firstWhereOrNull(symlinkPaths.contains);
+      final parentSymlinkDir =
+          _listParentDirs(relative).firstWhereOrNull(symlinkPaths.contains);
       if (parentSymlinkDir != null) {
         final path = resolve(parentSymlinkDir);
         throw DataException(

--- a/lib/src/validator/gitignore.dart
+++ b/lib/src/validator/gitignore.dart
@@ -46,10 +46,8 @@ class GitignoreValidator extends Validator {
         beneath: beneath,
         listDir: (dir) {
           var contents = Directory(resolve(dir)).listSync();
-          return contents
-              .where((e) => !(linkExists(e.path) && dirExists(e.path)))
-              .map((entity) => p.posix
-                  .joinAll(p.split(p.relative(entity.path, from: root))));
+          return contents.map((entity) =>
+              p.posix.joinAll(p.split(p.relative(entity.path, from: root))));
         },
         ignoreForDir: (dir) {
           final gitIgnore = resolve('$dir/.gitignore');
@@ -58,7 +56,10 @@ class GitignoreValidator extends Validator {
           ];
           return rules.isEmpty ? null : Ignore(rules);
         },
-        isDir: (dir) => dirExists(resolve(dir)),
+        isDir: (dir) {
+          final resolved = resolve(dir);
+          return dirExists(resolved) && !linkExists(resolved);
+        },
       ).map((file) {
         final relative = p.relative(resolve(file), from: entrypoint.root.dir);
         return Platform.isWindows

--- a/lib/src/validator/gitignore.dart
+++ b/lib/src/validator/gitignore.dart
@@ -45,7 +45,7 @@ class GitignoreValidator extends Validator {
       final unignoredByGitignore = Ignore.listFiles(
         beneath: beneath,
         listDir: (dir) {
-          var contents = Directory(resolve(dir)).listSync();
+          var contents = Directory(resolve(dir)).listSync(followLinks: false);
           return contents.map((entity) =>
               p.posix.joinAll(p.split(p.relative(entity.path, from: root))));
         },

--- a/lib/src/validator/gitignore.dart
+++ b/lib/src/validator/gitignore.dart
@@ -45,7 +45,7 @@ class GitignoreValidator extends Validator {
       final unignoredByGitignore = Ignore.listFiles(
         beneath: beneath,
         listDir: (dir) {
-          var contents = Directory(resolve(dir)).listSync(followLinks: false);
+          var contents = Directory(resolve(dir)).listSync();
           return contents.map((entity) =>
               p.posix.joinAll(p.split(p.relative(entity.path, from: root))));
         },

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -46,8 +46,6 @@ void main() {
         ]));
   });
 
-
-
   test('throws on directory symlinks', () async {
     await d.dir(appPath, [
       d.pubspec({'name': 'myapp'}),

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -12,6 +12,7 @@ import 'package:test/test.dart';
 
 import 'descriptor.dart' as d;
 import 'test_pub.dart';
+import 'validator/utils.dart';
 
 late String root;
 Entrypoint? entrypoint;
@@ -45,14 +46,7 @@ void main() {
         ]));
   });
 
-  // On windows symlinks to directories are distinct from symlinks to files.
-  void createDirectorySymlink(String path, String target) {
-    if (Platform.isWindows) {
-      Process.runSync('cmd', ['/c', 'mklink', '/D', path, target]);
-    } else {
-      Link(path).createSync(target);
-    }
-  }
+
 
   test('throws on directory symlinks', () async {
     await d.dir(appPath, [

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -97,6 +97,34 @@ void main() {
     });
   });
 
+  test('throws on symlink cycles', () async {
+    await d.dir(appPath, [
+      d.pubspec({'name': 'myapp'}),
+      d.file('file1.txt', 'contents'),
+      d.file('file2.txt', 'contents'),
+      d.dir('subdir', [
+        d.dir('a', [d.file('file')]),
+      ]),
+    ]).create();
+    createDirectorySymlink(
+        p.join(d.sandbox, appPath, 'subdir', 'symlink'), '..');
+
+    createEntrypoint();
+
+    expect(
+      () => entrypoint!.root.listFiles(),
+      throwsA(
+        isA<DataException>().having(
+          (e) => e.message,
+          'message',
+          contains(
+            'Pub does not support publishing packages with directory symlinks',
+          ),
+        ),
+      ),
+    );
+  });
+
   test('can list a package inside a symlinked folder', () async {
     await d.dir(appPath, [
       d.pubspec({'name': 'myapp'}),

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -76,6 +76,29 @@ void main() {
     );
   });
 
+  test('not throws on ignored directory symlinks', () async {
+    await d.dir(appPath, [
+      d.pubspec({'name': 'myapp'}),
+      d.file('file1.txt', 'contents'),
+      d.file('file2.txt', 'contents'),
+      d.dir('subdir', [
+        d.file('.pubignore', 'symlink'),
+        d.dir('a', [d.file('file')]),
+      ]),
+    ]).create();
+    createDirectorySymlink(
+        p.join(d.sandbox, appPath, 'subdir', 'symlink'), 'a');
+
+    createEntrypoint();
+
+    expect(entrypoint!.root.listFiles(), {
+      p.join(root, 'pubspec.yaml'),
+      p.join(root, 'file1.txt'),
+      p.join(root, 'file2.txt'),
+      p.join(root, 'subdir', 'a', 'file'),
+    });
+  });
+
   test('can list a package inside a symlinked folder', () async {
     await d.dir(appPath, [
       d.pubspec({'name': 'myapp'}),

--- a/test/validator/gitignore_test.dart
+++ b/test/validator/gitignore_test.dart
@@ -104,7 +104,9 @@ void main() {
         workingDirectory: packageRoot);
   });
 
-  test('Should consider symlinks to be valid files and not list them as gitignored', () async {
+  test(
+      'Should consider symlinks to be valid files and not list them as gitignored',
+      () async {
     final git = d.git(appPath, [
       ...d.validPackage.contents,
       d.dir('dir_with_symlink', [

--- a/test/validator/gitignore_test.dart
+++ b/test/validator/gitignore_test.dart
@@ -110,7 +110,7 @@ void main() {
     final git = d.git(appPath, [
       ...d.validPackage.contents,
       d.dir('dir_with_symlink', [
-        d.file('.pubignore', '/symlink'),
+        d.file('.pubignore', 'symlink'),
       ]),
     ]);
     await git.create();

--- a/test/validator/gitignore_test.dart
+++ b/test/validator/gitignore_test.dart
@@ -118,7 +118,7 @@ void main() {
         workingDirectory: packageRoot);
     createDirectorySymlink(
         p.join(d.sandbox, appPath, 'dir_with_symlink', 'symlink'), '..');
-    git.commit();
+    await git.commit();
 
     await expectValidation(contains('Package has 0 warnings.'), 0,
         workingDirectory: packageRoot);

--- a/test/validator/utils.dart
+++ b/test/validator/utils.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:test/test.dart';
 
 import '../test_pub.dart';
@@ -15,4 +17,13 @@ Future<void> expectValidation(ValidatorCreator fn,
   expect(validator.errors, errors ?? isEmpty);
   expect(validator.warnings, warnings ?? isEmpty);
   expect(validator.hints, hints ?? isEmpty);
+}
+
+// On windows symlinks to directories are distinct from symlinks to files.
+void createDirectorySymlink(String path, String target) {
+  if (Platform.isWindows) {
+    Process.runSync('cmd', ['/c', 'mklink', '/D', path, target]);
+  } else {
+    Link(path).createSync(target);
+  }
 }


### PR DESCRIPTION
spinoff: #3298

in this pull request I preserved error on directory symlinks, but allow ignored directory and non-resolving symlinks