### PR TITLE
Upgrade `package:tar` to 0.5.6

### DIFF
--- a/lib/src/third_party/tar/README.md
+++ b/lib/src/third_party/tar/README.md
@@ -4,4 +4,4 @@ Vendored elements from `package:tar` for use in creation and extraction of
 tar-archives.
 
  * Repository: `https://github.com/simolus3/tar/`
- * Revision: `901ae404e0a225d9b08e5253415ca092f5c08706`
+ * Revision: `23ee71d667f003fba8c80ee126d5e1330d17c141`


### PR DESCRIPTION
This fixes a bug in `package:tar` that occurred when listening to the contents of a tar entry and then cancelling that subscription (https://github.com/simolus3/tar/issues/23). I don't think this affected pub, but Jonas mentioned it'd be good to not let the vendored version diverge.

As usual, I have provided a comparison script in the `compare-tars` branch [of my pub fork](https://github.com/simolus3/pub/tree/compare-tars). The `tool/extract_all_pub_dev.dart` script can be used to compare the two versions.