### PR TITLE
Allow use of token for talking to pub.dev

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -167,10 +167,6 @@ class LishCommand extends PubCommand {
         if (runningFromTest &&
             Platform.environment.containsKey('_PUB_TEST_DEFAULT_HOSTED_URL'))
           Platform.environment['_PUB_TEST_DEFAULT_HOSTED_URL'],
-        /*if (runningFromTest &&
-            Platform.environment.containsKey('PUB_HOSTED_URL') &&
-            Platform.environment['_PUB_TEST_AUTH_METHOD'] == 'oauth2')
-          Platform.environment['PUB_HOSTED_URL'],*/
       };
 
       final isOfficalServer = officialPubServers.contains(server.toString());

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -165,13 +165,21 @@ class LishCommand extends PubCommand {
         // explicitly have to define mock servers as official server to test
         // publish command with oauth2 credentials.
         if (runningFromTest &&
+            Platform.environment.containsKey('_PUB_TEST_DEFAULT_HOSTED_URL'))
+          Platform.environment['_PUB_TEST_DEFAULT_HOSTED_URL'],
+        /*if (runningFromTest &&
             Platform.environment.containsKey('PUB_HOSTED_URL') &&
             Platform.environment['_PUB_TEST_AUTH_METHOD'] == 'oauth2')
-          Platform.environment['PUB_HOSTED_URL'],
+          Platform.environment['PUB_HOSTED_URL'],*/
       };
 
-      if (officialPubServers.contains(server.toString())) {
-        // Using OAuth2 authentication client for the official pub servers
+      final isOfficalServer = officialPubServers.contains(server.toString());
+      if (isOfficalServer && !cache.tokenStore.hasCredential(server)) {
+        // Using OAuth2 authentication client for the official pub servers, when
+        // we don't have an explicit token from [TokenStore] to use instead.
+        //
+        // This allows us to use `dart pub token add` to inject a token for use
+        // with the official servers.
         await oauth2.withClient(cache, (client) {
           return _publishUsingClient(packageBytes, client);
         });

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -117,8 +117,15 @@ class HostedSource extends Source {
     // Clearly, a bit of investigation is necessary before we update this to
     // pub.dev, it might be attractive to do next time we change the server API.
     try {
+      var defaultHostedUrl = 'https://pub.dartlang.org';
+      // Allow the defaultHostedUrl to be overriden when running from tests
+      if (runningFromTest) {
+        defaultHostedUrl =
+            io.Platform.environment['_PUB_TEST_DEFAULT_HOSTED_URL'] ??
+                defaultHostedUrl;
+      }
       return _defaultUrl ??= validateAndNormalizeHostedUrl(
-        io.Platform.environment['PUB_HOSTED_URL'] ?? 'https://pub.dartlang.org',
+        io.Platform.environment['PUB_HOSTED_URL'] ?? defaultHostedUrl,
       );
     } on FormatException catch (e) {
       throw ConfigException(

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -371,15 +371,17 @@ Future<void> runPub(
 Future<PubProcess> startPublish(
   PackageServer server, {
   List<String>? args,
-  String authMethod = 'oauth2',
+  bool overrideDefaultHostedServer = true,
   Map<String, String>? environment,
   String path = '',
 }) async {
   var tokenEndpoint = Uri.parse(server.url).resolve('/token').toString();
   args = ['lish', ...?args];
   return await startPub(args: args, tokenEndpoint: tokenEndpoint, environment: {
-    'PUB_HOSTED_URL': server.url + path,
-    '_PUB_TEST_AUTH_METHOD': authMethod,
+    if (overrideDefaultHostedServer)
+      '_PUB_TEST_DEFAULT_HOSTED_URL': server.url + path
+    else
+      'PUB_HOSTED_URL': server.url + path,
     if (environment != null) ...environment,
   });
 }

--- a/test/token/token_authentication_test.dart
+++ b/test/token/token_authentication_test.dart
@@ -19,8 +19,11 @@ void main() {
         {'url': globalServer.url, 'env': 'TOKEN'},
       ]
     }).create();
-    var pub = await startPublish(globalServer,
-        authMethod: 'token', environment: {'TOKEN': 'access token'});
+    var pub = await startPublish(
+      globalServer,
+      overrideDefaultHostedServer: false,
+      environment: {'TOKEN': 'access token'},
+    );
     await confirmPublish(pub);
 
     handleUploadForm(globalServer);
@@ -36,7 +39,10 @@ void main() {
         {'url': globalServer.url, 'token': 'access token'},
       ]
     }).create();
-    var pub = await startPublish(globalServer, authMethod: 'token');
+    var pub = await startPublish(
+      globalServer,
+      overrideDefaultHostedServer: false,
+    );
     await confirmPublish(pub);
 
     handleUploadForm(globalServer);

--- a/test/token/when_receives_401_removes_token_test.dart
+++ b/test/token/when_receives_401_removes_token_test.dart
@@ -19,7 +19,7 @@ void main() {
         {'url': server.url, 'token': 'access token'},
       ]
     }).create();
-    var pub = await startPublish(server, authMethod: 'token');
+    var pub = await startPublish(server, overrideDefaultHostedServer: false);
     await confirmPublish(pub);
 
     server.expect('GET', '/api/packages/versions/new', (request) {

--- a/test/token/when_receives_403_persists_saved_token_test.dart
+++ b/test/token/when_receives_403_persists_saved_token_test.dart
@@ -19,7 +19,7 @@ void main() {
         {'url': server.url, 'token': 'access token'},
       ]
     }).create();
-    var pub = await startPublish(server, authMethod: 'token');
+    var pub = await startPublish(server, overrideDefaultHostedServer: false);
     await confirmPublish(pub);
 
     server.expect('GET', '/api/packages/versions/new', (request) {


### PR DESCRIPTION
This refactors testing of publishing a bit... and allows use of `dart pub token add` when talking to `pub.dartlang.org`.
