### PR TITLE
Fix remaining usages of path.prettyUri on git uris

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -295,7 +295,7 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
 
     if (description is GitDescription) {
       log.message('Package ${log.bold(name)} is currently active from Git '
-          'repository "${p.prettyUri(description.url)}".');
+          'repository "${GitDescription.prettyUri(description.url)}".');
     } else if (description is PathDescription) {
       log.message('Package ${log.bold(name)} is currently active at path '
           '"${description.path}".');
@@ -457,7 +457,7 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
   String _formatPackage(PackageId id) {
     final description = id.description.description;
     if (description is GitDescription) {
-      var url = p.prettyUri(description.url);
+      var url = GitDescription.prettyUri(description.url);
       return '${log.bold(id.name)} ${id.version} from Git repository "$url"';
     } else if (description is PathDescription) {
       var path = description.path;

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -275,7 +275,7 @@ class GitSource extends CachedSource {
           .run(['show', '$revision:$pubspecPath'], workingDir: repoPath);
     } on git.GitException catch (_) {
       fail('Could not find a file named "$pubspecPath" in '
-          '${p.prettyUri(description.url)} $revision.');
+          '${GitDescription.prettyUri(description.url)} $revision.');
     }
 
     return Pubspec.parse(


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/3520
Fixes https://github.com/dart-lang/pub/issues/3497

There were remaining uses of `path.prettyUri` on git-URIs. These fails as `Uri.parse` does not handle `git@github.com/a/b.git` style urls. (As discussed in: https://github.com/dart-lang/pub/issues/3377#issuecomment-1091430936)

@mit-mit 
We should consider hotfixing this into 2.18 if there is time.