### PR TITLE
Support `--native-assets` in kernel compilation commands

### DIFF
--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -149,6 +149,9 @@ class AnalyzerErrorGroup implements Exception {
 /// The [additionalSources], if provided, instruct the compiler to include
 /// additional source files into compilation even if they are not referenced
 /// from the main library.
+///
+/// The [nativeAssets], if provided, instruct the compiler include a native
+/// assets map.
 Future<void> precompile({
   required String executablePath,
   required String incrementalDillPath,
@@ -156,6 +159,7 @@ Future<void> precompile({
   required String outputPath,
   required String packageConfigPath,
   List<String> additionalSources = const [],
+  String? nativeAssets,
 }) async {
   ensureDir(p.dirname(outputPath));
   ensureDir(p.dirname(incrementalDillPath));
@@ -187,6 +191,7 @@ Future<void> precompile({
       sdkRoot: sdkRoot,
       packagesJson: packageConfigPath,
       additionalSources: additionalSources,
+      nativeAssets: nativeAssets,
       printIncrementalDependencies: false,
     );
     final result = await client.compile();

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -451,9 +451,13 @@ class Entrypoint {
   /// The [additionalSources], if provided, instruct the compiler to include
   /// additional source files into compilation even if they are not referenced
   /// from the main library.
+  ///
+  /// The [nativeAssets], if provided, instruct the compiler include a native
+  /// assets map.
   Future<void> precompileExecutable(
     Executable executable, {
     List<String> additionalSources = const [],
+    String? nativeAssets,
   }) async {
     await log.progress('Building package executable', () async {
       ensureDir(p.dirname(pathOfExecutable(executable)));
@@ -461,6 +465,7 @@ class Entrypoint {
         _precompileExecutable(
           executable,
           additionalSources: additionalSources,
+          nativeAssets: nativeAssets,
         )
       ]);
     });
@@ -469,6 +474,7 @@ class Entrypoint {
   Future<void> _precompileExecutable(
     Executable executable, {
     List<String> additionalSources = const [],
+    String? nativeAssets,
   }) async {
     final package = executable.package;
 
@@ -479,6 +485,7 @@ class Entrypoint {
       packageConfigPath: packageConfigPath,
       name: '$package:${p.basenameWithoutExtension(executable.relativePath)}',
       additionalSources: additionalSources,
+      nativeAssets: nativeAssets,
     );
   }
 

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -271,6 +271,9 @@ class DartExecutableWithPackageConfig {
 /// The [additionalSources], if provided, instructs the compiler to include
 /// additional source files into compilation even if they are not referenced
 /// from the main library that [descriptor] resolves to.
+///
+/// The [nativeAssets], if provided, instructs the compiler to include
+/// the native-assets mapping for @Native external functions.
 Future<DartExecutableWithPackageConfig> getExecutableForCommand(
   String descriptor, {
   bool allowSnapshot = true,
@@ -278,6 +281,7 @@ Future<DartExecutableWithPackageConfig> getExecutableForCommand(
   String? pubCacheDir,
   PubAnalytics? analytics,
   List<String> additionalSources = const [],
+  String? nativeAssets,
 }) async {
   root ??= p.current;
   var asPath = descriptor;
@@ -371,6 +375,7 @@ Future<DartExecutableWithPackageConfig> getExecutableForCommand(
           () => entrypoint.precompileExecutable(
             executable,
             additionalSources: additionalSources,
+            nativeAssets: nativeAssets,
           ),
         );
       } on ApplicationException catch (e) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   collection: ^1.15.0
   convert: ^3.0.2
   crypto: ^3.0.1
-  frontend_server_client: ^3.1.0
+  frontend_server_client: ^3.2.0
   http: ^0.13.3
   http_multi_server: ^3.0.1
   http_parser: ^4.0.1


### PR DESCRIPTION
https://dart-review.googlesource.com/c/sdk/+/264842 introduces passing `--native-assets` to `gen_kernel`.

This PR enables passing native asset mapping files to the various pub commands compiling kernel, so that these arguments can be passed from dartdev.

Depends on:

* https://github.com/dart-lang/webdev/pull/1797