### PR TITLE
Workaround to allow using local git submodules in tests

### DIFF
--- a/test/lish/archives_and_uploads_a_package_test.dart
+++ b/test/lish/archives_and_uploads_a_package_test.dart
@@ -102,7 +102,16 @@ void main() {
     var repo = d.git(appPath, d.validPackage.contents);
     await repo.create();
 
-    await repo.runGit(['submodule', 'add', '../empty', 'empty']);
+    await repo.runGit([
+      // Hack to allow testing with local submodules after CVE-2022-39253.
+      '-c',
+      'protocol.file.allow=always',
+      'submodule',
+      'add',
+      '--',
+      '../empty',
+      'empty'
+    ]);
     await repo.commit();
 
     deleteEntry(p.join(d.sandbox, appPath, 'empty'));

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -276,7 +276,14 @@ void main() {
           d.file('file2.text', 'contents')
         ]).create();
 
-        await repo.runGit(['submodule', 'add', '../submodule']);
+        await repo.runGit([
+          // Hack to allow testing with local submodules after CVE-2022-39253.
+          '-c',
+          'protocol.file.allow=always',
+          'submodule',
+          'add',
+          '../submodule'
+        ]);
 
         await d.file('$appPath/submodule/file1.txt', 'contents').create();
 


### PR DESCRIPTION
Solution inspired from here: https://vielmetti.typepad.com/logbook/2022/10/git-security-fixes-lead-to-fatal-transport-file-not-allowed-error-in-ci-systems-cve-2022-39253.html

Allowing local submodules in tests should carry no security risk.