### PR TITLE
Roll tar to 0.5.5+1

### DIFF
--- a/lib/src/third_party/tar/README.md
+++ b/lib/src/third_party/tar/README.md
@@ -4,4 +4,4 @@ Vendored elements from `package:tar` for use in creation and extraction of
 tar-archives.
 
  * Repository: `https://github.com/simolus3/tar/`
- * Revision: `7cdb563c9894600c6a739ec268f8673d6122006f`
+ * Revision: `901ae404e0a225d9b08e5253415ca092f5c08706`

--- a/lib/src/third_party/tar/src/charcodes.dart
+++ b/lib/src/third_party/tar/src/charcodes.dart
@@ -1,3 +1,6 @@
+@internal
+import 'package:meta/meta.dart';
+
 /// "Line feed" control character.
 const int $lf = 0x0a;
 

--- a/lib/src/third_party/tar/src/constants.dart
+++ b/lib/src/third_party/tar/src/constants.dart
@@ -1,8 +1,11 @@
+@internal
 import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
 
 import 'charcodes.dart';
 import 'exception.dart';
-import 'header.dart' show TarHeader; // for dartdoc
+import 'header.dart';
 
 // Magic values to help us identify the TAR header type.
 const magicGnu = [$u, $s, $t, $a, $r, $space]; // 'ustar '
@@ -10,74 +13,6 @@ const versionGnu = [$space, 0]; // ' \x00'
 const magicUstar = [$u, $s, $t, $a, $r, 0]; // 'ustar\x00'
 const versionUstar = [$0, $0]; // '00'
 const trailerStar = [$t, $a, $r, 0]; // 'tar\x00'
-
-/// Type flags for [TarHeader].
-///
-/// The type flag of a header indicates the kind of file associated with the
-/// entry. This enum contains the various type flags over the different TAR
-/// formats, and users should be careful that the type flag corresponds to the
-/// TAR format they are working with.
-enum TypeFlag {
-  /// [reg] indicates regular files.
-  ///
-  /// Old tar implementations have a seperate `TypeRegA` value. This library
-  /// will transparently read those as [regA].
-  reg,
-
-  /// Legacy-version of [reg] in old tar implementations.
-  ///
-  /// This is only used internally.
-  regA,
-
-  /// Hard link - header-only, may not have a data body
-  link,
-
-  /// Symbolic link - header-only, may not have a data body
-  symlink,
-
-  /// Character device node - header-only, may not have a data body
-  char,
-
-  /// Block device node - header-only, may not have a data body
-  block,
-
-  /// Directory - header-only, may not have a data body
-  dir,
-
-  /// FIFO node - header-only, may not have a data body
-  fifo,
-
-  /// Currently does not have any meaning, but is reserved for the future.
-  reserved,
-
-  /// Used by the PAX format to store key-value records that are only relevant
-  /// to the next file.
-  ///
-  /// This package transparently handles these types.
-  xHeader,
-
-  /// Used by the PAX format to store key-value records that are relevant to all
-  /// subsequent files.
-  ///
-  /// This package only supports parsing and composing such headers,
-  /// but does not currently support persisting the global state across files.
-  xGlobalHeader,
-
-  /// Indiates a sparse file in the GNU format
-  gnuSparse,
-
-  /// Used by the GNU format for a meta file to store the path or link name for
-  /// the next file.
-  /// This package transparently handles these types.
-  gnuLongName,
-  gnuLongLink,
-
-  /// Vendor specific typeflag, as defined in POSIX.1-1998. Seen as outdated but
-  /// may still exist on old files.
-  ///
-  /// This library uses a single enum to catch them all.
-  vendor
-}
 
 /// Generates the corresponding [TypeFlag] associated with [byte].
 TypeFlag typeflagFromByte(int byte) {

--- a/lib/src/third_party/tar/src/entry.dart
+++ b/lib/src/third_party/tar/src/entry.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 
-import 'constants.dart';
 import 'header.dart';
 
 /// An entry in a tar file.

--- a/lib/src/third_party/tar/src/format.dart
+++ b/lib/src/third_party/tar/src/format.dart
@@ -28,7 +28,7 @@ class TarFormat {
   int get hashCode => _value;
 
   @override
-  bool operator ==(Object? other) {
+  bool operator ==(Object other) {
     if (other is! TarFormat) return false;
 
     return _value == other._value;

--- a/lib/src/third_party/tar/src/header.dart
+++ b/lib/src/third_party/tar/src/header.dart
@@ -7,6 +7,74 @@ import 'exception.dart';
 import 'format.dart';
 import 'utils.dart';
 
+/// Type flags for [TarHeader].
+///
+/// The type flag of a header indicates the kind of file associated with the
+/// entry. This enum contains the various type flags over the different TAR
+/// formats, and users should be careful that the type flag corresponds to the
+/// TAR format they are working with.
+enum TypeFlag {
+  /// [reg] indicates regular files.
+  ///
+  /// Old tar implementations have a seperate `TypeRegA` value. This library
+  /// will transparently read those as [regA].
+  reg,
+
+  /// Legacy-version of [reg] in old tar implementations.
+  ///
+  /// This is only used internally.
+  regA,
+
+  /// Hard link - header-only, may not have a data body
+  link,
+
+  /// Symbolic link - header-only, may not have a data body
+  symlink,
+
+  /// Character device node - header-only, may not have a data body
+  char,
+
+  /// Block device node - header-only, may not have a data body
+  block,
+
+  /// Directory - header-only, may not have a data body
+  dir,
+
+  /// FIFO node - header-only, may not have a data body
+  fifo,
+
+  /// Currently does not have any meaning, but is reserved for the future.
+  reserved,
+
+  /// Used by the PAX format to store key-value records that are only relevant
+  /// to the next file.
+  ///
+  /// This package transparently handles these types.
+  xHeader,
+
+  /// Used by the PAX format to store key-value records that are relevant to all
+  /// subsequent files.
+  ///
+  /// This package only supports parsing and composing such headers,
+  /// but does not currently support persisting the global state across files.
+  xGlobalHeader,
+
+  /// Indiates a sparse file in the GNU format
+  gnuSparse,
+
+  /// Used by the GNU format for a meta file to store the path or link name for
+  /// the next file.
+  /// This package transparently handles these types.
+  gnuLongName,
+  gnuLongLink,
+
+  /// Vendor specific typeflag, as defined in POSIX.1-1998. Seen as outdated but
+  /// may still exist on old files.
+  ///
+  /// This library uses a single enum to catch them all.
+  vendor
+}
+
 /// Header of a tar entry
 ///
 /// A tar header stores meta-information about the matching tar entry, such as

--- a/lib/src/third_party/tar/src/sparse.dart
+++ b/lib/src/third_party/tar/src/sparse.dart
@@ -1,3 +1,4 @@
+@internal
 import 'package:async/async.dart';
 import 'package:meta/meta.dart';
 
@@ -21,7 +22,7 @@ class SparseEntry {
   String toString() => 'offset: $offset, length $length';
 
   @override
-  bool operator ==(Object? other) {
+  bool operator ==(Object other) {
     if (other is! SparseEntry) return false;
 
     return offset == other.offset && length == other.length;

--- a/lib/src/third_party/tar/tar.dart
+++ b/lib/src/third_party/tar/tar.dart
@@ -8,10 +8,9 @@ library tar;
 import 'src/reader.dart';
 import 'src/writer.dart';
 
-export 'src/constants.dart' show TypeFlag;
 export 'src/entry.dart' show TarEntry, SynchronousTarEntry;
 export 'src/exception.dart';
 export 'src/format.dart';
-export 'src/header.dart' show TarHeader;
+export 'src/header.dart' show TarHeader, TypeFlag;
 export 'src/reader.dart' show TarReader;
 export 'src/writer.dart';


### PR DESCRIPTION
The only non-trivial change is that the reader now handles pause events happening after the last chunk of a tar entry but before the stream is fully closed.
I don't believe these changes to have an impact on pub, but if you want me to I can once again setup a comparison script ensuring all packages extract without changes.

This also contains the changes from #3446.