### PR TITLE
Always use forward slash for relative paths in lockfile

### DIFF
--- a/lib/src/source/path.dart
+++ b/lib/src/source/path.dart
@@ -239,7 +239,9 @@ class ResolvedPathDescription extends ResolvedDescription {
   Object? serializeForLockfile({required String? containingDir}) {
     if (description.relative) {
       return {
-        'path': p.relative(description.path, from: containingDir),
+        'path': PathSource.relativePathWithPosixSeparators(
+          p.relative(description.path, from: containingDir),
+        ),
         'relative': true
       };
     }

--- a/test/get/path/relative_path_test.dart
+++ b/test/get/path/relative_path_test.dart
@@ -2,11 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:path/path.dart' as path;
 import 'package:pub/src/lock_file.dart';
 import 'package:pub/src/source/path.dart';
 import 'package:pub/src/system_cache.dart';
 import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
@@ -91,6 +94,12 @@ void main() {
     await pubGet();
 
     var lockfilePath = path.join(d.sandbox, appPath, 'pubspec.lock');
+    final lockfileJson = loadYaml(File(lockfilePath).readAsStringSync());
+    expect(
+      lockfileJson['packages']['foo']['description']['path'],
+      '../foo',
+      reason: 'Should use `/` as separator on all platforms',
+    );
     var lockfile = LockFile.load(lockfilePath, SystemCache().sources);
     var description =
         lockfile.packages['foo']!.description.description as PathDescription;


### PR DESCRIPTION
This broke in https://github.com/dart-lang/pub/pull/3305

