### PR TITLE
Make `name` field of `_UserInfo` nullable. Fix #3424

### DIFF
--- a/lib/src/command/login.dart
+++ b/lib/src/command/login.dart
@@ -55,7 +55,7 @@ class LoginCommand extends PubCommand {
         final userInfo = json.decode(userInfoRequest.body);
         final name = userInfo['name'];
         final email = userInfo['email'];
-        if (name is String && email is String) {
+        if (email is String) {
           return _UserInfo(name, email);
         } else {
           log.fine(
@@ -72,9 +72,9 @@ class LoginCommand extends PubCommand {
 }
 
 class _UserInfo {
-  final String name;
+  final String? name;
   final String email;
   _UserInfo(this.name, this.email);
   @override
-  String toString() => ['<$email>', name].join(' ');
+  String toString() => ['<$email>', name ?? ''].join(' ');
 }


### PR DESCRIPTION
Fix #3424 .

The PR #3427 only fix the dart error. But actually pub cannot retrieve the user info. 

As @bsutton said.

> The symptom is that the 'name' field is not being returned by the google auth mechanism.
> I've tried pub logout and then pub login with the same results.
> Is there some chance that google no longer return the 'name' field in the user info response?
> 
> Reading the google documentation:
> https://developers.google.com/identity/protocols/oauth2/openid-connect#server-flow
> name - The user's full name, in a displayable form. Might be provided when: The request scope included the string "profile"
> The ID token is returned from a token refresh. When name claims are present, you can use them to update your app's user records. 
> 
> Note that this claim is never guaranteed to be present.
> Note the last sentence.

We should make the `name` filed nullable.