### PR TITLE
Make binstubs offset invariant

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -735,7 +735,9 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
     // To ensure that the byte-offsets of everything stays the same even if the
     // snapshot filename changes we insert some padding in lines containing the
     // snapshot.
-    final padding = ' ' * (200 - snapshot.length);
+    // 260 is the maximal short path length on Windows. Hopefully that is
+    // enough.
+    final padding = ' ' * (260 - snapshot.length);
     // We need an absolute path since relative ones won't be relative to the
     // right directory when the user runs this.
     snapshot = p.absolute(snapshot);

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -735,7 +735,7 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
     // To ensure that the byte-offsets of everything stays the same even if the
     // snapshot filename changes we insert some padding in lines containing the
     // snapshot.
-    final padding = ' ' * (20 - snapshot.length);
+    final padding = ' ' * (200 - snapshot.length);
     // We need an absolute path since relative ones won't be relative to the
     // right directory when the user runs this.
     snapshot = p.absolute(snapshot);
@@ -747,8 +747,8 @@ rem Package: ${package.name}
 rem Version: ${package.version}
 rem Executable: $executable
 rem Script: $script
-if exist "$snapshot"$padding(
-  call dart "$snapshot"$padding%*
+if exist "$snapshot" $padding(
+  call dart "$snapshot" $padding%*
   rem The VM exits with code 253 if the snapshot version is out-of-date.
   rem If it is, we need to delete it and run "pub global" manually.
   if not errorlevel 253 (


### PR DESCRIPTION
After realizing that batch-files pick up changes while they are running: https://stackoverflow.com/questions/906586/changing-a-batch-file-when-its-running it seems that it is prudent to avoid changing the offsets inside the file when it is regenerated.

This pr changes two things:
* Always generate the full logic in the binstub (it will check for snapshot presence anyways)
* For windows we generate some padding after the snapshot path, such that changing the path will not affect indices.

This hopefully fixes: https://github.com/dart-lang/pub/issues/3575
