### PR TITLE
Completely switch from pub.dartlang.org to pub.dev

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -155,9 +155,9 @@ class LishCommand extends PubCommand {
   Future<void> _publish(List<int> packageBytes) async {
     try {
       final officialPubServers = {
-        'https://pub.dartlang.org',
-        // [validateAndNormalizeHostedUrl] normalizes https://pub.dev
-        // to https://pub.dartlang.org, so we don't need to do allow that here.
+        'https://pub.dev',
+        // [validateAndNormalizeHostedUrl] normalizes https://pub.dartlang.org
+        // to https://pub.dev, so we don't need to do allow that here.
 
         // Pub uses oauth2 credentials only for authenticating official pub
         // servers for security purposes (to not expose pub.dev access token to

--- a/lib/src/command/uploader.dart
+++ b/lib/src/command/uploader.dart
@@ -27,8 +27,7 @@ class UploaderCommand extends PubCommand {
 
   UploaderCommand() {
     argParser.addOption('server',
-        defaultsTo: Platform.environment['PUB_HOSTED_URL'] ??
-            'https://pub.dartlang.org',
+        defaultsTo: Platform.environment['PUB_HOSTED_URL'] ?? 'https://pub.dev',
         help: 'The package server on which the package is hosted.\n',
         hide: true);
     argParser.addOption('package',

--- a/lib/src/oauth2.dart
+++ b/lib/src/oauth2.dart
@@ -212,7 +212,7 @@ String _legacyCredentialsFile(SystemCache cache) {
   return path.join(cache.rootDir, 'credentials.json');
 }
 
-/// Gets the user to authorize pub as a client of pub.dartlang.org via oauth2.
+/// Gets the user to authorize pub as a client of pub.dev via oauth2.
 ///
 /// Returns a Future that completes to a fully-authorized [Client].
 Future<Client> _authorize() async {
@@ -241,7 +241,7 @@ Future<Client> _authorize() async {
     completer
         .complete(grant.handleAuthorizationResponse(queryToMap(queryString)));
 
-    return shelf.Response.found('https://pub.dartlang.org/authorized');
+    return shelf.Response.found('https://pub.dev/authorized');
   });
 
   var authUrl = grant.getAuthorizationUrl(

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -44,8 +44,8 @@ import 'cached.dart';
 /// unless the path is merely `/`, in which case we normalize to the bare
 /// domain.
 ///
-/// We change `https://pub.dev` to `https://pub.dartlang.org`, this  maintains
-/// avoids churn for `pubspec.lock`-files which contain
+/// We change `https://pub.dartlang.org` to `https://pub.dev`, this  maintains
+/// backwards compatibility with `pubspec.lock`-files which contain
 /// `https://pub.dartlang.org`.
 ///
 /// Throws [FormatException] if there is anything wrong [hostedUrl].
@@ -102,9 +102,9 @@ Uri validateAndNormalizeHostedUrl(String hostedUrl) {
   //
   // Clearly, a bit of investigation is necessary before we update this to
   // pub.dev, it might be attractive to do next time we change the server API.
-  if (u == Uri.parse('https://pub.dev')) {
-    log.fine('Using https://pub.dartlang.org instead of https://pub.dev.');
-    u = Uri.parse('https://pub.dartlang.org');
+  if (u == Uri.parse('https://pub.dartlang.org')) {
+    log.fine('Using https://pub.dev instead of https://pub.dartlang.org.');
+    u = Uri.parse('https://pub.dev');
   }
   return u;
 }
@@ -148,7 +148,7 @@ class HostedSource extends CachedSource {
     // Clearly, a bit of investigation is necessary before we update this to
     // pub.dev, it might be attractive to do next time we change the server API.
     try {
-      var defaultHostedUrl = 'https://pub.dartlang.org';
+      var defaultHostedUrl = 'https://pub.dev';
       // Allow the defaultHostedUrl to be overriden when running from tests
       if (runningFromTest) {
         defaultHostedUrl =

--- a/test/cache/list_test.dart
+++ b/test/cache/list_test.dart
@@ -10,8 +10,7 @@ import '../test_pub.dart';
 
 void main() {
   String hostedDir(package) {
-    return path.join(
-        d.sandbox, cachePath, 'hosted', 'pub.dartlang.org', package);
+    return path.join(d.sandbox, cachePath, 'hosted', 'pub.dev', package);
   }
 
   test('running pub cache list when there is no cache', () async {
@@ -21,7 +20,7 @@ void main() {
   test('running pub cache list on empty cache', () async {
     // Set up a cache.
     await d.dir(cachePath, [
-      d.dir('hosted', [d.dir('pub.dartlang.org', [])])
+      d.dir('hosted', [d.dir('pub.dev', [])])
     ]).create();
 
     await runPub(args: ['cache', 'list'], outputJson: {'packages': {}});
@@ -31,7 +30,7 @@ void main() {
     // Set up a cache.
     await d.dir(cachePath, [
       d.dir('hosted', [
-        d.dir('pub.dartlang.org', [
+        d.dir('pub.dev', [
           d.dir('foo-1.2.3', [d.libPubspec('foo', '1.2.3'), d.libDir('foo')]),
           d.dir('bar-2.0.0', [d.libPubspec('bar', '2.0.0'), d.libDir('bar')])
         ])
@@ -57,7 +56,7 @@ void main() {
     // Set up a cache.
     await d.dir(cachePath, [
       d.dir('hosted', [
-        d.dir('pub.dartlang.org', [
+        d.dir('pub.dev', [
           d.dir('foo-1.2.3', [
             d.libPubspec('foo', '1.2.3', deps: {
               'bar': {'bad': 'bar'}

--- a/test/oauth2/utils.dart
+++ b/test/oauth2/utils.dart
@@ -35,8 +35,7 @@ Future authorizePub(TestProcess pub, PackageServer server,
   // sign-in with Google account.
   var response =
       await (http.Request('GET', redirectUrl)..followRedirects = false).send();
-  expect(response.headers['location'],
-      equals('https://pub.dev/authorized'));
+  expect(response.headers['location'], equals('https://pub.dev/authorized'));
 }
 
 void handleAccessTokenRequest(PackageServer server, String accessToken) {

--- a/test/oauth2/utils.dart
+++ b/test/oauth2/utils.dart
@@ -36,7 +36,7 @@ Future authorizePub(TestProcess pub, PackageServer server,
   var response =
       await (http.Request('GET', redirectUrl)..followRedirects = false).send();
   expect(response.headers['location'],
-      equals('https://pub.dartlang.org/authorized'));
+      equals('https://pub.dev/authorized'));
 }
 
 void handleAccessTokenRequest(PackageServer server, String accessToken) {

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -371,7 +371,7 @@ dependencies:
             ResolvedHostedDescription(foo.description as HostedDescription)
                 .serializeForLockfile(containingDir: null),
             {
-              'url': 'https://pub.dartlang.org',
+              'url': 'https://pub.dev',
               'name': 'bar',
             });
       });
@@ -415,7 +415,7 @@ dependencies:
             ResolvedHostedDescription(foo.description as HostedDescription)
                 .serializeForLockfile(containingDir: null),
             {
-              'url': 'https://pub.dartlang.org',
+              'url': 'https://pub.dev',
               'name': 'foo',
             });
       });

--- a/test/token/add_token_test.dart
+++ b/test/token/add_token_test.dart
@@ -151,18 +151,18 @@ void main() {
     );
   });
 
-  test('with https://pub.dev rewrites to https://pub.dartlang.org', () async {
+  test('with https://pub.dartlang.org rewrites to https://pub.dev', () async {
     await runPub(
-      args: ['token', 'add', 'https://pub.dev'],
+      args: ['token', 'add', 'https://pub.dartlang.org'],
       input: ['auth-token'],
       silent: contains(
-          'Using https://pub.dartlang.org instead of https://pub.dev.'),
+          'Using https://pub.dev instead of https://pub.dartlang.org.'),
     );
 
     await d.tokensFile({
       'version': 1,
       'hosted': [
-        {'url': 'https://pub.dartlang.org', 'token': 'auth-token'}
+        {'url': 'https://pub.dev', 'token': 'auth-token'}
       ]
     }).validate();
   });


### PR DESCRIPTION
As content-hashes are introduced with https://github.com/dart-lang/pub/pull/3482 all packages in the cache has to be downloaded again (to validate the hash).

We use this chance to clean up move the client entirely to using pub.dev.

pub.dartlang.org will be rewritten internally, so these should continue working:

* `dart pub token add pub.dartlang.org` (will add a pub.dev token)
* `dependencies: {foo: {hosted: pub.dartlang.org}}`
* `publish_to: pub.dartlang.org`
* `dart pub publish --server=pub.dartlang.org`

This pr will incur a disk-space overhead in existing caches where the pub.dartlang.org directory will linger.
But any kind of reusing the old directory will likely be buggy and have poor backwards compatibility and as mentioned redownloads would happen anyway because of content hashing.

Continues the effort we started when fixing: https://github.com/dart-lang/pub/issues/3519 .