### PR TITLE
Make tests more agnostic to the test environment

### DIFF
--- a/test/get/with_empty_environment_test.dart
+++ b/test/get/with_empty_environment_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;

--- a/test/get/with_empty_environment_test.dart
+++ b/test/get/with_empty_environment_test.dart
@@ -22,6 +22,6 @@ void main() {
         'SYSTEMROOT': Platform.environment['SYSTEMROOT'],
         'TMP': Platform.environment['TMP'],
       },
-    }, includeParentEnvironment: false);
+    }, includeParentHomeAndPath: false);
   });
 }

--- a/test/get/with_empty_environment_test.dart
+++ b/test/get/with_empty_environment_test.dart
@@ -18,10 +18,6 @@ void main() {
 
     await pubGet(environment: {
       '_PUB_TEST_CONFIG_DIR': null,
-      if (Platform.isWindows) ...{
-        'SYSTEMROOT': Platform.environment['SYSTEMROOT'],
-        'TMP': Platform.environment['TMP'],
-      },
     }, includeParentHomeAndPath: false);
   });
 }

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -130,7 +130,7 @@ Future<void> pubCommand(
   int? exitCode,
   Map<String, String?>? environment,
   String? workingDirectory,
-  includeParentEnvironment = true,
+  includeParentHomeAndPath = true,
 }) async {
   if (error != null && warning != null) {
     throw ArgumentError("Cannot pass both 'error' and 'warning'.");
@@ -155,7 +155,7 @@ Future<void> pubCommand(
       exitCode: exitCode,
       environment: environment,
       workingDirectory: workingDirectory,
-      includeParentEnvironment: includeParentEnvironment);
+      includeParentHomeAndPath: includeParentHomeAndPath);
 }
 
 Future<void> pubAdd({
@@ -186,7 +186,7 @@ Future<void> pubGet({
   int? exitCode,
   Map<String, String?>? environment,
   String? workingDirectory,
-  bool includeParentEnvironment = true,
+  bool includeParentHomeAndPath = true,
 }) async =>
     await pubCommand(
       RunCommand.get,
@@ -197,7 +197,7 @@ Future<void> pubGet({
       exitCode: exitCode,
       environment: environment,
       workingDirectory: workingDirectory,
-      includeParentEnvironment: includeParentEnvironment,
+      includeParentHomeAndPath: includeParentHomeAndPath,
     );
 
 Future<void> pubUpgrade(
@@ -322,7 +322,7 @@ Future<void> runPub(
     String? workingDirectory,
     Map<String, String?>? environment,
     List<String>? input,
-    includeParentEnvironment = true}) async {
+    includeParentHomeAndPath = true}) async {
   exitCode ??= exit_codes.SUCCESS;
   // Cannot pass both output and outputJson.
   assert(output == null || outputJson == null);
@@ -331,7 +331,7 @@ Future<void> runPub(
     args: args,
     workingDirectory: workingDirectory,
     environment: environment,
-    includeParentEnvironment: includeParentEnvironment,
+    includeParentHomeAndPath: includeParentHomeAndPath,
   );
 
   if (input != null) {
@@ -446,7 +446,7 @@ Future<PubProcess> startPub(
     String? workingDirectory,
     Map<String, String?>? environment,
     bool verbose = true,
-    includeParentEnvironment = true}) async {
+    includeParentHomeAndPath = true}) async {
   args ??= [];
 
   ensureDir(_pathInSandbox(appPath));
@@ -468,7 +468,13 @@ Future<PubProcess> startPub(
     ..addAll([pubPath, if (!verbose) '--verbosity=normal'])
     ..addAll(args);
 
-  final mergedEnvironment = getPubTestEnvironment(tokenEndpoint);
+  final mergedEnvironment = {
+    if (includeParentHomeAndPath) ...{
+      'HOME': Platform.environment['HOME'] ?? '',
+      'PATH': Platform.environment['PATH'] ?? '',
+    },
+    ...getPubTestEnvironment(tokenEndpoint)
+  };
   for (final e in (environment ?? {}).entries) {
     var value = e.value;
     if (value == null) {
@@ -482,7 +488,7 @@ Future<PubProcess> startPub(
       environment: mergedEnvironment,
       workingDirectory: workingDirectory ?? _pathInSandbox(appPath),
       description: args.isEmpty ? 'pub' : 'pub ${args.first}',
-      includeParentEnvironment: includeParentEnvironment);
+      includeParentEnvironment: false);
 }
 
 /// A subclass of [TestProcess] that parses pub's verbose logging output and

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -473,6 +473,11 @@ Future<PubProcess> startPub(
       'HOME': Platform.environment['HOME'] ?? '',
       'PATH': Platform.environment['PATH'] ?? '',
     },
+    // These seem to be needed for networking to work.
+    if (Platform.isWindows) ...{
+      'SYSTEMROOT': Platform.environment['SYSTEMROOT'],
+      'TMP': Platform.environment['TMP'],
+    },
     ...getPubTestEnvironment(tokenEndpoint)
   };
   for (final e in (environment ?? {}).entries) {

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -468,6 +468,9 @@ Future<PubProcess> startPub(
     ..addAll([pubPath, if (!verbose) '--verbosity=normal'])
     ..addAll(args);
 
+  final systemRoot = Platform.environment['SYSTEMROOT'];
+  final tmp = Platform.environment['TMP'];
+
   final mergedEnvironment = {
     if (includeParentHomeAndPath) ...{
       'HOME': Platform.environment['HOME'] ?? '',
@@ -475,8 +478,8 @@ Future<PubProcess> startPub(
     },
     // These seem to be needed for networking to work.
     if (Platform.isWindows) ...{
-      'SYSTEMROOT': Platform.environment['SYSTEMROOT'],
-      'TMP': Platform.environment['TMP'],
+      if (systemRoot != null) 'SYSTEMROOT': systemRoot,
+      if (tmp != null) 'TMP': tmp,
     },
     ...getPubTestEnvironment(tokenEndpoint)
   };

--- a/test/token/add_token_test.dart
+++ b/test/token/add_token_test.dart
@@ -147,7 +147,7 @@ void main() {
       error: contains('No config dir found.'),
       exitCode: exit_codes.DATA,
       environment: {'_PUB_TEST_CONFIG_DIR': null},
-      includeParentEnvironment: false,
+      includeParentHomeAndPath: false,
     );
   });
 

--- a/test/token/remove_token_test.dart
+++ b/test/token/remove_token_test.dart
@@ -66,7 +66,7 @@ void main() {
       error: contains('No config dir found.'),
       exitCode: exit_codes.DATA,
       environment: {'_PUB_TEST_CONFIG_DIR': null},
-      includeParentEnvironment: false,
+      includeParentHomeAndPath: false,
     );
   });
 }

--- a/tool/test.dart
+++ b/tool/test.dart
@@ -17,6 +17,11 @@ import 'package:pub/src/dart.dart';
 import 'package:pub/src/exceptions.dart';
 
 Future<void> main(List<String> args) async {
+  if (Platform.environment['FLUTTER_ROOT'] != null) {
+    print(
+      'WARNING: The tests will not run correctly with dart from a flutter checkout!',
+    );
+  }
   Process? testProcess;
   final sub = ProcessSignal.sigint.watch().listen((signal) {
     testProcess?.kill(signal);


### PR DESCRIPTION
This was triggered by spending time not understanding why tests failed when run with dart from a flutter checkout.

They will still not run with a dart from a flutter checkout (but you'll get a warning).

However in my opinion it is still preferable that tests are not affected by the environment.
We need to pass HOME for the .config stuff - we could also consider making a homedir in the sandbox....
We need to pass PATH for enabling use of the system git.