### PR TITLE
Support --git-ref argument in pub global activate (#3608)

### DIFF
--- a/lib/src/command/global_activate.dart
+++ b/lib/src/command/global_activate.dart
@@ -14,8 +14,10 @@ import '../utils.dart';
 class GlobalActivateCommand extends PubCommand {
   @override
   String get name => 'activate';
+
   @override
   String get description => "Make a package's executables globally available.";
+
   @override
   String get argumentsDescription => '<package> [version-constraint]';
 
@@ -29,7 +31,8 @@ class GlobalActivateCommand extends PubCommand {
     argParser.addOption('git-path', help: 'Path of git package in repository');
 
     argParser.addOption('git-ref',
-        help: 'Git branch or commit to be retrieved');
+        help: 'Git branch, tag, or commit SHA to be retrieved. '
+            'When using a commit SHA, must be the full SHA (40 characters).');
 
     argParser.addMultiOption('features',
         abbr: 'f', help: 'Feature(s) to enable.', hide: true);

--- a/lib/src/command/global_activate.dart
+++ b/lib/src/command/global_activate.dart
@@ -14,10 +14,8 @@ import '../utils.dart';
 class GlobalActivateCommand extends PubCommand {
   @override
   String get name => 'activate';
-
   @override
   String get description => "Make a package's executables globally available.";
-
   @override
   String get argumentsDescription => '<package> [version-constraint]';
 

--- a/lib/src/command/global_activate.dart
+++ b/lib/src/command/global_activate.dart
@@ -31,8 +31,7 @@ class GlobalActivateCommand extends PubCommand {
     argParser.addOption('git-path', help: 'Path of git package in repository');
 
     argParser.addOption('git-ref',
-        help: 'Git branch, tag, or commit SHA to be retrieved. '
-            'When using a commit SHA, must be the full SHA (40 characters).');
+        help: 'Git branch, tag, or commit SHA to be retrieved.');
 
     argParser.addMultiOption('features',
         abbr: 'f', help: 'Feature(s) to enable.', hide: true);

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -207,6 +207,7 @@ class GlobalPackages {
     // being available, report that as a [dataError].
     SolveResult result;
     try {
+      // TODO continue here, this is the next part to fix. shouldn't fetch origin completely because it was fetched already earlier.
       result = await log.spinner(
         'Resolving dependencies',
         () => resolveVersions(SolveType.get, cache, root),

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -207,7 +207,6 @@ class GlobalPackages {
     // being available, report that as a [dataError].
     SolveResult result;
     try {
-      // TODO continue here, this is the next part to fix. shouldn't fetch origin completely because it was fetched already earlier.
       result = await log.spinner(
         'Resolving dependencies',
         () => resolveVersions(SolveType.get, cache, root),

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -199,10 +199,6 @@ class GitSource extends CachedSource {
   Future<String> getPackageNameFromRepo(
       String repo, String? ref, String? path, SystemCache cache) {
     // Clone the repo to a temp directory.
-
-    // TODO: why is it cloned to a temp dir? it's downloaded again later?!
-    // TODO: let's not delete the temp dir but instead move it to the right destination in .pub-cache
-
     return withTempDir((tempDir) async {
       await _clone(repo, tempDir, shallow: true, ref: ref);
       var pubspec = Pubspec.load(p.join(tempDir, path), cache.sources);

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -762,8 +762,8 @@ class GitDescription extends Description {
 class GitResolvedDescription extends ResolvedDescription {
   @override
   GitDescription get description => super.description as GitDescription;
-  final String resolvedRef;
 
+  final String resolvedRef;
   GitResolvedDescription(GitDescription description, this.resolvedRef)
       : super(description);
 

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -424,7 +424,7 @@ class GitSource extends CachedSource {
 
   /// Ensures that the canonical clone of the repository referred to by [ref]
   /// contains the given Git [revision].
-  Future<void> _ensureRevision(
+  Future _ensureRevision(
     PackageRef ref,
     String revision,
     SystemCache cache,
@@ -447,7 +447,7 @@ class GitSource extends CachedSource {
 
   /// Ensures that the canonical clone of the repository referred to by [ref]
   /// exists and is up-to-date.
-  Future<void> _ensureRepoCache(PackageRef ref, SystemCache cache) async {
+  Future _ensureRepoCache(PackageRef ref, SystemCache cache) async {
     var path = _repoCachePath(ref, cache);
     if (_updatedRepos.contains(path)) return;
 
@@ -463,7 +463,7 @@ class GitSource extends CachedSource {
   /// Creates the canonical clone of the repository referred to by [ref].
   ///
   /// This assumes that the canonical clone doesn't yet exist.
-  Future<void> _createRepoCache(PackageRef ref, SystemCache cache) async {
+  Future _createRepoCache(PackageRef ref, SystemCache cache) async {
     final description = ref.description;
     if (description is! GitDescription) {
       throw ArgumentError('Wrong source');
@@ -483,7 +483,7 @@ class GitSource extends CachedSource {
   /// [ref].
   ///
   /// This assumes that the canonical clone already exists.
-  Future<void> _updateRepoCache(
+  Future _updateRepoCache(
     PackageRef ref,
     SystemCache cache,
   ) async {
@@ -570,7 +570,7 @@ class GitSource extends CachedSource {
   ///
   /// If [shallow] is true, creates a shallow clone that contains no history
   /// for the repository.
-  Future<void> _clone(
+  Future _clone(
     String from,
     String to, {
     bool mirror = false,
@@ -614,8 +614,10 @@ class GitSource extends CachedSource {
   }
 
   /// Checks out the reference [ref] in [repoPath].
-  Future<void> _checkOut(String repoPath, String ref) =>
-      git.run(['checkout', ref], workingDir: repoPath);
+  Future _checkOut(String repoPath, String ref) {
+    return git
+        .run(['checkout', ref], workingDir: repoPath).then((result) => null);
+  }
 
   String _revisionCachePath(PackageId id, SystemCache cache) => p.join(
       cache.rootDirForSource(this),
@@ -760,7 +762,6 @@ class GitDescription extends Description {
 class GitResolvedDescription extends ResolvedDescription {
   @override
   GitDescription get description => super.description as GitDescription;
-
   final String resolvedRef;
 
   GitResolvedDescription(GitDescription description, this.resolvedRef)
@@ -802,6 +803,5 @@ class GitResolvedDescription extends ResolvedDescription {
 class _ValidatedUrl {
   final String url;
   final bool wasRelative;
-
   _ValidatedUrl(this.url, this.wasRelative);
 }

--- a/test/descriptor/git.dart
+++ b/test/descriptor/git.dart
@@ -15,7 +15,7 @@ class GitRepoDescriptor extends DirectoryDescriptor {
 
   /// Creates the Git repository and commits the contents.
   @override
-  Future create([String? parent]) async {
+  Future<void> create([String? parent]) async {
     await super.create(parent);
     await _runGitCommands(parent, [
       ['init'],
@@ -33,7 +33,7 @@ class GitRepoDescriptor extends DirectoryDescriptor {
   /// the previous structure to the Git repo.
   ///
   /// [parent] defaults to [sandbox].
-  Future commit([String? parent]) async {
+  Future<void> commit([String? parent]) async {
     await super.create(parent);
     await _runGitCommands(parent, [
       ['add', '.'],
@@ -46,7 +46,7 @@ class GitRepoDescriptor extends DirectoryDescriptor {
   ///
   /// [parent] defaults to [sandbox].
   Future<String> revParse(String ref, [String? parent]) async {
-    var output = await _runGit(['rev-parse', ref], parent);
+    final output = await _runGit(['rev-parse', ref], parent);
     return output[0];
   }
 
@@ -55,17 +55,20 @@ class GitRepoDescriptor extends DirectoryDescriptor {
   /// [parent] defaults to [sandbox].
   Future runGit(List<String> args, [String? parent]) => _runGit(args, parent);
 
+  Future<void> tag(String tagName, [String? parent]) =>
+      _runGit(['tag', tagName], parent);
+
   Future<List<String>> _runGit(List<String> args, String? parent) {
     // Explicitly specify the committer information. Git needs this to commit
     // and we don't want to rely on the buildbots having this already set up.
-    var environment = {
+    final environment = {
       'GIT_AUTHOR_NAME': 'Pub Test',
       'GIT_AUTHOR_EMAIL': 'pub@dartlang.org',
       'GIT_COMMITTER_NAME': 'Pub Test',
       'GIT_COMMITTER_EMAIL': 'pub@dartlang.org',
       // To make stable commits ids we fix the date.
-      'GIT_COMMITTER_DATE': DateTime(1970).toIso8601String(),
-      'GIT_AUTHOR_DATE': DateTime(1970).toIso8601String(),
+      'GIT_COMMITTER_DATE': '1970-01-01T01:00:00',
+      'GIT_AUTHOR_DATE': '1970-01-01T01:00:00',
     };
 
     return git.run(args,
@@ -74,7 +77,7 @@ class GitRepoDescriptor extends DirectoryDescriptor {
   }
 
   Future _runGitCommands(String? parent, List<List<String>> commands) async {
-    for (var command in commands) {
+    for (final command in commands) {
       await _runGit(command, parent);
     }
   }

--- a/test/descriptor/git.dart
+++ b/test/descriptor/git.dart
@@ -15,7 +15,7 @@ class GitRepoDescriptor extends DirectoryDescriptor {
 
   /// Creates the Git repository and commits the contents.
   @override
-  Future<void> create([String? parent]) async {
+  Future create([String? parent]) async {
     await super.create(parent);
     await _runGitCommands(parent, [
       ['init'],
@@ -33,7 +33,7 @@ class GitRepoDescriptor extends DirectoryDescriptor {
   /// the previous structure to the Git repo.
   ///
   /// [parent] defaults to [sandbox].
-  Future<void> commit([String? parent]) async {
+  Future commit([String? parent]) async {
     await super.create(parent);
     await _runGitCommands(parent, [
       ['add', '.'],
@@ -46,7 +46,7 @@ class GitRepoDescriptor extends DirectoryDescriptor {
   ///
   /// [parent] defaults to [sandbox].
   Future<String> revParse(String ref, [String? parent]) async {
-    final output = await _runGit(['rev-parse', ref], parent);
+    var output = await _runGit(['rev-parse', ref], parent);
     return output[0];
   }
 
@@ -77,7 +77,7 @@ class GitRepoDescriptor extends DirectoryDescriptor {
   }
 
   Future _runGitCommands(String? parent, List<List<String>> commands) async {
-    for (final command in commands) {
+    for (var command in commands) {
       await _runGit(command, parent);
     }
   }

--- a/test/descriptor/git.dart
+++ b/test/descriptor/git.dart
@@ -61,7 +61,7 @@ class GitRepoDescriptor extends DirectoryDescriptor {
   Future<List<String>> _runGit(List<String> args, String? parent) {
     // Explicitly specify the committer information. Git needs this to commit
     // and we don't want to rely on the buildbots having this already set up.
-    final environment = {
+    var environment = {
       'GIT_AUTHOR_NAME': 'Pub Test',
       'GIT_AUTHOR_EMAIL': 'pub@dartlang.org',
       'GIT_COMMITTER_NAME': 'Pub Test',

--- a/test/global/activate/git_package_test.dart
+++ b/test/global/activate/git_package_test.dart
@@ -9,9 +9,8 @@ import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
 
 void main() {
-  setUp(ensureGit);
-
   test('activates a package from a Git repo', () async {
+    ensureGit();
     await d.git('foo.git', [
       d.libPubspec('foo', '1.0.0'),
       d.dir('bin', [d.file('foo.dart', "main() => print('ok');")])
@@ -29,6 +28,8 @@ void main() {
   });
 
   test('activates a package from a Git repo with path and ref', () async {
+    ensureGit();
+    
     await d.git('foo.git', [
       d.libPubspec('foo', '0.0.0'),
       d.dir('bin', [d.file('foo.dart', "main() => print('0');")]),

--- a/test/global/activate/git_package_test.dart
+++ b/test/global/activate/git_package_test.dart
@@ -89,6 +89,7 @@ void main() {
   });
 
   group('activates packages from Git repos with non-trivial refs', () {
+    late String gitRepoPath;
     setUp(() async {
       // Generates a git repository with the following structure for the tests:
       //
@@ -128,6 +129,10 @@ void main() {
         d.libPubspec('foo', '0.0.0+master'),
         d.dir('sub', [d.libPubspec('sub', '0.0.0+master')]),
       ]).commit();
+
+      // Using `file://<path>` is required to mimick a remote repository more closely
+      // Otherwise, `git clone --depth 1` behaves differently: --depth is ignored in local clones; use file:// instead
+      gitRepoPath = 'file://${descriptor.io.absolute.path}';
     });
 
     test('with branch name as --git-ref', () async {
@@ -137,7 +142,7 @@ void main() {
           'activate',
           '-s',
           'git',
-          '../foo.git',
+          gitRepoPath,
           '--git-path',
           'sub',
           '--git-ref',
@@ -164,7 +169,7 @@ void main() {
           'activate',
           '-s',
           'git',
-          '../foo.git',
+          gitRepoPath,
           '--git-path',
           'sub',
           '--git-ref',
@@ -191,7 +196,7 @@ void main() {
           'activate',
           '-s',
           'git',
-          '../foo.git',
+          gitRepoPath,
           '--git-ref',
           'HEAD~',
         ],
@@ -216,9 +221,34 @@ void main() {
           'activate',
           '-s',
           'git',
-          '../foo.git',
+          gitRepoPath,
           '--git-ref',
           '855ca7db03741823945496b6e656464736819dc8',
+        ],
+        silent:
+            contains('git checkout 855ca7db03741823945496b6e656464736819dc8'),
+      );
+
+      await runPub(
+        args: [
+          'global',
+          'run',
+          'foo',
+        ],
+        output: contains('hello from foo'),
+      );
+    });
+
+    test('with partial commit SHA as --git-ref', () async {
+      await runPub(
+        args: [
+          'global',
+          'activate',
+          '-s',
+          'git',
+          gitRepoPath,
+          '--git-ref',
+          '855ca7',
         ],
         silent:
             contains('git checkout 855ca7db03741823945496b6e656464736819dc8'),
@@ -241,7 +271,7 @@ void main() {
           'activate',
           '-s',
           'git',
-          '../foo.git',
+          gitRepoPath,
           '--git-ref',
           'HEAD~2',
         ],
@@ -266,7 +296,7 @@ void main() {
           'activate',
           '-s',
           'git',
-          '../foo.git',
+          gitRepoPath,
           '--git-ref',
           'master',
         ],
@@ -280,7 +310,7 @@ void main() {
           'activate',
           '-s',
           'git',
-          '../foo.git',
+          gitRepoPath,
           '--git-ref',
           'master',
         ],

--- a/test/global/activate/git_package_test.dart
+++ b/test/global/activate/git_package_test.dart
@@ -9,9 +9,9 @@ import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
 
 void main() {
-  test('activates a package from a Git repo', () async {
-    ensureGit();
+  setUp(ensureGit);
 
+  test('activates a package from a Git repo', () async {
     await d.git('foo.git', [
       d.libPubspec('foo', '1.0.0'),
       d.dir('bin', [d.file('foo.dart', "main() => print('ok');")])
@@ -29,8 +29,6 @@ void main() {
   });
 
   test('activates a package from a Git repo with path and ref', () async {
-    ensureGit();
-
     await d.git('foo.git', [
       d.libPubspec('foo', '0.0.0'),
       d.dir('bin', [d.file('foo.dart', "main() => print('0');")]),
@@ -88,5 +86,215 @@ void main() {
       ],
       output: contains('2'),
     );
+  });
+
+  group('activates packages from Git repos with non-trivial refs', () {
+    setUp(() async {
+      // Generates a git repository with the following structure for the tests:
+      //
+      // * commit 25f3a8192e40ffcf2440008849560f3b90f75399 (a-branch)
+      // | * commit cecd703af8cd1047f2631ca0bf677aad617bf50b (HEAD -> master)
+      // | * commit ea74c8f2115b28b8fc4cb55926c564669c5d3489 (tag: a-tag)
+      // |/
+      // * commit 855ca7db03741823945496b6e656464736819dc8
+
+      await d.git('foo.git', [
+        d.libPubspec('foo', '0.0.0+initial'),
+        d.dir(
+            'bin', [d.file('foo.dart', "main() => print('hello from foo');")]),
+        d.dir('sub', [
+          d.libPubspec('sub', '0.0.0+initial'),
+          d.dir('bin',
+              [d.file('sub.dart', "main() => print('hello from sub');")]),
+        ]),
+      ]).create();
+
+      var descriptor = d.git('foo.git', [
+        d.libPubspec('foo', '0.0.0+a-branch'),
+        d.dir('sub', [d.libPubspec('sub', '0.0.0+a-branch')])
+      ]);
+      await descriptor.runGit(['checkout', '-b', 'a-branch']);
+      await descriptor.commit();
+
+      await descriptor.runGit(['checkout', 'master']);
+      descriptor = d.git('foo.git', [
+        d.libPubspec('foo', '0.0.0+a-tag'),
+        d.dir('sub', [d.libPubspec('sub', '0.0.0+a-tag')]),
+      ]);
+      await descriptor.commit();
+      await descriptor.tag('a-tag');
+
+      await d.git('foo.git', [
+        d.libPubspec('foo', '0.0.0+master'),
+        d.dir('sub', [d.libPubspec('sub', '0.0.0+master')]),
+      ]).commit();
+    });
+
+    test('with branch name as --git-ref', () async {
+      await runPub(
+        args: [
+          'global',
+          'activate',
+          '-s',
+          'git',
+          '../foo.git',
+          '--git-path',
+          'sub',
+          '--git-ref',
+          'a-branch',
+        ],
+        silent:
+            contains('git checkout 25f3a8192e40ffcf2440008849560f3b90f75399'),
+      );
+
+      await runPub(
+        args: [
+          'global',
+          'run',
+          'sub',
+        ],
+        output: contains('hello from sub'),
+      );
+    });
+
+    test('with tag as --git-ref', () async {
+      await runPub(
+        args: [
+          'global',
+          'activate',
+          '-s',
+          'git',
+          '../foo.git',
+          '--git-path',
+          'sub',
+          '--git-ref',
+          'a-tag',
+        ],
+        silent:
+            contains('git checkout ea74c8f2115b28b8fc4cb55926c564669c5d3489'),
+      );
+
+      await runPub(
+        args: [
+          'global',
+          'run',
+          'sub',
+        ],
+        output: contains('hello from sub'),
+      );
+    });
+
+    test('with HEAD~ as --git-ref', () async {
+      await runPub(
+        args: [
+          'global',
+          'activate',
+          '-s',
+          'git',
+          '../foo.git',
+          '--git-ref',
+          'HEAD~',
+        ],
+        silent:
+            contains('git checkout ea74c8f2115b28b8fc4cb55926c564669c5d3489'),
+      );
+
+      await runPub(
+        args: [
+          'global',
+          'run',
+          'foo',
+        ],
+        output: contains('hello from foo'),
+      );
+    });
+
+    test('with full commit SHA as --git-ref', () async {
+      await runPub(
+        args: [
+          'global',
+          'activate',
+          '-s',
+          'git',
+          '../foo.git',
+          '--git-ref',
+          '855ca7db03741823945496b6e656464736819dc8',
+        ],
+        silent:
+            contains('git checkout 855ca7db03741823945496b6e656464736819dc8'),
+      );
+
+      await runPub(
+        args: [
+          'global',
+          'run',
+          'foo',
+        ],
+        output: contains('hello from foo'),
+      );
+    });
+
+    test('with HEAD~2 as --git-ref', () async {
+      await runPub(
+        args: [
+          'global',
+          'activate',
+          '-s',
+          'git',
+          '../foo.git',
+          '--git-ref',
+          'HEAD~2',
+        ],
+        silent:
+            contains('git checkout 855ca7db03741823945496b6e656464736819dc8'),
+      );
+
+      await runPub(
+        args: [
+          'global',
+          'run',
+          'foo',
+        ],
+        output: contains('hello from foo'),
+      );
+    });
+
+    test('with master as --git-ref and activating it twice', () async {
+      await runPub(
+        args: [
+          'global',
+          'activate',
+          '-s',
+          'git',
+          '../foo.git',
+          '--git-ref',
+          'master',
+        ],
+        silent:
+            contains('git checkout cecd703af8cd1047f2631ca0bf677aad617bf50b'),
+      );
+
+      await runPub(
+        args: [
+          'global',
+          'activate',
+          '-s',
+          'git',
+          '../foo.git',
+          '--git-ref',
+          'master',
+        ],
+        silent: contains('git show cecd703af8cd1047f2631ca0bf677aad617bf50b'),
+      );
+
+      await runPub(
+        args: [
+          'global',
+          'run',
+          'foo',
+        ],
+        output: contains('hello from foo'),
+      );
+    });
   });
 }

--- a/test/global/activate/git_package_test.dart
+++ b/test/global/activate/git_package_test.dart
@@ -11,6 +11,7 @@ import '../../test_pub.dart';
 void main() {
   test('activates a package from a Git repo', () async {
     ensureGit();
+
     await d.git('foo.git', [
       d.libPubspec('foo', '1.0.0'),
       d.dir('bin', [d.file('foo.dart', "main() => print('ok');")])
@@ -29,7 +30,7 @@ void main() {
 
   test('activates a package from a Git repo with path and ref', () async {
     ensureGit();
-    
+
     await d.git('foo.git', [
       d.libPubspec('foo', '0.0.0'),
       d.dir('bin', [d.file('foo.dart', "main() => print('0');")]),


### PR DESCRIPTION
This fixes https://github.com/dart-lang/pub/issues/3608.

A branch name, tag, or full length commit SHA can be passed to the `--git-ref` argument in `dart pub global activate --source git`.

While fixing this I noticed that for `--source git`, `pub` downloads the git repository quite often. E.g. it is downloaded in the very beginning just to get the package name from the repository and then it is deleted immediately, just to be downloaded again in a later step. So I'm sure we can optimize the download behavior in another PR.