### PR TITLE
Use non-nullable parameters for operator ==

### DIFF
--- a/lib/src/third_party/tar/src/format.dart
+++ b/lib/src/third_party/tar/src/format.dart
@@ -28,7 +28,7 @@ class TarFormat {
   int get hashCode => _value;
 
   @override
-  bool operator ==(Object? other) {
+  bool operator ==(Object other) {
     if (other is! TarFormat) return false;
 
     return _value == other._value;

--- a/lib/src/third_party/tar/src/sparse.dart
+++ b/lib/src/third_party/tar/src/sparse.dart
@@ -21,7 +21,7 @@ class SparseEntry {
   String toString() => 'offset: $offset, length $length';
 
   @override
-  bool operator ==(Object? other) {
+  bool operator ==(Object other) {
     if (other is! SparseEntry) return false;
 
     return offset == other.offset && length == other.length;


### PR DESCRIPTION
The null value will never be passed to the equals operator
implementation. Widening the type causes any other class which
implements this interface to also widen the type.
