### PR TITLE
Use pub.dev in writing

### DIFF
--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -4,12 +4,12 @@ This document specifies the REST API that a hosted pub _package repository_ must
 implement.
 
 A package repository is a server from which packages can be downloaded,
-the default package repository is `'https://pub.dartlang.org'`, with public
-interface hosted at [pub.dev](https://pub.dev).
+the default package repository is `'https://pub.dev'`.
+It used to be [pub.dartlang.org](https://pub.dartlang.org).
 
 ## Hosted URL
 A custom package repository is identified by a _hosted-url_, like
-`https://pub.dartlang.org` or `https://some-server.com/prefix/pub/`.
+`https://pub.dev` or `https://some-server.com/prefix/pub/`.
 The _hosted-url_ always includes protocol `http://` or `https://`.
 For the purpose of this specification the _hosted-url_ should always be
 normalized such that it doesn't end with a slash (`/`). As all URL end-points
@@ -17,7 +17,7 @@ described in this specification includes slash prefix.
 
 For the remainder of this specification the placeholder `<hosted-url>` will be
 used in place of a _hosted-url_ such as:
- * `https://pub.dartlang.org`
+ * `https://pub.dev`
  * `https://some-server.com/prefix/pub`
  * `https://pub.other-server.com/prefix`
  * `http://localhost:8080`

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -154,7 +154,7 @@ class LishCommand extends PubCommand {
   Future<void> _publish(List<int> packageBytes) async {
     try {
       final officialPubServers = {
-        'https://dev',
+        'https://pub.dev',
         // [validateAndNormalizeHostedUrl] normalizes https://pub.dartlang.org
         // to https://pub.dev, so we don't need to do allow that here.
 

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -25,7 +25,7 @@ class LishCommand extends PubCommand {
   @override
   String get name => 'publish';
   @override
-  String get description => 'Publish the current package to pub.dartlang.org.';
+  String get description => 'Publish the current package to pub.dev.';
   @override
   String get argumentsDescription => '[options]';
   @override
@@ -154,9 +154,9 @@ class LishCommand extends PubCommand {
   Future<void> _publish(List<int> packageBytes) async {
     try {
       final officialPubServers = {
-        'https://pub.dartlang.org',
-        // [validateAndNormalizeHostedUrl] normalizes https://pub.dev to
-        // https://pub.dartlang.org, so we don't need to do allow that here.
+        'https://dev',
+        // [validateAndNormalizeHostedUrl] normalizes https://pub.dartlang.org
+        // to https://pub.dev, so we don't need to do allow that here.
 
         // Pub uses oauth2 credentials only for authenticating official pub
         // servers for security purposes (to not expose pub.dev access token to

--- a/lib/src/command/uploader.dart
+++ b/lib/src/command/uploader.dart
@@ -13,8 +13,7 @@ class UploaderCommand extends PubCommand {
   @override
   String get name => 'uploader';
   @override
-  String get description =>
-      'Manage uploaders for a package on pub.dartlang.org.';
+  String get description => 'Manage uploaders for a package on pub.dev.';
   @override
   String get argumentsDescription => '[options] {add/remove} <email>';
   @override

--- a/lib/src/oauth2.dart
+++ b/lib/src/oauth2.dart
@@ -78,7 +78,7 @@ void _clearCredentials(SystemCache cache) {
 void logout(SystemCache cache) {
   var credentialsFile = _credentialsFile(cache);
   if (credentialsFile != null && entryExists(credentialsFile)) {
-    log.message('Logging out of pub.dartlang.org.');
+    log.message('Logging out of pub.dev.');
     log.message('Deleting $credentialsFile');
     _clearCredentials(cache);
     // Test if we also have a legacy credentials file.

--- a/lib/src/pubspec_parse.dart
+++ b/lib/src/pubspec_parse.dart
@@ -14,7 +14,7 @@ import 'utils.dart' show identifierRegExp, reservedWords;
 ///
 /// This allows dot-separated valid Dart identifiers. The dots are there for
 /// compatibility with Google's internal Dart packages, but they may not be used
-/// when publishing a package to pub.dartlang.org.
+/// when publishing a package to pub.dev.
 final packageNameRegExp =
     RegExp('^${identifierRegExp.pattern}(\\.${identifierRegExp.pattern})*\$');
 

--- a/lib/src/source.dart
+++ b/lib/src/source.dart
@@ -66,7 +66,7 @@ abstract class Source {
   /// [containingDir] is the path to the directory of the pubspec where this
   /// description appears. It may be `null` if the description is coming from
   /// some in-memory source (such as pulling down a pubspec from
-  /// pub.dartlang.org).
+  /// pub.dev).
   ///
   /// [languageVersion] is the minimum Dart version parsed from the pubspec's
   /// `environment` field. Source implementations may use this parameter to only

--- a/test/global/activate/custom_hosted_url_test.dart
+++ b/test/global/activate/custom_hosted_url_test.dart
@@ -8,7 +8,7 @@ import '../../test_pub.dart';
 
 void main() {
   test('activating a package from a custom pub server', () async {
-    // The default pub server (i.e. pub.dartlang.org).
+    // The default pub server (i.e. pub.dev).
     final server = await servePackages();
     server.serve('baz', '1.0.0');
 

--- a/test/lish/force_does_not_publish_if_there_are_errors_test.dart
+++ b/test/lish/force_does_not_publish_if_there_are_errors_test.dart
@@ -15,7 +15,7 @@ void main() {
     await d.dir(appPath, [
       d.rawPubspec({
         'name': 'test_pkg',
-        'homepage': 'http://pub.dartlang.org',
+        'homepage': 'https://pub.dartlang.org',
         'version': '1.0.0',
       }),
     ]).create();

--- a/test/lish/package_validation_has_an_error_test.dart
+++ b/test/lish/package_validation_has_an_error_test.dart
@@ -15,7 +15,7 @@ void main() {
     await d.dir(appPath, [
       d.rawPubspec({
         'name': 'test_pkg',
-        'homepage': 'http://pub.dartlang.org',
+        'homepage': 'https://pub.dev',
         'version': '1.0.0',
       }),
     ]).create();

--- a/test/oauth2/logout_test.dart
+++ b/test/oauth2/logout_test.dart
@@ -16,8 +16,7 @@ void main() {
             expiration: DateTime.now().add(Duration(hours: 1)))
         .create();
 
-    await runPub(
-        args: ['logout'], output: contains('Logging out of pub.dartlang.org.'));
+    await runPub(args: ['logout'], output: contains('Logging out of pub.dev.'));
 
     await d.dir(configPath, [d.nothing('pub-credentials.json')]).validate();
   });
@@ -48,7 +47,7 @@ void main() {
       args: ['logout'],
       output: allOf(
         [
-          contains('Logging out of pub.dartlang.org.'),
+          contains('Logging out of pub.dev.'),
           contains('Also deleting legacy credentials at ')
         ],
       ),

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -370,7 +370,7 @@ dependencies:
             ResolvedHostedDescription(foo.description as HostedDescription)
                 .serializeForLockfile(containingDir: null),
             {
-              'url': 'https://pub.dartlang.org',
+              'url': 'https://pub.dev',
               'name': 'bar',
             });
       });
@@ -414,7 +414,7 @@ dependencies:
             ResolvedHostedDescription(foo.description as HostedDescription)
                 .serializeForLockfile(containingDir: null),
             {
-              'url': 'https://pub.dartlang.org',
+              'url': 'https://pub.dev',
               'name': 'foo',
             });
       });
@@ -622,7 +622,7 @@ publish_to: none
 
       test('throws on non-absolute URLs', () {
         expectPubspecException(
-            'publish_to: pub.dartlang.org', (pubspec) => pubspec.publishTo);
+            'publish_to: pub.dev', (pubspec) => pubspec.publishTo);
       });
     });
 

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -370,7 +370,7 @@ dependencies:
             ResolvedHostedDescription(foo.description as HostedDescription)
                 .serializeForLockfile(containingDir: null),
             {
-              'url': 'https://pub.dev',
+              'url': 'https://pub.dartlang.org',
               'name': 'bar',
             });
       });
@@ -414,7 +414,7 @@ dependencies:
             ResolvedHostedDescription(foo.description as HostedDescription)
                 .serializeForLockfile(containingDir: null),
             {
-              'url': 'https://pub.dev',
+              'url': 'https://pub.dartlang.org',
               'name': 'foo',
             });
       });

--- a/test/reformat_ranges_test.dart
+++ b/test/reformat_ranges_test.dart
@@ -11,7 +11,7 @@ import 'package:test/test.dart';
 
 void main() {
   final description = ResolvedHostedDescription(
-    HostedDescription('foo', 'https://pub.dartlang.org'),
+    HostedDescription('foo', 'https://pub.dev'),
   );
   test('reformatMax when max has a build identifier', () {
     expect(

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -681,7 +681,7 @@ Map<String, Object> packageMap(
   var package = <String, Object>{
     'name': name,
     'version': version,
-    'homepage': 'http://pub.dartlang.org',
+    'homepage': 'http://pub.dev',
     'description': 'A package, I guess.'
   };
 
@@ -691,7 +691,7 @@ Map<String, Object> packageMap(
   return package;
 }
 
-/// Returns a Map in the format used by the pub.dartlang.org API to represent a
+/// Returns a Map in the format used by the pub.dev API to represent a
 /// package version.
 ///
 /// [pubspec] is the parsed pubspec of the package version. If [full] is true,
@@ -946,8 +946,8 @@ Future<void> runPubIntoBuffer(
 PackageServer get globalServer => _globalServer!;
 PackageServer? _globalServer;
 
-/// Creates an HTTP server that replicates the structure of pub.dartlang.org and
-/// makes it the current [globalServer].
+/// Creates an HTTP server that replicates the structure of pub.dev and makes it
+/// the current [globalServer].
 Future<PackageServer> servePackages() async {
   final server = await startPackageServer();
   _globalServer = server;

--- a/test/testdata/goldens/dependency_services/dependency_services_test/Can update a git package.txt
+++ b/test/testdata/goldens/dependency_services/dependency_services_test/Can update a git package.txt
@@ -11,7 +11,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "92cdd4ac724a6da0db2a69ac149820aa220e8518"
+      resolved-ref: "5373af3230028f3e31e9ee39e326228db83710cb"
       url: "../bar.git"
     source: git
     version: "1.0.0"
@@ -20,7 +20,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "1ae220cc484311a7a1e2e31d1ccc6ea995acb6ba"
+      resolved-ref: "428f5dd6e627cb2384343eca6aed099f4f7d183d"
       url: "../foo.git"
     source: git
     version: "1.0.0"
@@ -34,7 +34,7 @@ $ dependency_services list
   "dependencies": [
     {
       "name": "bar",
-      "version": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+      "version": "5373af3230028f3e31e9ee39e326228db83710cb",
       "kind": "direct",
       "constraint": "^1.0.0",
       "source": {
@@ -42,14 +42,14 @@ $ dependency_services list
         "description": {
           "url": "../bar.git",
           "ref": "HEAD",
-          "resolved-ref": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+          "resolved-ref": "5373af3230028f3e31e9ee39e326228db83710cb",
           "path": "."
         }
       }
     },
     {
       "name": "foo",
-      "version": "1ae220cc484311a7a1e2e31d1ccc6ea995acb6ba",
+      "version": "428f5dd6e627cb2384343eca6aed099f4f7d183d",
       "kind": "direct",
       "constraint": "any",
       "source": {
@@ -57,7 +57,7 @@ $ dependency_services list
         "description": {
           "url": "../foo.git",
           "ref": "HEAD",
-          "resolved-ref": "1ae220cc484311a7a1e2e31d1ccc6ea995acb6ba",
+          "resolved-ref": "428f5dd6e627cb2384343eca6aed099f4f7d183d",
           "path": "."
         }
       }
@@ -73,45 +73,45 @@ $ dependency_services report
   "dependencies": [
     {
       "name": "bar",
-      "version": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+      "version": "5373af3230028f3e31e9ee39e326228db83710cb",
       "kind": "direct",
       "source": {
         "type": "git",
         "description": {
           "url": "../bar.git",
           "ref": "HEAD",
-          "resolved-ref": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+          "resolved-ref": "5373af3230028f3e31e9ee39e326228db83710cb",
           "path": "."
         }
       },
-      "latest": "cf473c33e39eeec4615bc2cde8bf68cbb10ad02c",
+      "latest": "40d0ffbfc376f2a796b0bbb928636c242285a01c",
       "constraint": "^1.0.0",
       "compatible": [],
       "singleBreaking": [
         {
           "name": "bar",
-          "version": "cf473c33e39eeec4615bc2cde8bf68cbb10ad02c",
+          "version": "40d0ffbfc376f2a796b0bbb928636c242285a01c",
           "kind": "direct",
           "source": {
             "type": "git",
             "description": {
               "url": "../bar.git",
               "ref": "HEAD",
-              "resolved-ref": "cf473c33e39eeec4615bc2cde8bf68cbb10ad02c",
+              "resolved-ref": "40d0ffbfc376f2a796b0bbb928636c242285a01c",
               "path": "."
             }
           },
           "constraintBumped": "^2.0.0",
           "constraintWidened": ">=1.0.0 <3.0.0",
           "constraintBumpedIfNeeded": "^2.0.0",
-          "previousVersion": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+          "previousVersion": "5373af3230028f3e31e9ee39e326228db83710cb",
           "previousConstraint": "^1.0.0",
           "previousSource": {
             "type": "git",
             "description": {
               "url": "../bar.git",
               "ref": "HEAD",
-              "resolved-ref": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+              "resolved-ref": "5373af3230028f3e31e9ee39e326228db83710cb",
               "path": "."
             }
           }
@@ -120,28 +120,28 @@ $ dependency_services report
       "multiBreaking": [
         {
           "name": "bar",
-          "version": "cf473c33e39eeec4615bc2cde8bf68cbb10ad02c",
+          "version": "40d0ffbfc376f2a796b0bbb928636c242285a01c",
           "kind": "direct",
           "source": {
             "type": "git",
             "description": {
               "url": "../bar.git",
               "ref": "HEAD",
-              "resolved-ref": "cf473c33e39eeec4615bc2cde8bf68cbb10ad02c",
+              "resolved-ref": "40d0ffbfc376f2a796b0bbb928636c242285a01c",
               "path": "."
             }
           },
           "constraintBumped": "^2.0.0",
           "constraintWidened": ">=1.0.0 <3.0.0",
           "constraintBumpedIfNeeded": "^2.0.0",
-          "previousVersion": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+          "previousVersion": "5373af3230028f3e31e9ee39e326228db83710cb",
           "previousConstraint": "^1.0.0",
           "previousSource": {
             "type": "git",
             "description": {
               "url": "../bar.git",
               "ref": "HEAD",
-              "resolved-ref": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+              "resolved-ref": "5373af3230028f3e31e9ee39e326228db83710cb",
               "path": "."
             }
           }
@@ -150,46 +150,46 @@ $ dependency_services report
     },
     {
       "name": "foo",
-      "version": "1ae220cc484311a7a1e2e31d1ccc6ea995acb6ba",
+      "version": "428f5dd6e627cb2384343eca6aed099f4f7d183d",
       "kind": "direct",
       "source": {
         "type": "git",
         "description": {
           "url": "../foo.git",
           "ref": "HEAD",
-          "resolved-ref": "1ae220cc484311a7a1e2e31d1ccc6ea995acb6ba",
+          "resolved-ref": "428f5dd6e627cb2384343eca6aed099f4f7d183d",
           "path": "."
         }
       },
-      "latest": "ad2d659389d4475f6c3a34282e2204160b753fd9",
+      "latest": "40c4eb4fb235961264ee9cdbdfa54ef7f6aa5199",
       "constraint": "any",
       "compatible": [],
       "singleBreaking": [],
       "multiBreaking": [
         {
           "name": "foo",
-          "version": "ad2d659389d4475f6c3a34282e2204160b753fd9",
+          "version": "40c4eb4fb235961264ee9cdbdfa54ef7f6aa5199",
           "kind": "direct",
           "source": {
             "type": "git",
             "description": {
               "url": "../foo.git",
               "ref": "HEAD",
-              "resolved-ref": "ad2d659389d4475f6c3a34282e2204160b753fd9",
+              "resolved-ref": "40c4eb4fb235961264ee9cdbdfa54ef7f6aa5199",
               "path": "."
             }
           },
           "constraintBumped": "^2.0.0",
           "constraintWidened": "any",
           "constraintBumpedIfNeeded": "any",
-          "previousVersion": "1ae220cc484311a7a1e2e31d1ccc6ea995acb6ba",
+          "previousVersion": "428f5dd6e627cb2384343eca6aed099f4f7d183d",
           "previousConstraint": "any",
           "previousSource": {
             "type": "git",
             "description": {
               "url": "../foo.git",
               "ref": "HEAD",
-              "resolved-ref": "1ae220cc484311a7a1e2e31d1ccc6ea995acb6ba",
+              "resolved-ref": "428f5dd6e627cb2384343eca6aed099f4f7d183d",
               "path": "."
             }
           }
@@ -202,7 +202,7 @@ $ dependency_services report
 -------------------------------- END OF OUTPUT ---------------------------------
 
 ## Section apply
-$ echo '{"dependencyChanges":[{"name":"foo","version":"ad2d659389d4475f6c3a34282e2204160b753fd9"}]}' | dependency_services apply
+$ echo '{"dependencyChanges":[{"name":"foo","version":"40c4eb4fb235961264ee9cdbdfa54ef7f6aa5199"}]}' | dependency_services apply
 {"dependencies":[]}
 
 -------------------------------- END OF OUTPUT ---------------------------------
@@ -218,7 +218,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: "92cdd4ac724a6da0db2a69ac149820aa220e8518"
+      resolved-ref: "5373af3230028f3e31e9ee39e326228db83710cb"
       url: "../bar.git"
     source: git
     version: "1.0.0"
@@ -227,7 +227,7 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: ad2d659389d4475f6c3a34282e2204160b753fd9
+      resolved-ref: "40c4eb4fb235961264ee9cdbdfa54ef7f6aa5199"
       url: "../foo.git"
     source: git
     version: "2.0.0"

--- a/test/testdata/goldens/dependency_services/dependency_services_test/No pubspec.lock.txt
+++ b/test/testdata/goldens/dependency_services/dependency_services_test/No pubspec.lock.txt
@@ -12,7 +12,7 @@ $ dependency_services list
   "dependencies": [
     {
       "name": "bar",
-      "version": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+      "version": "5373af3230028f3e31e9ee39e326228db83710cb",
       "kind": "direct",
       "constraint": "any",
       "source": {
@@ -20,7 +20,7 @@ $ dependency_services list
         "description": {
           "url": "../bar.git",
           "ref": "HEAD",
-          "resolved-ref": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+          "resolved-ref": "5373af3230028f3e31e9ee39e326228db83710cb",
           "path": "."
         }
       }
@@ -62,18 +62,18 @@ $ dependency_services report
   "dependencies": [
     {
       "name": "bar",
-      "version": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+      "version": "5373af3230028f3e31e9ee39e326228db83710cb",
       "kind": "direct",
       "source": {
         "type": "git",
         "description": {
           "url": "../bar.git",
           "ref": "HEAD",
-          "resolved-ref": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+          "resolved-ref": "5373af3230028f3e31e9ee39e326228db83710cb",
           "path": "."
         }
       },
-      "latest": "92cdd4ac724a6da0db2a69ac149820aa220e8518",
+      "latest": "5373af3230028f3e31e9ee39e326228db83710cb",
       "constraint": "any",
       "compatible": [],
       "singleBreaking": [],

--- a/test/testdata/goldens/directory_option_test/commands taking a --directory~-C parameter work.txt
+++ b/test/testdata/goldens/directory_option_test/commands taking a --directory~-C parameter work.txt
@@ -53,7 +53,7 @@ $ pub get bar -C 'myapp/example2'
 Resolving dependencies in myapp/example2...
 [STDERR] Error on line 1, column 9 of myapp/pubspec.yaml: "name" field doesn't match expected name "myapp".
 [STDERR]   ╷
-[STDERR] 1 │ {"name":"test_pkg","version":"1.0.0","homepage":"http://pub.dartlang.org","description":"A package, I guess.","environment":{"sdk":">=1.8.0 <=2.0.0"}, dependencies: { foo: ^1.0.0}}
+[STDERR] 1 │ {"name":"test_pkg","version":"1.0.0","homepage":"http://pub.dev","description":"A package, I guess.","environment":{"sdk":">=1.8.0 <=2.0.0"}, dependencies: { foo: ^1.0.0}}
 [STDERR]   │         ^^^^^^^^^^
 [STDERR]   ╵
 [EXIT CODE] 65

--- a/test/testdata/goldens/embedding/embedding_test/--help.txt
+++ b/test/testdata/goldens/embedding/embedding_test/--help.txt
@@ -23,7 +23,7 @@ Available subcommands:
   login   Log into pub.dev.
   logout   Log out of pub.dev.
   outdated   Analyze your dependencies to find which ones can be upgraded.
-  publish   Publish the current package to pub.dartlang.org.
+  publish   Publish the current package to pub.dev.
   remove   Removes a dependency from the current package.
   token   Manage authentication tokens for hosted pub repositories.
   upgrade   Upgrade the current package's dependencies to latest versions.

--- a/test/testdata/goldens/help_test/pub publish --help.txt
+++ b/test/testdata/goldens/help_test/pub publish --help.txt
@@ -2,7 +2,7 @@
 
 ## Section 0
 $ pub publish --help
-Publish the current package to pub.dartlang.org.
+Publish the current package to pub.dev.
 
 Usage: pub publish [options]
 -h, --help               Print this usage information.

--- a/test/token/add_token_test.dart
+++ b/test/token/add_token_test.dart
@@ -151,18 +151,18 @@ void main() {
     );
   });
 
-  test('with https://pub.dev rewrites to https://pub.dartlang.org', () async {
+  test('with https://pub.dartlang.org rewrites to https://pub.dev', () async {
     await runPub(
-      args: ['token', 'add', 'https://pub.dev'],
+      args: ['token', 'add', 'https://pub.dartlang.org'],
       input: ['auth-token'],
       silent: contains(
-          'Using https://pub.dartlang.org instead of https://pub.dev.'),
+          'Using https://pub.dev instead of https://pub.dartlang.org.'),
     );
 
     await d.tokensFile({
       'version': 1,
       'hosted': [
-        {'url': 'https://pub.dartlang.org', 'token': 'auth-token'}
+        {'url': 'https://pub.dev', 'token': 'auth-token'}
       ]
     }).validate();
   });

--- a/test/token/add_token_test.dart
+++ b/test/token/add_token_test.dart
@@ -151,18 +151,18 @@ void main() {
     );
   });
 
-  test('with https://pub.dartlang.org rewrites to https://pub.dev', () async {
+  test('with https://pub.dev rewrites to https://pub.dartlang.org', () async {
     await runPub(
-      args: ['token', 'add', 'https://pub.dartlang.org'],
+      args: ['token', 'add', 'https://pub.dev'],
       input: ['auth-token'],
       silent: contains(
-          'Using https://pub.dev instead of https://pub.dartlang.org.'),
+          'Using https://pub.dartlang.org instead of https://pub.dev.'),
     );
 
     await d.tokensFile({
       'version': 1,
       'hosted': [
-        {'url': 'https://pub.dev', 'token': 'auth-token'}
+        {'url': 'https://pub.dartlang.org', 'token': 'auth-token'}
       ]
     }).validate();
   });

--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -236,10 +236,7 @@ void main() {
                     'bar': {
                       'version': '1.2.3',
                       'source': 'hosted',
-                      'description': {
-                        'name': 'bar',
-                        'url': 'https://pub.dev'
-                      }
+                      'description': {'name': 'bar', 'url': 'https://pub.dev'}
                     }
                   }
                 }))
@@ -262,10 +259,7 @@ void main() {
                     'foo': {
                       'version': '1.2.3',
                       'source': 'hosted',
-                      'description': {
-                        'name': 'foo',
-                        'url': 'https://pub.dev'
-                      }
+                      'description': {'name': 'foo', 'url': 'https://pub.dev'}
                     }
                   }
                 }))
@@ -286,10 +280,7 @@ void main() {
                     'foo': {
                       'version': '0.1.2',
                       'source': 'hosted',
-                      'description': {
-                        'name': 'foo',
-                        'url': 'https://pub.dev'
-                      }
+                      'description': {'name': 'foo', 'url': 'https://pub.dev'}
                     }
                   }
                 }))
@@ -344,10 +335,7 @@ void main() {
                     'bar': {
                       'version': '1.2.3',
                       'source': 'hosted',
-                      'description': {
-                        'name': 'bar',
-                        'url': 'https://pub.dev'
-                      }
+                      'description': {'name': 'bar', 'url': 'https://pub.dev'}
                     }
                   }
                 }))
@@ -370,10 +358,7 @@ void main() {
                     'foo': {
                       'version': '1.2.3',
                       'source': 'hosted',
-                      'description': {
-                        'name': 'foo',
-                        'url': 'https://pub.dev'
-                      }
+                      'description': {'name': 'foo', 'url': 'https://pub.dev'}
                     }
                   }
                 }))
@@ -392,10 +377,7 @@ void main() {
                     'foo': {
                       'version': '1.2.3',
                       'source': 'hosted',
-                      'description': {
-                        'name': 'foo',
-                        'url': 'https://pub.dev'
-                      }
+                      'description': {'name': 'foo', 'url': 'https://pub.dev'}
                     }
                   }
                 }))
@@ -416,10 +398,7 @@ void main() {
                     'foo': {
                       'version': '1.2.3',
                       'source': 'hosted',
-                      'description': {
-                        'name': 'foo',
-                        'url': 'https://pub.dev'
-                      }
+                      'description': {'name': 'foo', 'url': 'https://pub.dev'}
                     }
                   }
                 }))

--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -238,7 +238,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'bar',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'https://pub.dev'
                       }
                     }
                   }
@@ -264,7 +264,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'foo',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'https://pub.dev'
                       }
                     }
                   }
@@ -288,7 +288,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'foo',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'https://pub.dev'
                       }
                     }
                   }
@@ -346,7 +346,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'bar',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'https://pub.dev'
                       }
                     }
                   }
@@ -372,7 +372,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'foo',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'https://pub.dev'
                       }
                     }
                   }
@@ -394,7 +394,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'foo',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'https://pub.dev'
                       }
                     }
                   }
@@ -418,7 +418,7 @@ void main() {
                       'source': 'hosted',
                       'description': {
                         'name': 'foo',
-                        'url': 'http://pub.dartlang.org'
+                        'url': 'https://pub.dev'
                       }
                     }
                   }

--- a/test/validator/pubspec_field_test.dart
+++ b/test/validator/pubspec_field_test.dart
@@ -20,7 +20,7 @@ void main() {
 
     test('has an HTTPS homepage URL', () async {
       var pkg = packageMap('test_pkg', '1.0.0');
-      pkg['homepage'] = 'https://pub.dartlang.org';
+      pkg['homepage'] = 'https://pub.dev';
       await d.dir(appPath, [d.pubspec(pkg)]).create();
 
       await expectValidation(pubspecField);
@@ -29,7 +29,7 @@ void main() {
     test('has an HTTPS repository URL instead of homepage', () async {
       var pkg = packageMap('test_pkg', '1.0.0');
       pkg.remove('homepage');
-      pkg['repository'] = 'https://pub.dartlang.org';
+      pkg['repository'] = 'https://pub.dev';
       await d.dir(appPath, [d.pubspec(pkg)]).create();
 
       await expectValidation(pubspecField);
@@ -37,7 +37,7 @@ void main() {
 
     test('has an HTTPS documentation URL', () async {
       var pkg = packageMap('test_pkg', '1.0.0');
-      pkg['documentation'] = 'https://pub.dartlang.org';
+      pkg['documentation'] = 'https://pub.dev';
       await d.dir(appPath, [d.pubspec(pkg)]).create();
 
       await expectValidation(pubspecField);

--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -2911,7 +2911,7 @@ Future expectResolves(
     if (description is HostedDescription &&
         (description.url == SystemCache().hosted.defaultUrl)) {
       // If the dep uses the default hosted source, grab it from the test
-      // package server rather than pub.dartlang.org.
+      // package server rather than pub.dev.
       dep = cache.hosted
           .refFor(dep.name, url: globalServer.url)
           .withConstraint(dep.constraint);


### PR DESCRIPTION
Change all mentions of the pub.dartlang.org website to pub.dev in the ui.

Fixes: https://github.com/dart-lang/pub/issues/3519
