### PR TITLE
New command `dart pub cache preload`

### DIFF
--- a/lib/src/command/cache.dart
+++ b/lib/src/command/cache.dart
@@ -6,6 +6,7 @@ import '../command.dart';
 import 'cache_add.dart';
 import 'cache_clean.dart';
 import 'cache_list.dart';
+import 'cache_preload.dart';
 import 'cache_repair.dart';
 
 /// Handles the `cache` pub command.
@@ -22,5 +23,6 @@ class CacheCommand extends PubCommand {
     addSubcommand(CacheListCommand());
     addSubcommand(CacheCleanCommand());
     addSubcommand(CacheRepairCommand());
+    addSubcommand(CachePreloadCommand());
   }
 }

--- a/lib/src/command/cache.dart
+++ b/lib/src/command/cache.dart
@@ -23,6 +23,8 @@ class CacheCommand extends PubCommand {
     addSubcommand(CacheListCommand());
     addSubcommand(CacheCleanCommand());
     addSubcommand(CacheRepairCommand());
-    addSubcommand(CachePreloadCommand());
+    addSubcommand(
+      CachePreloadCommand(),
+    );
   }
 }

--- a/lib/src/command/cache_preload.dart
+++ b/lib/src/command/cache_preload.dart
@@ -21,6 +21,8 @@ class CachePreloadCommand extends PubCommand {
   @override
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-cache';
 
+  /// The `cache preload` command is hidden by default, because it's really only intended for
+  /// `flutter` to use when pre-loading `PUB_CACHE` after being installed from `zip` archive.
   @override
   bool get hidden => true;
 

--- a/lib/src/command/cache_preload.dart
+++ b/lib/src/command/cache_preload.dart
@@ -10,7 +10,7 @@ import '../log.dart' as log;
 import '../source/hosted.dart';
 import '../utils.dart';
 
-/// Handles the `cache add` pub command.
+/// Handles the `cache preload` pub command.
 class CachePreloadCommand extends PubCommand {
   @override
   String get name => 'preload';

--- a/lib/src/command/cache_preload.dart
+++ b/lib/src/command/cache_preload.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import '../command.dart';
+import '../io.dart';
+import '../log.dart' as log;
+import '../source/hosted.dart';
+import '../utils.dart';
+
+/// Handles the `cache add` pub command.
+class CachePreloadCommand extends PubCommand {
+  @override
+  String get name => 'preload';
+  @override
+  String get description => 'Install packages from a .tar.gz archive.';
+  @override
+  String get argumentsDescription => '<package1.tar.gz> ...';
+  @override
+  String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-cache';
+
+  @override
+  bool get hidden => true;
+
+  @override
+  Future<void> runProtected() async {
+    // Make sure there is a package.
+    if (argResults.rest.isEmpty) {
+      usageException('No package to preload given.');
+    }
+
+    for (String packagePath in argResults.rest) {
+      if (!fileExists(packagePath)) {
+        fail('Could not find file $packagePath.');
+      }
+    }
+    for (String archivePath in argResults.rest) {
+      final id = await cache.hosted.preloadPackage(archivePath, cache);
+      final url = (id.description.description as HostedDescription).url;
+
+      final fromPart = HostedSource.isFromPubDev(id) ? '' : ' from $url';
+      log.message('Installed $archivePath in cache as $id$fromPart.');
+    }
+  }
+}

--- a/test/cache/preload_test.dart
+++ b/test/cache/preload_test.dart
@@ -57,7 +57,9 @@ void main() {
     await pubGet(args: ['--offline']);
   });
 
-  test('installs package from according to PUB_HOSTED_URL', () async {
+  test(
+      'installs package according to PUB_HOSTED_URL even on non-offical server',
+      () async {
     final server = await servePackages();
     server.serve('foo', '1.0.0');
 
@@ -67,6 +69,9 @@ void main() {
         Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz')));
     await runPub(
       args: ['cache', 'preload', archivePath],
+      // By having pub.dev be the "official" server the test-server (localhost)
+      // is considered non-official. Test that the output mentions that we
+      // are installing to a non-official server.
       environment: {'_PUB_TEST_DEFAULT_HOSTED_URL': 'pub.dev'},
       output: allOf([
         contains(

--- a/test/cache/preload_test.dart
+++ b/test/cache/preload_test.dart
@@ -26,8 +26,8 @@ void main() {
 
     await runPub(args: ['cache', 'clean', '-f']);
 
-    final archivePath = p.join(sandbox, 'archive');
-    final archivePath2 = p.join(sandbox, 'archive2');
+    final archivePath1 = p.join(sandbox, 'foo-1.0.0-archive.tar.gz');
+    final archivePath2 = p.join(sandbox, 'foo-2.0.0-archive.tar.gz');
 
     File(archivePath).writeAsBytesSync(await readBytes(
         Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz')));

--- a/test/cache/preload_test.dart
+++ b/test/cache/preload_test.dart
@@ -82,8 +82,11 @@ void main() {
 
     final archivePath = p.join(sandbox, 'archive');
 
-    File(archivePath).writeAsBytesSync(await readBytes(
-        Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz')));
+    File(archivePath).writeAsBytesSync(
+      await readBytes(
+        Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz'),
+      ),
+    );
     await runPub(
       args: ['cache', 'preload', archivePath],
       environment: {'_PUB_TEST_DEFAULT_HOSTED_URL': server.url},
@@ -93,11 +96,17 @@ void main() {
 
     server.serve('foo', '1.0.0', contents: [file('new-file.txt')]);
 
-    File(archivePath).writeAsBytesSync(await readBytes(
-        Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz')));
+    File(archivePath).writeAsBytesSync(
+      await readBytes(
+        Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz'),
+      ),
+    );
 
-    File(archivePath).writeAsBytesSync(await readBytes(
-        Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz')));
+    File(archivePath).writeAsBytesSync(
+      await readBytes(
+        Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz'),
+      ),
+    );
 
     await runPub(
       args: ['cache', 'preload', archivePath],
@@ -135,14 +144,14 @@ void main() {
 
     // Create a tar.gz with a single file (and no pubspec.yaml).
     File(archivePath).writeAsBytesSync(
-        await tarFromDescriptors([d.file('foo.txt')])
-            .expand((x) => x)
-            .toList());
+      await tarFromDescriptors([d.file('foo.txt')]).expand((x) => x).toList(),
+    );
 
     await runPub(
       args: ['cache', 'preload', archivePath],
       error: contains(
-          'Found no `pubspec.yaml` in $archivePath. Is it a valid pub package archive?'),
+        'Found no `pubspec.yaml` in $archivePath. Is it a valid pub package archive?',
+      ),
       exitCode: 1,
     );
   });
@@ -158,7 +167,8 @@ void main() {
     await runPub(
       args: ['cache', 'preload', archivePath],
       error: contains(
-          'Failed to load `pubspec.yaml` from `$archivePath`: Error on line 1, column 1'),
+        'Failed to load `pubspec.yaml` from `$archivePath`: Error on line 1, column 1',
+      ),
       exitCode: 1,
     );
   });

--- a/test/cache/preload_test.dart
+++ b/test/cache/preload_test.dart
@@ -1,0 +1,165 @@
+// Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:http/http.dart';
+import 'package:path/path.dart' as p;
+import 'package:pub/src/exit_codes.dart';
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../descriptor.dart';
+import '../test_pub.dart';
+
+void main() {
+  test('adds correct entries to cache and stores the content-hash', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0');
+    server.serve('foo', '2.0.0');
+
+    await appDir({'foo': '^2.0.0'}).create();
+    // Do a `pub get` here to create a lock file in order to validate we later can
+    // `pub get --offline` with packages installed by `preload`.
+    await pubGet();
+
+    await runPub(args: ['cache', 'clean', '-f']);
+
+    final archivePath = p.join(sandbox, 'archive');
+    final archivePath2 = p.join(sandbox, 'archive2');
+
+    File(archivePath).writeAsBytesSync(await readBytes(
+        Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz')));
+    File(archivePath2).writeAsBytesSync(await readBytes(
+        Uri.parse(server.url).resolve('packages/foo/versions/2.0.0.tar.gz')));
+    await runPub(
+      args: ['cache', 'preload', archivePath, archivePath2],
+      environment: {'_PUB_TEST_DEFAULT_HOSTED_URL': server.url},
+      output: allOf(
+        [
+          contains('Installed $archivePath in cache as foo 1.0.0.'),
+          contains('Installed $archivePath2 in cache as foo 2.0.0.'),
+        ],
+      ),
+    );
+    await d.cacheDir({'foo': '1.0.0'}).validate();
+    await d.cacheDir({'foo': '2.0.0'}).validate();
+
+    await hostedHashesCache([
+      file('foo-1.0.0.sha256', await server.peekArchiveSha256('foo', '1.0.0')),
+    ]).validate();
+
+    await hostedHashesCache([
+      file('foo-2.0.0.sha256', await server.peekArchiveSha256('foo', '2.0.0')),
+    ]).validate();
+
+    await pubGet(args: ['--offline']);
+  });
+
+  test('installs package from according to PUB_HOSTED_URL', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0');
+
+    final archivePath = p.join(sandbox, 'archive');
+
+    File(archivePath).writeAsBytesSync(await readBytes(
+        Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz')));
+    await runPub(
+      args: ['cache', 'preload', archivePath],
+      environment: {'_PUB_TEST_DEFAULT_HOSTED_URL': 'pub.dev'},
+      output: allOf([
+        contains(
+            'Installed $archivePath in cache as foo 1.0.0 from ${server.url}.')
+      ]),
+    );
+    await d.cacheDir({'foo': '1.0.0'}).validate();
+  });
+
+  test('overwrites existing entry in cache', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0', contents: [file('old-file.txt')]);
+
+    final archivePath = p.join(sandbox, 'archive');
+
+    File(archivePath).writeAsBytesSync(await readBytes(
+        Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz')));
+    await runPub(
+      args: ['cache', 'preload', archivePath],
+      environment: {'_PUB_TEST_DEFAULT_HOSTED_URL': server.url},
+      output:
+          allOf([contains('Installed $archivePath in cache as foo 1.0.0.')]),
+    );
+
+    server.serve('foo', '1.0.0', contents: [file('new-file.txt')]);
+
+    File(archivePath).writeAsBytesSync(await readBytes(
+        Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz')));
+
+    File(archivePath).writeAsBytesSync(await readBytes(
+        Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz')));
+
+    await runPub(
+      args: ['cache', 'preload', archivePath],
+      environment: {'_PUB_TEST_DEFAULT_HOSTED_URL': server.url},
+      output:
+          allOf([contains('Installed $archivePath in cache as foo 1.0.0.')]),
+    );
+    await hostedCache([
+      dir('foo-1.0.0', [file('new-file.txt'), nothing('old-file.txt')])
+    ]).validate();
+  });
+
+  test('handles missing archive', () async {
+    final archivePath = p.join(sandbox, 'archive');
+    await runPub(
+      args: ['cache', 'preload', archivePath],
+      error: contains('Could not find file $archivePath.'),
+      exitCode: 1,
+    );
+  });
+
+  test('handles broken archives', () async {
+    final archivePath = p.join(sandbox, 'archive');
+    File(archivePath).writeAsBytesSync('garbage'.codeUnits);
+    await runPub(
+      args: ['cache', 'preload', archivePath],
+      error:
+          contains('Failed to extract `$archivePath`: Filter error, bad data.'),
+      exitCode: DATA,
+    );
+  });
+
+  test('handles missing pubspec.yaml in archive', () async {
+    final archivePath = p.join(sandbox, 'archive');
+
+    // Create a tar.gz with a single file (and no pubspec.yaml).
+    File(archivePath).writeAsBytesSync(
+        await tarFromDescriptors([d.file('foo.txt')])
+            .expand((x) => x)
+            .toList());
+
+    await runPub(
+      args: ['cache', 'preload', archivePath],
+      error: contains(
+          'Found no `pubspec.yaml` in $archivePath. Is it a valid pub package archive?'),
+      exitCode: 1,
+    );
+  });
+
+  test('handles broken pubspec.yaml in archive', () async {
+    final archivePath = p.join(sandbox, 'archive');
+
+    File(archivePath).writeAsBytesSync(
+        await tarFromDescriptors([d.file('pubspec.yaml', '{}')])
+            .expand((x) => x)
+            .toList());
+
+    await runPub(
+      args: ['cache', 'preload', archivePath],
+      error: contains(
+          'Failed to load `pubspec.yaml` from `$archivePath`: Error on line 1, column 1'),
+      exitCode: 1,
+    );
+  });
+}

--- a/test/cache/preload_test.dart
+++ b/test/cache/preload_test.dart
@@ -29,16 +29,16 @@ void main() {
     final archivePath1 = p.join(sandbox, 'foo-1.0.0-archive.tar.gz');
     final archivePath2 = p.join(sandbox, 'foo-2.0.0-archive.tar.gz');
 
-    File(archivePath).writeAsBytesSync(await readBytes(
+    File(archivePath1).writeAsBytesSync(await readBytes(
         Uri.parse(server.url).resolve('packages/foo/versions/1.0.0.tar.gz')));
     File(archivePath2).writeAsBytesSync(await readBytes(
         Uri.parse(server.url).resolve('packages/foo/versions/2.0.0.tar.gz')));
     await runPub(
-      args: ['cache', 'preload', archivePath, archivePath2],
+      args: ['cache', 'preload', archivePath1, archivePath2],
       environment: {'_PUB_TEST_DEFAULT_HOSTED_URL': server.url},
       output: allOf(
         [
-          contains('Installed $archivePath in cache as foo 1.0.0.'),
+          contains('Installed $archivePath1 in cache as foo 1.0.0.'),
           contains('Installed $archivePath2 in cache as foo 2.0.0.'),
         ],
       ),


### PR DESCRIPTION
Will load one or more tar.gz archives of packages as those served by pub.get and add them to the cache.

Will overwrite an existing entry for the same package-version.

No attempt is made to verify this against what is really being served -> this can be done offline.
Writes the sha256 hash of the archive as the content-hash in the cache -> later pub get invocations will verify the cached hash against what is in the cache.

Fixes: https://github.com/dart-lang/pub/issues/3532