### PR TITLE
Fix reading pubspecs from git

### DIFF
--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -254,7 +254,7 @@ class GitSource extends CachedSource {
       fail('Could not find a file named "$pathInCache" in '
           '${GitDescription.prettyUri(description.url)} $revision.');
     }
-    return lines.join();
+    return lines.join('\n');
   }
 
   @override

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -248,6 +248,8 @@ class GitSource extends CachedSource {
 
     late List<String> lines;
     try {
+      // TODO(sigurdm): We should have a `git.run` alternative that gives back
+      // a stream of stdout instead of the lines.
       lines = await git
           .run(['show', '$revision:$pathInCache'], workingDir: repoPath);
     } on git.GitException catch (_) {

--- a/test/get/git/check_out_test.dart
+++ b/test/get/git/check_out_test.dart
@@ -43,6 +43,25 @@ void main() {
     expect(packageSpec('foo'), isNotNull);
   }, skip: true);
 
+  test('checks out a package from Git using non-json YAML', () async {
+    ensureGit();
+
+    await d.git('foo.git', [
+      d.libDir('foo'),
+      d.file('pubspec.yaml', '''
+name: foo
+environment:
+  sdk: ^0.1.2
+'''),
+    ]).create();
+
+    await d.appDir({
+      'foo': {'git': '../foo.git'}
+    }).create();
+
+    await pubGet();
+  });
+
   test(
       'checks out a package from Git with a name that is not a valid '
       'file name in the url', () async {

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -611,7 +611,7 @@ class PubProcess extends TestProcess {
 /// We require machines running these tests to have git installed. This
 /// validation gives an easier-to-understand error when that requirement isn't
 /// met than just failing in the middle of a test when pub invokes git.
-void ensureGit() {
+void  ensureGit() {
   if (!git.isInstalled) fail('Git must be installed to run this test.');
 }
 

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -611,7 +611,7 @@ class PubProcess extends TestProcess {
 /// We require machines running these tests to have git installed. This
 /// validation gives an easier-to-understand error when that requirement isn't
 /// met than just failing in the middle of a test when pub invokes git.
-void  ensureGit() {
+void ensureGit() {
   if (!git.isInstalled) fail('Git must be installed to run this test.');
 }
 


### PR DESCRIPTION
Fix of https://github.com/flutter/flutter/issues/116107

I slightly refactored how we read a pubspec from a git revision without checking it out. But unfortunately made a mistake in how we join the lines coming from the git process stdout.

Unfortunately all tests we have of git uses a json descriptor that is not sensitive to removal of newlines.