### PR TITLE
Only check for sdk updates during `resolveExecutable`

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -593,7 +593,13 @@ Unable to satisfy `$pubspecPath` using `$lockFilePath`$suffix.${forDetails()}$su
   ///
   /// A `.packages` file is not required. But if it exists it is checked for
   /// consistency with the pubspec.lock.
-  void assertUpToDate() {
+  ///
+  /// If [checkForSdkUpdate] is `true`, the resolution is considered outdated if
+  /// the package_config.json was created by a different sdk. See
+  /// [_checkPackageConfigSameDartSdk].
+  /// TODO(sigurdm): we should consider if we can instead in all places update
+  /// the resolution automatically.
+  void assertUpToDate({bool checkForSdkUpdate = false}) {
     if (isCached) return;
 
     if (!entryExists(lockFilePath)) {
@@ -684,7 +690,7 @@ Unable to satisfy `$pubspecPath` using `$lockFilePath`$suffix.${forDetails()}$su
     //
     // Putting this check last because it leads to less specific messages than
     // the 'incompatible sdk' check above.
-    _checkPackageConfigSameDartSdk();
+    if (checkForSdkUpdate) _checkPackageConfigSameDartSdk();
   }
 
   /// Determines whether or not the lockfile is out of date with respect to the

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -306,7 +306,7 @@ Future<DartExecutableWithPackageConfig> getExecutableForCommand(
   final entrypoint = Entrypoint(root, SystemCache(rootDir: pubCacheDir));
   try {
     // TODO(sigurdm): it would be nicer with a 'isUpToDate' function.
-    entrypoint.assertUpToDate();
+    entrypoint.assertUpToDate(checkForSdkUpdate: true);
   } on DataException catch (e) {
     log.fine('Resolution not up to date: ${e.message}. Redoing.');
     try {


### PR DESCRIPTION
This partially undoes https://github.com/dart-lang/pub/pull/3652 .

We realized that all `pub global activate`d packages would now be broken on sdk-update.

Still the situation with globally activated packages have other issues. But we need a coherent plan to resolve those.