### PR TITLE
Fix crash when checking code with bad import

### DIFF
--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -42,11 +42,9 @@ class StrictDependenciesValidator extends Validator {
 
       for (var directive in directives) {
         Uri? url;
-        try {
-          url = Uri.parse(directive.uri.stringValue!);
-        } on FormatException catch (_) {
-          // Ignore a format exception. [url] will be null, and we'll emit an
-          // "Invalid URL" warning below.
+        final uriString = directive.uri.stringValue;
+        if (uriString != null) {
+          url = Uri.tryParse(uriString);
         }
 
         // If the URL could not be parsed or it is a `package:` URL AND there

--- a/test/validator/strict_dependencies_test.dart
+++ b/test/validator/strict_dependencies_test.dart
@@ -183,6 +183,14 @@ linter:
   group('should consider a package invalid if it', () {
     setUp(d.validPackage.create);
 
+    test('has an invalid String value', () async {
+      await d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+        import 'package:$bad';
+      ''').create();
+
+      await expectValidation(strictDeps, errors: [matches('Invalid URL.')]);
+    });
+
     test('does not declare an "import" as a dependency', () async {
       await d.file(path.join(appPath, 'lib', 'library.dart'), r'''
         import 'package:silly_monkey/silly_monkey.dart';


### PR DESCRIPTION
Closes #1731

If an import attempts to use string interpolation it will have a null
`stringValue` in the analyzer. Fix the resulting crash trying to parse
the null string.

Refactor to `Uri.tryParse` instead of catching the `FormatException`.