### PR TITLE
Avoid failing in gitignore validator

### DIFF
--- a/lib/src/git.dart
+++ b/lib/src/git.dart
@@ -5,6 +5,7 @@
 /// Helper functionality for invoking Git.
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 
@@ -88,24 +89,9 @@ List<String> runSync(List<String> args,
   return result.stdout;
 }
 
-/// Returns the name of the git command-line app, or `null` if Git could not be
-/// found on the user's PATH.
-String? get command {
-  if (_commandCache != null) return _commandCache;
-
-  if (_tryGitCommand('git')) {
-    _commandCache = 'git';
-  } else if (_tryGitCommand('git.cmd')) {
-    _commandCache = 'git.cmd';
-  } else {
-    return null;
-  }
-
-  log.fine('Determined git command $_commandCache.');
-  return _commandCache;
-}
-
-String? _commandCache;
+/// The name of the git command-line app, or `null` if Git could not be found on
+/// the user's PATH.
+final String? command = ['git', 'git.cmd'].firstWhereOrNull(_tryGitCommand);
 
 /// Returns the root of the git repo [dir] belongs to. Returns `null` if not
 /// in a git repo or git is not installed.
@@ -150,6 +136,7 @@ You have a very old version of git (version ${output.substring('git version '.le
 for $topLevelProgram it is recommended to use git version 2.14 or newer.
 ''');
     }
+    log.fine('Determined git command $command.');
     return true;
   } on RunProcessException catch (err) {
     // If the process failed, they probably don't have it.

--- a/lib/src/validator/gitignore.dart
+++ b/lib/src/validator/gitignore.dart
@@ -11,6 +11,7 @@ import '../entrypoint.dart';
 import '../git.dart' as git;
 import '../ignore.dart';
 import '../io.dart';
+import '../log.dart' as log;
 import '../utils.dart';
 import '../validator.dart';
 
@@ -23,12 +24,21 @@ class GitignoreValidator extends Validator {
   @override
   Future<void> validate() async {
     if (entrypoint.root.inGitRepo) {
-      final checkedIntoGit = git.runSync([
-        'ls-files',
-        '--cached',
-        '--exclude-standard',
-        '--recurse-submodules'
-      ], workingDir: entrypoint.root.dir);
+      late final List<String> checkedIntoGit;
+      try {
+        checkedIntoGit = git.runSync([
+          'ls-files',
+          '--cached',
+          '--exclude-standard',
+          '--recurse-submodules'
+        ], workingDir: entrypoint.root.dir);
+      } on git.GitException catch (e) {
+        log.fine('Could not run `git ls-files` files in repo (${e.message}).');
+        // This validation is only a warning.
+        // If git is not supported on the platform, or too old to support
+        // --recurse-submodules we just continue silently.
+        return;
+      }
       final root = git.repoRoot(entrypoint.root.dir) ?? entrypoint.root.dir;
       var beneath = p.posix.joinAll(
           p.split(p.normalize(p.relative(entrypoint.root.dir, from: root))));

--- a/test/get/git/git_not_installed_test.dart
+++ b/test/get/git/git_not_installed_test.dart
@@ -5,41 +5,10 @@
 @TestOn('linux')
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
-import 'package:pub/src/io.dart' show runProcess;
 import 'package:test/test.dart';
-import 'package:test_descriptor/test_descriptor.dart' show sandbox;
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
-
-/// Create temporary folder 'bin/' containing a 'git' script in [sandbox]
-/// By adding the bin/ folder to the search `$PATH` we can prevent `pub` from
-/// detecting the installed 'git' binary and we can test that it prints
-/// a useful error message.
-Future<void> setUpFakeGitScript(
-    {required String bash, required String batch}) async {
-  await d.dir('bin', [
-    if (!Platform.isWindows) d.file('git', bash),
-    if (Platform.isWindows) d.file('git.bat', batch),
-  ]).create();
-  if (!Platform.isWindows) {
-    // Make the script executable.
-
-    await runProcess('chmod', ['+x', p.join(sandbox, 'bin', 'git')]);
-  }
-}
-
-/// Returns an environment where PATH is extended with `$sandbox/bin`.
-Map<String, String> extendedPathEnv() {
-  final separator = Platform.isWindows ? ';' : ':';
-  final binFolder = p.join(sandbox, 'bin');
-
-  return {
-    // Override 'PATH' to ensure that we can't detect a working "git" binary
-    'PATH': '$binFolder$separator${Platform.environment['PATH']}',
-  };
-}
 
 void main() {
   test('reports failure if Git is not installed', () async {

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -980,3 +980,30 @@ Future<PackageServer> startPackageServer() async {
   });
   return server;
 }
+
+/// Create temporary folder 'bin/' containing a 'git' script in [sandbox]
+/// By adding the bin/ folder to the search `$PATH` we can prevent `pub` from
+/// detecting the installed 'git' binary and we can test that it prints
+/// a useful error message.
+Future<void> setUpFakeGitScript(
+    {required String bash, required String batch}) async {
+  await d.dir('bin', [
+    if (!Platform.isWindows) d.file('git', bash),
+    if (Platform.isWindows) d.file('git.bat', batch),
+  ]).create();
+  if (!Platform.isWindows) {
+    // Make the script executable.
+    await runProcess('chmod', ['+x', p.join(d.sandbox, 'bin', 'git')]);
+  }
+}
+
+/// Returns an environment where PATH is extended with `$sandbox/bin`.
+Map<String, String> extendedPathEnv() {
+  final separator = Platform.isWindows ? ';' : ':';
+  final binFolder = p.join(d.sandbox, 'bin');
+
+  return {
+    // Override 'PATH' to ensure that we can't detect a working "git" binary
+    'PATH': '$binFolder$separator${Platform.environment['PATH']}',
+  };
+}


### PR DESCRIPTION
The gitignore validator is only a warning, its failure to run git should not prevent publication.

This is a followup to: https://github.com/dart-lang/pub/pull/3332