### PR TITLE
update docs for running 'pub token'

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -126,7 +126,7 @@ class LishCommand extends PubCommand {
       if (error.statusCode == 401) {
         msg += '$host package repository requested authentication!\n'
             'You can provide credentials using:\n'
-            '    dart pub token add $host\n';
+            '    $topLevelProgram pub token add $host\n';
       }
       if (error.statusCode == 403) {
         msg += 'Insufficient permissions to the resource at the $host '

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -131,7 +131,7 @@ class LishCommand extends PubCommand {
       if (error.statusCode == 403) {
         msg += 'Insufficient permissions to the resource at the $host '
             'package repository.\nYou can modify credentials using:\n'
-            '    dart pub token add $host\n';
+            '    $topLevelProgram pub token add $host\n';
       }
       if (error.serverMessage != null) {
         msg += '\n${error.serverMessage!}\n';

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -126,12 +126,12 @@ class LishCommand extends PubCommand {
       if (error.statusCode == 401) {
         msg += '$host package repository requested authentication!\n'
             'You can provide credentials using:\n'
-            '    pub token add $host\n';
+            '    dart pub token add $host\n';
       }
       if (error.statusCode == 403) {
         msg += 'Insufficient permissions to the resource at the $host '
             'package repository.\nYou can modify credentials using:\n'
-            '    pub token add $host\n';
+            '    dart pub token add $host\n';
       }
       if (error.serverMessage != null) {
         msg += '\n${error.serverMessage!}\n';

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -10,6 +10,7 @@ import 'package:http/http.dart' as http;
 import '../ascii_tree.dart' as tree;
 import '../authentication/client.dart';
 import '../command.dart';
+import '../command_runner.dart';
 import '../exceptions.dart' show DataException;
 import '../exit_codes.dart' as exit_codes;
 import '../http.dart';

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -971,12 +971,12 @@ class HostedSource extends CachedSource {
       if (error.statusCode == 401) {
         hint = '$hostedUrl package repository requested authentication!\n'
             'You can provide credentials using:\n'
-            '    pub token add $hostedUrl';
+            '    dart pub token add $hostedUrl';
       }
       if (error.statusCode == 403) {
         hint = 'Insufficient permissions to the resource at the $hostedUrl '
             'package repository.\nYou can modify credentials using:\n'
-            '    pub token add $hostedUrl';
+            '    dart pub token add $hostedUrl';
         message = 'authorization failed';
       }
 

--- a/test/testdata/goldens/hosted/fail_gracefully_on_bad_version_listing_response_test/401-with-message.txt
+++ b/test/testdata/goldens/hosted/fail_gracefully_on_bad_version_listing_response_test/401-with-message.txt
@@ -7,7 +7,7 @@ Resolving dependencies...
 [STDERR] 
 [STDERR] http://localhost:$PORT package repository requested authentication!
 [STDERR] You can provide credentials using:
-[STDERR]     pub token add http://localhost:$PORT
+[STDERR]     dart pub token add http://localhost:$PORT
 [STDERR] <message>
 [EXIT CODE] 69
 

--- a/test/testdata/goldens/hosted/fail_gracefully_on_bad_version_listing_response_test/401.txt
+++ b/test/testdata/goldens/hosted/fail_gracefully_on_bad_version_listing_response_test/401.txt
@@ -7,6 +7,6 @@ Resolving dependencies...
 [STDERR] 
 [STDERR] http://localhost:$PORT package repository requested authentication!
 [STDERR] You can provide credentials using:
-[STDERR]     pub token add http://localhost:$PORT
+[STDERR]     dart pub token add http://localhost:$PORT
 [EXIT CODE] 69
 

--- a/test/testdata/goldens/hosted/fail_gracefully_on_bad_version_listing_response_test/403-with-message.txt
+++ b/test/testdata/goldens/hosted/fail_gracefully_on_bad_version_listing_response_test/403-with-message.txt
@@ -7,7 +7,7 @@ Resolving dependencies...
 [STDERR] 
 [STDERR] Insufficient permissions to the resource at the http://localhost:$PORT package repository.
 [STDERR] You can modify credentials using:
-[STDERR]     pub token add http://localhost:$PORT
+[STDERR]     dart pub token add http://localhost:$PORT
 [STDERR] <message>
 [EXIT CODE] 69
 

--- a/test/testdata/goldens/hosted/fail_gracefully_on_bad_version_listing_response_test/403.txt
+++ b/test/testdata/goldens/hosted/fail_gracefully_on_bad_version_listing_response_test/403.txt
@@ -7,6 +7,6 @@ Resolving dependencies...
 [STDERR] 
 [STDERR] Insufficient permissions to the resource at the http://localhost:$PORT package repository.
 [STDERR] You can modify credentials using:
-[STDERR]     pub token add http://localhost:$PORT
+[STDERR]     dart pub token add http://localhost:$PORT
 [EXIT CODE] 69
 


### PR DESCRIPTION
- update docs for running 'pub token'

I noticed that the error messages here are outdated - they specified running `pub token` instead of `dart pub token`.
