### PR TITLE
Create output folder if it doesn't exist in the precompiler

### DIFF
--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -157,6 +157,10 @@ Future<void> precompile({
       log.message('Built $highlightedName.');
       // By using rename we ensure atomicity. An external observer will either
       // see the old or the new snapshot.
+      final parent = File(outputPath).parent;
+      if (!await parent.exists()) {
+        await parent.create(recursive: true);
+      }
       renameFile(temporaryIncrementalDill, outputPath);
     } else {
       // By using rename we ensure atomicity. An external observer will either


### PR DESCRIPTION
The exception is caught and printed, but not the stack-trace. So I have no idea which call site is responsible for omitting to create the output folder. This should likely be fixed at the call site.