### PR TITLE
Avoid .incremental.dill.incremental.dill in temporary file name

### DIFF
--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -129,7 +129,7 @@ Future<void> precompile({
     // To avoid potential races we copy the incremental data to a temporary file
     // for just this compilation.
     final temporaryIncrementalDill =
-        p.join(tempDir, '${p.basename(incrementalDillPath)}.incremental.dill');
+        p.join(tempDir, '${p.basename(incrementalDillPath)}.copy');
     try {
       if (fileExists(incrementalDillPath)) {
         copyFile(incrementalDillPath, temporaryIncrementalDill);

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -129,7 +129,7 @@ Future<void> precompile({
     // To avoid potential races we copy the incremental data to a temporary file
     // for just this compilation.
     final temporaryIncrementalDill =
-        p.join(tempDir, '${p.basename(incrementalDillPath)}.copy');
+        p.join(tempDir, '${p.basename(incrementalDillPath)}.temp');
     try {
       if (fileExists(incrementalDillPath)) {
         copyFile(incrementalDillPath, temporaryIncrementalDill);


### PR DESCRIPTION
`path.basename` does not remove the extension of the filename, so we ended up doubling the extension.

