### PR TITLE
Suggest using 2.12 as lower-bound SDK constraint

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -894,12 +894,12 @@ class Entrypoint {
   void _checkSdkConstraint(Pubspec pubspec) {
     final dartSdkConstraint = pubspec.dartSdkConstraint.effectiveConstraint;
     if (dartSdkConstraint is! VersionRange || dartSdkConstraint.min == null) {
-      // Suggest version range '>=2.10.0 <3.0.0', we avoid using:
+      // Suggest version range '>=2.12.0 <3.0.0', we avoid using:
       // [CompatibleWithVersionRange] because some pub versions don't support
-      // caret syntax (e.g. '^2.10.0')
+      // caret syntax (e.g. '^2.12.0')
       var suggestedConstraint = VersionRange(
-        min: Version.parse('2.10.0'),
-        max: Version.parse('2.10.0').nextBreaking,
+        min: Version.parse('2.12.0'),
+        max: Version.parse('2.12.0').nextBreaking,
         includeMin: true,
       );
       // But if somehow that doesn't work, we fallback to safe sanity, mostly


### PR DESCRIPTION
Fixes #3659

I'm down for us making progress on ^-syntax, but let's do this in a follow up. I think it's important that we roll this into 2.19.