### PR TITLE
Revert "Add env var flag to override stdout.hasTerminal for output animations"

### DIFF
--- a/lib/src/progress.dart
+++ b/lib/src/progress.dart
@@ -39,8 +39,9 @@ class Progress {
     // The animation is only shown when it would be meaningful to a human.
     // That means we're writing a visible message to a TTY at normal log levels
     // with non-JSON output.
-    if (!canAnimateOutput ||
+    if (stdioType(stdout) != StdioType.terminal ||
         !log.verbosity.isLevelVisible(level) ||
+        log.json.enabled ||
         fine ||
         log.verbosity.isLevelVisible(log.Level.fine)) {
       // Not animating, so just log the start and wait until the task is

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -426,26 +426,6 @@ bool get canUseAnsiCodes {
 /// Gets an ANSI escape if those are supported by stdout (or nothing).
 String getAnsi(String ansiCode) => canUseAnsiCodes ? ansiCode : '';
 
-/// Whether an environment variable overriding the [stdout.hasTerminal] check
-/// was passed.
-bool get forceTerminalOutput =>
-    Platform.environment.containsKey('_PUB_FORCE_TERMINAL_OUTPUT');
-
-/// Whether it makes sense to do stdout animation.
-///
-/// Checks if pub is in JSON output mode or if stdout has no terminal attached.
-/// The flutter tool sets an environment variable when running "pub get" that
-/// overrides the terminal check. See [forceTerminalOutput].
-bool get canAnimateOutput {
-  if (log.json.enabled) {
-    return false;
-  }
-  if (!stdout.hasTerminal && !forceTerminalOutput) {
-    return false;
-  }
-  return true;
-}
-
 /// Gets a emoji special character as unicode, or the [alternative] if unicode
 /// charactors are not supported by stdout.
 String emoji(String unicode, String alternative) =>


### PR DESCRIPTION
Reverts dart-lang/pub#3658

This flag was added with the intention of forcing output animations when run by "flutter pub", but I ended up using `inheritStdio` in https://github.com/flutter/flutter/pull/115801 instead.