### PR TITLE
dependency_services: use revisions as versions for git deps.

### DIFF
--- a/lib/src/git.dart
+++ b/lib/src/git.dart
@@ -62,6 +62,7 @@ Future<List<String>> run(List<String> args,
         workingDir: workingDir,
         environment: {...?environment, 'LANG': 'en_GB'});
     if (!result.success) {
+      print(result.stderr);
       throw GitException(args, result.stdout.join('\n'),
           result.stderr.join('\n'), result.exitCode);
     }


### PR DESCRIPTION
This is part of solving: https://github.com/dart-lang/pub/issues/3382 (this will most likely require changes in dependabot).

Instead of the version of a git dependency we write the commit hash.
We special case applying these to the lockfile.
