### PR TITLE
Support Git URL for --git-url option

### DIFF
--- a/lib/src/command/add.dart
+++ b/lib/src/command/add.dart
@@ -12,6 +12,7 @@ import '../command.dart';
 import '../entrypoint.dart';
 import '../exceptions.dart';
 import '../git.dart';
+import '../git_url.dart';
 import '../io.dart';
 import '../language_version.dart';
 import '../log.dart' as log;
@@ -334,11 +335,13 @@ class AddCommand extends PubCommand {
       if (gitUrl == null) {
         usageException('The `--git-url` is required for git dependencies.');
       }
-      Uri parsed;
+      String parsed;
       try {
-        parsed = Uri.parse(gitUrl);
+        parsed = parseGitUrl(gitUrl);
       } on FormatException catch (e) {
         usageException('The --git-url must be a valid url: ${e.message}.');
+      } on GitUrlException catch (e) {
+        usageException('The --git-url must be a valid git format: ${e.message}.');
       }
 
       /// Process the git options to return the simplest representation to be
@@ -347,7 +350,7 @@ class AddCommand extends PubCommand {
       ref = PackageRef(
         packageName,
         GitDescription(
-          url: parsed.toString(),
+          url: parsed,
           containingDir: p.current,
           ref: gitRef,
           path: gitPath,

--- a/lib/src/git_url.dart
+++ b/lib/src/git_url.dart
@@ -1,0 +1,39 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+String parseGitUrl(String url) {
+  if (url.startsWith('http://') | url.startsWith('https://')) {
+    return Uri.parse(url).toString();
+  } else if (url.startsWith('git@')) {
+    return _parseGitUrl(url);
+  } else {
+    throw GitUrlException('This is not git format.');
+  }
+}
+
+String _parseGitUrl(String url) {
+  if (!url.endsWith('.git')) {
+    throw GitUrlException('This is not git format.');
+  }
+  int colonIndex = url.indexOf(':');
+  if (colonIndex == -1) {
+    throw GitUrlException('Need to contain a domain.');
+  }
+  final domain = url.substring(4, colonIndex);
+  if (Uri.tryParse(domain) == null) {
+    throw GitUrlException('Need to contain a valid domain.');
+  }
+  return url;
+}
+
+class GitUrlException implements Exception {
+  final String message;
+
+  GitUrlException(this.message);
+
+  @override
+  String toString() {
+    return message;
+  }
+}

--- a/lib/src/git_url.dart
+++ b/lib/src/git_url.dart
@@ -18,7 +18,7 @@ String _parseGitUrl(String url) {
     throw GitUrlException('Need to contain a domain.');
   }
   final domain = url.substring(4, colonIndex);
-  if (Uri.tryParse(domain) == null) {
+  if (domain.isEmpty || Uri.tryParse(domain) == null) {
     throw GitUrlException('Need to contain a valid domain.');
   }
   return url;

--- a/lib/src/git_url.dart
+++ b/lib/src/git_url.dart
@@ -3,13 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 String parseGitUrl(String url) {
-  if (url.startsWith('http://') | url.startsWith('https://')) {
-    return Uri.parse(url).toString();
-  } else if (url.startsWith('git@')) {
+  if (url.startsWith('git@')) {
     return _parseGitUrl(url);
-  } else {
-    throw GitUrlException('This is not git format.');
   }
+  return Uri.parse(url).toString();
 }
 
 String _parseGitUrl(String url) {

--- a/test/git_url_test.dart
+++ b/test/git_url_test.dart
@@ -7,12 +7,6 @@ import 'package:test/test.dart';
 
 void main() {
   group('parse()', () {
-    test('http', () {
-      const gitUrl = 'http://github.com/dart-lang/pub.git';
-      final uri = Uri.parse(gitUrl);
-      expect(parseGitUrl(gitUrl), equals(uri.toString()));
-    });
-
     test('https', () {
       const gitUrl = 'https://github.com/dart-lang/pub.git';
       final uri = Uri.parse(gitUrl);
@@ -21,6 +15,16 @@ void main() {
 
     test('git', () {
       const gitUrl = 'git@github.com:dart-lang/pub.git';
+      expect(parseGitUrl(gitUrl), equals(gitUrl));
+    });
+
+    test('current directory path', () {
+      const gitUrl = 'foo.git';
+      expect(parseGitUrl(gitUrl), equals(gitUrl));
+    });
+
+    test('another directory path', () {
+      const gitUrl = '../foo.git';
       expect(parseGitUrl(gitUrl), equals(gitUrl));
     });
   });

--- a/test/git_url_test.dart
+++ b/test/git_url_test.dart
@@ -1,0 +1,27 @@
+// Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub/src/git_url.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('parse()', () {
+    test('http', () {
+      const gitUrl = 'http://github.com/dart-lang/pub.git';
+      final uri = Uri.parse(gitUrl);
+      expect(parseGitUrl(gitUrl), equals(uri.toString()));
+    });
+
+    test('https', () {
+      const gitUrl = 'https://github.com/dart-lang/pub.git';
+      final uri = Uri.parse(gitUrl);
+      expect(parseGitUrl(gitUrl), equals(uri.toString()));
+    });
+
+    test('git', () {
+      const gitUrl = 'git@github.com:dart-lang/pub.git';
+      expect(parseGitUrl(gitUrl), equals(gitUrl));
+    });
+  });
+}

--- a/test/git_url_test.dart
+++ b/test/git_url_test.dart
@@ -6,26 +6,41 @@ import 'package:pub/src/git_url.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('parse()', () {
-    test('https', () {
-      const gitUrl = 'https://github.com/dart-lang/pub.git';
-      final uri = Uri.parse(gitUrl);
-      expect(parseGitUrl(gitUrl), equals(uri.toString()));
+  test('correct https url', () {
+    const gitUrl = 'https://github.com/dart-lang/pub.git';
+    final uri = Uri.parse(gitUrl);
+    expect(parseGitUrl(gitUrl), equals(uri.toString()));
+  });
+
+  test('current directory path', () {
+    const gitUrl = 'foo.git';
+    expect(parseGitUrl(gitUrl), equals(gitUrl));
+  });
+
+  test('other directory path', () {
+    const gitUrl = '../foo.git';
+    expect(parseGitUrl(gitUrl), equals(gitUrl));
+  });
+
+  test('correct git url', () {
+    const gitUrl = 'git@github.com:dart-lang/pub.git';
+    expect(parseGitUrl(gitUrl), equals(gitUrl));
+  });
+
+  group('git url exception', () {
+    test('invalid git format', () {
+      const gitUrl = 'git@github.com:dart-lang/pub';
+      expect(() => parseGitUrl(gitUrl), throwsA(isA<GitUrlException>()));
     });
 
-    test('git', () {
-      const gitUrl = 'git@github.com:dart-lang/pub.git';
-      expect(parseGitUrl(gitUrl), equals(gitUrl));
+    test('need domain', () {
+      const gitUrl = 'git@dart-lang/pub.git';
+      expect(() => parseGitUrl(gitUrl), throwsA(isA<GitUrlException>()));
     });
 
-    test('current directory path', () {
-      const gitUrl = 'foo.git';
-      expect(parseGitUrl(gitUrl), equals(gitUrl));
-    });
-
-    test('another directory path', () {
-      const gitUrl = '../foo.git';
-      expect(parseGitUrl(gitUrl), equals(gitUrl));
+    test('invalid domain', () {
+      const gitUrl = 'git@:dart-lang/pub.git';
+      expect(() => parseGitUrl(gitUrl), throwsA(isA<GitUrlException>()));
     });
   });
 }


### PR DESCRIPTION
Fix: #3651 

If the URL starts with `git＠` it will be in the flow supported this time. 
Otherwise, there is no effect.