### PR TITLE
Upgrade `package:tar` to version `0.5.4`.

### DIFF
--- a/lib/src/third_party/tar/README.md
+++ b/lib/src/third_party/tar/README.md
@@ -1,7 +1,7 @@
 # package:tar
 
-Vendored elements from `package:tar` for use in creation and extration of
+Vendored elements from `package:tar` for use in creation and extraction of
 tar-archives.
 
  * Repository: `https://github.com/simolus3/tar/`
- * Revision: `b5c5a11d8969f458ccdeb8cf01615f692fed3e97`
+ * Revision: `ce8aae4825ac4cbed80829cd0d6e181b924b3db2`

--- a/lib/src/third_party/tar/README.md
+++ b/lib/src/third_party/tar/README.md
@@ -4,4 +4,4 @@ Vendored elements from `package:tar` for use in creation and extraction of
 tar-archives.
 
  * Repository: `https://github.com/simolus3/tar/`
- * Revision: `ce8aae4825ac4cbed80829cd0d6e181b924b3db2`
+ * Revision: `7cdb563c9894600c6a739ec268f8673d6122006f`

--- a/lib/src/third_party/tar/src/constants.dart
+++ b/lib/src/third_party/tar/src/constants.dart
@@ -216,13 +216,6 @@ const c_ISGID = 1024;
 /// Sticky bit
 const c_ISVTX = 512;
 
-/// **********************
-///  Convenience constants
-/// **********************
-/// 64-bit integer max and min values
-const int64MaxValue = 9223372036854775807;
-const int64MinValue = -9223372036854775808;
-
 /// Constants to determine file modes.
 const modeType = 2401763328;
 const modeSymLink = 134217728;

--- a/lib/src/third_party/tar/src/entry.dart
+++ b/lib/src/third_party/tar/src/entry.dart
@@ -52,8 +52,17 @@ class TarEntry {
   TarEntry._(this.header, this.contents);
 
   /// Creates an in-memory tar entry from the [header] and the [data] to store.
-  factory TarEntry.data(TarHeader header, List<int> data) {
+  static SynchronousTarEntry data(TarHeader header, List<int> data) {
     (header as HeaderImpl).size = data.length;
-    return TarEntry(header, Stream.value(data));
+    return SynchronousTarEntry._(header, data);
   }
+}
+
+/// A tar entry stored in memory.
+class SynchronousTarEntry extends TarEntry {
+  /// The contents of this tar entry as a byte array.
+  final List<int> data;
+
+  SynchronousTarEntry._(TarHeader header, this.data)
+      : super._(header, Stream.value(data));
 }

--- a/lib/src/third_party/tar/src/utils.dart
+++ b/lib/src/third_party/tar/src/utils.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
@@ -92,25 +93,31 @@ extension ByteBufferUtils on Uint8List {
   }
 
   int computeUnsignedHeaderChecksum() {
-    var result = 0;
+    // Accessing the last element first helps the VM eliminate bounds checks in
+    // the loops below.
+    this[blockSize - 1];
+    var result = checksumLength * _checksumPlaceholder;
 
-    for (var i = 0; i < length; i++) {
-      result += (i < checksumOffset || i >= _checksumEnd)
-          ? this[i] // Not in range of where the checksum is written
-          : _checksumPlaceholder;
+    for (var i = 0; i < checksumOffset; i++) {
+      result += this[i];
+    }
+    for (var i = _checksumEnd; i < blockSize; i++) {
+      result += this[i];
     }
 
     return result;
   }
 
   int computeSignedHeaderChecksum() {
-    var result = 0;
+    this[blockSize - 1];
+    // Note that _checksumPlaceholder.toSigned(8) == _checksumPlaceholder
+    var result = checksumLength * _checksumPlaceholder;
 
-    for (var i = 0; i < length; i++) {
-      // Note that _checksumPlaceholder.toSigned(8) == _checksumPlaceholder
-      result += (i < checksumOffset || i >= _checksumEnd)
-          ? this[i].toSigned(8)
-          : _checksumPlaceholder;
+    for (var i = 0; i < checksumOffset; i++) {
+      result += this[i].toSigned(8);
+    }
+    for (var i = _checksumEnd; i < blockSize; i++) {
+      result += this[i].toSigned(8);
     }
 
     return result;
@@ -119,6 +126,14 @@ extension ByteBufferUtils on Uint8List {
   bool matchesHeader(List<int> header, {int offset = magicOffset}) {
     for (var i = 0; i < header.length; i++) {
       if (this[offset + i] != header[i]) return false;
+    }
+
+    return true;
+  }
+
+  bool get isAllZeroes {
+    for (var i = 0; i < length; i++) {
+      if (this[i] != 0) return false;
     }
 
     return true;
@@ -200,14 +215,6 @@ extension ToTyped on List<int> {
     final $this = this;
     return $this is Uint8List ? $this : Uint8List.fromList(this);
   }
-
-  bool get isAllZeroes {
-    for (var i = 0; i < length; i++) {
-      if (this[i] != 0) return false;
-    }
-
-    return true;
-  }
 }
 
 /// Generates a chunked stream of [length] zeroes.
@@ -228,4 +235,326 @@ Stream<List<int>> zeroes(int length) async* {
   if (remainingBytes != 0) {
     yield Uint8List(remainingBytes);
   }
+}
+
+/// An optimized reader reading 512-byte blocks from an [input] stream.
+class BlockReader {
+  final Stream<List<int>> input;
+  StreamSubscription<List<int>>? _subscription;
+  bool _isClosed = false;
+
+  /// If a request is active, returns the current stream that we're reporting.
+  /// This controler is synchronous.
+  StreamController<Uint8List>? _outgoing;
+
+  /// The amount of (512-byte) blocks remaining before [_outgoing] should close.
+  int _remainingBlocksInOutgoing = 0;
+
+  /// A pending tar block that has not been emitted yet.
+  ///
+  /// This can happen if we receive small chunks of data in [_onData] that
+  /// aren't enough to form a full block.
+  final Uint8List _pendingBlock = Uint8List(blockSize);
+
+  /// The offset in [_pendingBlock] at which new data should start.
+  ///
+  /// For instance, if this value is `502`, we're missing `10` additional bytes
+  /// to complete the [_pendingBlock].
+  /// When this value is `0`, there is no active pending block.
+  int _offsetInPendingBlock = 0;
+
+  /// Additional data that we received, but were unable to dispatch to a
+  /// downstream listener yet.
+  ///
+  /// This can happen if a we receive a large chunk of data and a listener is
+  /// only interested in a small chunk.
+  ///
+  /// We will never have trailing data and a pending block at the same time.
+  /// When we haver fewer than 512 bytes of trailing data, it should be stored
+  /// as a pending block instead.
+  Uint8List? _trailingData;
+
+  /// The offset in the [_trailingData] byte array.
+  ///
+  /// When a new listener attaches, we can start by emitting the sublist
+  /// starting at this offset.
+  int _offsetInTrailingData = 0;
+
+  BlockReader(this.input);
+
+  /// Emits full blocks.
+  ///
+  /// Returns `true` if the listener detached in response to emitting these
+  /// blocks. In this case, remaining data must be saved in [_trailingData].
+  bool _emitBlocks(Uint8List data, {int amount = 1}) {
+    assert(_remainingBlocksInOutgoing >= amount);
+    final outgoing = _outgoing!;
+
+    if (!outgoing.isClosed) outgoing.add(data);
+
+    final remainingNow = _remainingBlocksInOutgoing -= amount;
+    if (remainingNow == 0) {
+      _outgoing = null;
+      _pause();
+
+      scheduleMicrotask(() {
+        outgoing.close();
+      });
+      return true;
+    } else if (outgoing.isPaused || outgoing.isClosed) {
+      _pause();
+      return true;
+    }
+
+    return false;
+  }
+
+  void _onData(List<int> data) {
+    assert(_outgoing != null && _trailingData == null);
+
+    final typedData = data.asUint8List();
+    var offsetInData = 0;
+
+    /// Saves parts of the current chunks that couldn't be emitted.
+    void saveTrailingState() {
+      assert(_trailingData == null && _offsetInPendingBlock == 0);
+
+      final remaining = typedData.length - offsetInData;
+
+      if (remaining == 0) {
+        return; // Nothing to save, the chunk has been consumed fully.
+      } else if (remaining < blockSize) {
+        // Store remaining data as a pending block.
+        _pendingBlock.setAll(0, typedData.sublistView(offsetInData));
+        _offsetInPendingBlock = remaining;
+      } else {
+        _trailingData = typedData;
+        _offsetInTrailingData = offsetInData;
+      }
+    }
+
+    // Try to complete a pending block first
+    var offsetInPending = _offsetInPendingBlock;
+    final canWriteIntoPending = min(blockSize - offsetInPending, data.length);
+
+    if (offsetInPending != 0 && canWriteIntoPending > 0) {
+      _pendingBlock.setAll(
+          offsetInPending, typedData.sublistView(0, canWriteIntoPending));
+      offsetInPending = _offsetInPendingBlock += canWriteIntoPending;
+      offsetInData += canWriteIntoPending;
+
+      // Did this finish the pending block?
+      if (offsetInPending == blockSize) {
+        _offsetInPendingBlock = 0;
+        if (_emitBlocks(_pendingBlock)) {
+          // Emitting the pending block completed all pending requests.
+          saveTrailingState();
+          return;
+        }
+      } else {
+        // The chunk we received didn't fill up the pending block, so just stop
+        // here.
+        assert(offsetInData == data.length);
+        return;
+      }
+    }
+
+    // At this point, the pending block should have been served.
+    assert(_offsetInPendingBlock == 0);
+
+    final fullBlocksToEmit = min(_remainingBlocksInOutgoing,
+        (typedData.length - offsetInData) ~/ blockSize);
+
+    if (fullBlocksToEmit > 0) {
+      _emitBlocks(
+        typedData.sublistView(
+            offsetInData, offsetInData += fullBlocksToEmit * blockSize),
+        amount: fullBlocksToEmit,
+      );
+    }
+
+    saveTrailingState();
+  }
+
+  void _onError(Object error, StackTrace trace) {
+    assert(_outgoing != null && _trailingData == null);
+
+    _outgoing!.addError(error, trace);
+  }
+
+  void _onDone() {
+    assert(_outgoing != null && _trailingData == null);
+    final outgoing = _outgoing!;
+
+    // Add pending data, then close
+    if (_offsetInPendingBlock != 0) {
+      outgoing.add(_pendingBlock.sublistView(0, _offsetInPendingBlock));
+    }
+
+    _isClosed = true;
+    _subscription?.cancel();
+    outgoing.close();
+  }
+
+  void _subscribeOrResume() {
+    // We should not resume the subscription if there is trailing data ready to
+    // be emitted.
+    assert(_trailingData == null);
+
+    final sub = _subscription;
+    if (sub == null) {
+      _subscription = input.listen(_onData,
+          onError: _onError, onDone: _onDone, cancelOnError: true);
+    } else {
+      sub.resume();
+    }
+  }
+
+  void _pause() {
+    final sub = _subscription!; // ignore: cancel_subscriptions
+
+    if (!sub.isPaused) sub.pause();
+  }
+
+  Future<Uint8List> nextBlock() {
+    final result = Uint8List(blockSize);
+    var offset = 0;
+
+    return nextBlocks(1).forEach((chunk) {
+      result.setAll(offset, chunk);
+      offset += chunk.length;
+    }).then((void _) => result.sublistView(0, offset));
+  }
+
+  Stream<Uint8List> nextBlocks(int amount) {
+    if (_isClosed || amount == 0) {
+      return const Stream.empty();
+    }
+    if (_outgoing != null) {
+      throw StateError(
+          'Cannot call nextBlocks() before the previous stream completed.');
+    }
+    assert(_remainingBlocksInOutgoing == 0);
+
+    // We're making this synchronous because we will mostly add events in
+    // response to receiving chunks from the source stream. We manually ensure
+    // that other emits are happening asynchronously.
+    final controller = StreamController<Uint8List>(sync: true);
+    _outgoing = controller;
+    _remainingBlocksInOutgoing = amount;
+
+    var state = _StreamState.initial;
+
+    /// Sends trailing data to the stream. Reeturns true if the subscription
+    /// should still be resumed afterwards.
+    bool emitTrailing() {
+      // Attempt to serve requests from pending data first.
+      final trailing = _trailingData;
+      if (trailing != null) {
+        // There should never be trailing data and a pending block at the
+        // same time
+        assert(_offsetInPendingBlock == 0);
+
+        var remaining = trailing.length - _offsetInTrailingData;
+        // If there is trailing data, it should contain a full block
+        // (otherwise we would have stored it as a pending block)
+        assert(remaining >= blockSize);
+
+        final blocks = min(_remainingBlocksInOutgoing, remaining ~/ blockSize);
+        assert(blocks > 0);
+
+        final done = _emitBlocks(
+            trailing.sublistView(_offsetInTrailingData,
+                _offsetInTrailingData + blocks * blockSize),
+            amount: blocks);
+
+        remaining -= blocks * blockSize;
+        _offsetInTrailingData += blocks * blockSize;
+
+        if (remaining == 0) {
+          _trailingData = null;
+          _offsetInTrailingData = 0;
+        } else if (remaining < blockSize) {
+          assert(_offsetInPendingBlock == 0);
+
+          // Move trailing data into a pending block
+          _pendingBlock.setAll(0, trailing.sublistView(_offsetInTrailingData));
+          _offsetInPendingBlock = remaining;
+          _trailingData = null;
+          _offsetInTrailingData = 0;
+        } else {
+          // If there is still more than a full block of data waiting, we
+          // should not listen. This implies that the stream is done already.
+          assert(done);
+        }
+
+        // The listener detached in response to receiving the event.
+        if (done) {
+          if (_remainingBlocksInOutgoing == 0) state = _StreamState.done;
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    void scheduleInitialEmit() {
+      scheduleMicrotask(() {
+        if (state != _StreamState.initial) return;
+        state = _StreamState.attached;
+
+        if (emitTrailing()) {
+          _subscribeOrResume();
+        }
+      });
+    }
+
+    controller
+      ..onListen = scheduleInitialEmit
+      ..onPause = () {
+        assert(state == _StreamState.initial || state == _StreamState.attached);
+
+        if (state == _StreamState.initial) {
+          state = _StreamState.pausedAfterInitial;
+        } else {
+          _pause();
+          state = _StreamState.pausedAfterAttached;
+        }
+      }
+      ..onResume = () {
+        // We're done already
+        if (_remainingBlocksInOutgoing == 0) return;
+
+        assert(state == _StreamState.pausedAfterAttached ||
+            state == _StreamState.pausedAfterInitial);
+
+        if (state == _StreamState.pausedAfterInitial) {
+          state = _StreamState.initial;
+          scheduleInitialEmit();
+        } else {
+          state = _StreamState.attached;
+          if (emitTrailing()) {
+            _subscribeOrResume();
+          }
+        }
+      }
+      ..onCancel = () {
+        state = _StreamState.done;
+      };
+
+    return controller.stream;
+  }
+
+  FutureOr<void> close() {
+    _isClosed = true;
+    return _subscription?.cancel();
+  }
+}
+
+enum _StreamState {
+  initial,
+  attached,
+  pausedAfterInitial,
+  pausedAfterAttached,
+  done,
 }

--- a/lib/src/third_party/tar/src/utils.dart
+++ b/lib/src/third_party/tar/src/utils.dart
@@ -237,9 +237,9 @@ Stream<List<int>> zeroes(int length) async* {
   }
 }
 
-/// An optimized reader reading 512-byte blocks from an [input] stream.
+/// An optimized reader reading 512-byte blocks from an input stream.
 class BlockReader {
-  final Stream<List<int>> input;
+  final Stream<List<int>> _input;
   StreamSubscription<List<int>>? _subscription;
   bool _isClosed = false;
 
@@ -280,7 +280,7 @@ class BlockReader {
   /// starting at this offset.
   int _offsetInTrailingData = 0;
 
-  BlockReader(this.input);
+  BlockReader(this._input);
 
   /// Emits full blocks.
   ///
@@ -403,7 +403,7 @@ class BlockReader {
 
     final sub = _subscription;
     if (sub == null) {
-      _subscription = input.listen(_onData,
+      _subscription = _input.listen(_onData,
           onError: _onError, onDone: _onDone, cancelOnError: true);
     } else {
       sub.resume();

--- a/lib/src/third_party/tar/tar.dart
+++ b/lib/src/third_party/tar/tar.dart
@@ -9,7 +9,7 @@ import 'src/reader.dart';
 import 'src/writer.dart';
 
 export 'src/constants.dart' show TypeFlag;
-export 'src/entry.dart';
+export 'src/entry.dart' show TarEntry, SynchronousTarEntry;
 export 'src/exception.dart';
 export 'src/format.dart';
 export 'src/header.dart' show TarHeader;

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -291,7 +291,7 @@ void main() {
     test(
       'applies executable bits from tar file',
       () => withTempDir((tempDir) async {
-        final entry = Stream.value(TarEntry.data(
+        final entry = Stream<TarEntry>.value(TarEntry.data(
             TarHeader(
               name: 'weird_exe',
               typeFlag: TypeFlag.reg,
@@ -309,7 +309,7 @@ void main() {
 
     test('extracts files and links', () {
       return withTempDir((tempDir) async {
-        final entries = Stream.fromIterable([
+        final entries = Stream<TarEntry>.fromIterable([
           TarEntry.data(
             TarHeader(name: 'lib/main.txt', typeFlag: TypeFlag.reg),
             utf8.encode('text content'),
@@ -349,7 +349,7 @@ void main() {
 
     test('preserves empty directories', () {
       return withTempDir((tempDir) async {
-        final entry = Stream.value(TarEntry.data(
+        final entry = Stream<TarEntry>.value(TarEntry.data(
             TarHeader(
               name: 'bin/',
               typeFlag: TypeFlag.dir,
@@ -368,7 +368,7 @@ void main() {
 
     test('throws for entries escaping the tar file', () {
       return withTempDir((tempDir) async {
-        final entry = Stream.value(TarEntry.data(
+        final entry = Stream<TarEntry>.value(TarEntry.data(
             TarHeader(
               name: '../other_package-1.2.3/lib/file.dart',
               typeFlag: TypeFlag.reg,
@@ -386,7 +386,7 @@ void main() {
 
     test('skips symlinks escaping the tar file', () {
       return withTempDir((tempDir) async {
-        final entry = Stream.value(TarEntry.data(
+        final entry = Stream<TarEntry>.value(TarEntry.data(
             TarHeader(
               name: 'nested/bad_link',
               typeFlag: TypeFlag.symlink,
@@ -403,7 +403,7 @@ void main() {
 
     test('skips hardlinks escaping the tar file', () {
       return withTempDir((tempDir) async {
-        final entry = Stream.value(TarEntry.data(
+        final entry = Stream<TarEntry>.value(TarEntry.data(
             TarHeader(
               name: 'nested/bad_link',
               typeFlag: TypeFlag.link,


### PR DESCRIPTION
This upgrades the vendored `tar` package from https://github.com/simolus3/tar/commit/b5c5a11d8969f458ccdeb8cf01615f692fed3e97 to https://github.com/simolus3/tar/commit/ce8aae4825ac4cbed80829cd0d6e181b924b3db2.

Noteworthy changes in `package:tar`:

- Decode tar archives with malformed UTF-8 data in non-important PAX headers.
- Forward pause/resume requests when writing tar streams.
- Use a faster, tar-specifc implementation to split the input stream into suitably-sized blocks.
- Support writing tar entries synchronously.
- Faster checksum implementation.
- Avoid copying when reading old GNU sparse maps.

Overall, I expect that these changes will improve the performance of extracting or archiving packages. Quite a bit has changed between the two versions though, so maybe we should once again check published packages and make sure they behave identically? I'm happy to write a script for that if needed.