### PR TITLE
Revert "Create output folder if it doesn't exist in the precompiler (#3676)"

### DIFF
--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -157,10 +157,6 @@ Future<void> precompile({
       log.message('Built $highlightedName.');
       // By using rename we ensure atomicity. An external observer will either
       // see the old or the new snapshot.
-      final parent = File(outputPath).parent;
-      if (!await parent.exists()) {
-        await parent.create(recursive: true);
-      }
       renameFile(temporaryIncrementalDill, outputPath);
     } else {
       // By using rename we ensure atomicity. An external observer will either


### PR DESCRIPTION
This reverts commit 74473e12bd82514f24568822d2d2b0893236b319.

This was not the right solution - we still have to come up with the right design here.