### PR TITLE
Fix stack-trace expectation

### DIFF
--- a/test/embedding/embedding_test.dart
+++ b/test/embedding/embedding_test.dart
@@ -231,7 +231,7 @@ main() {
 }
 
 String _filter(String input) {
-  return input
+  final r = input
       .replaceAll(p.toUri(d.sandbox).toString(), r'file://$SANDBOX')
       .replaceAll(d.sandbox, r'$SANDBOX')
       .replaceAll(Platform.pathSeparator, '/')
@@ -326,5 +326,16 @@ String _filter(String input) {
       .replaceAll(
         RegExp(r'Writing \d+ characters', multiLine: true),
         r'Writing $N characters',
-      );
+      )
+
+      /// TODO(sigurdm): This hack suppresses differences in stack-traces
+      /// between dart 2.17 and 2.18. Remove when 2.18 is stable.
+      .replaceAllMapped(
+          RegExp(
+            r'(^(.*)pub/src/command.dart \$LINE:\$COL(.*)$)\n\1',
+            multiLine: true,
+          ),
+          (match) => match[1]!);
+  print(r);
+  return r;
 }

--- a/test/embedding/embedding_test.dart
+++ b/test/embedding/embedding_test.dart
@@ -39,10 +39,15 @@ Future<void> runEmbeddingToBuffer(
   );
   await process.shouldExit(exitCode);
 
+  final stdoutLines = await process.stdout.rest.toList();
+  final stderrLines = await process.stderr.rest.toList();
+
   buffer.writeln([
     '\$ $_commandRunner ${args.join(' ')}',
-    ...await process.stdout.rest.map(_filter).toList(),
-    ...await process.stderr.rest.map((e) => '[E] ${_filter(e)}').toList(),
+    if (stdoutLines.isNotEmpty) _filter(stdoutLines.join('\n')),
+    if (stderrLines.isNotEmpty)
+      _filter(stderrLines.join('\n'))
+          .replaceAll(RegExp('^', multiLine: true), '[E] '),
   ].join('\n'));
   buffer.write('\n');
 }
@@ -231,7 +236,7 @@ main() {
 }
 
 String _filter(String input) {
-  final r = input
+  return input
       .replaceAll(p.toUri(d.sandbox).toString(), r'file://$SANDBOX')
       .replaceAll(d.sandbox, r'$SANDBOX')
       .replaceAll(Platform.pathSeparator, '/')
@@ -336,6 +341,4 @@ String _filter(String input) {
             multiLine: true,
           ),
           (match) => match[1]!);
-  print(r);
-  return r;
 }

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -249,7 +249,6 @@ $ tool/test-bin/pub_command_runner.dart pub fail
 [E] Bad state: Pub has crashed
 [E]  tool/test-bin/pub_command_runner.dart $LINE:$COL   ThrowingCommand.runProtected
 [E] package:pub/src/command.dart $LINE:$COL   PubCommand.run.<fn>
-[E] package:pub/src/command.dart $LINE:$COL   PubCommand.run.<fn>
 [E] dart:async   new Future.sync
 [E] package:pub/src/utils.dart $LINE:$COL   captureErrors.wrappedCallback
 [E] dart:async   runZonedGuarded

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -289,7 +289,6 @@ ERR : Bad state: Pub has crashed
 FINE: Exception type: StateError
 ERR : tool/test-bin/pub_command_runner.dart $LINE:$COL   ThrowingCommand.runProtected
    | package:pub/src/command.dart $LINE:$COL   PubCommand.run.<fn>
-   | package:pub/src/command.dart $LINE:$COL   PubCommand.run.<fn>
    | dart:async   new Future.sync
    | package:pub/src/utils.dart $LINE:$COL   captureErrors.wrappedCallback
    | dart:async   runZonedGuarded


### PR DESCRIPTION
Dart 2.18 will have better stack-traces.

Hardcoded filter of the stacktrace to be compatible with both worlds.