### PR TITLE
Fix typo "exitcode"

### DIFF
--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -165,7 +165,7 @@ abstract class PubCommand extends Command<int> {
 
   /// Override the exit code that would normally be used when exiting
   /// successfully. Intended to be used by subcommands like `run` that wishes
-  /// to control the top-level exitcode.
+  /// to control the top-level exit code.
   ///
   /// This may only be called once.
   @nonVirtual

--- a/test/golden_file.dart
+++ b/test/golden_file.dart
@@ -149,7 +149,7 @@ class GoldenTestContext {
       _expectSection(_nextSectionIndex++, actual);
 
   /// Run `pub` [args] with [environment] variables in [workingDirectory], and
-  /// log stdout/stderr and exitcode to golden file.
+  /// log stdout/stderr and exit code to golden file.
   Future<void> run(
     List<String> args, {
     Map<String, String>? environment,


### PR DESCRIPTION
I think it should be called "exit code" instead "exitcode". Correct me, if I'm wrong.