### PR TITLE
Use resident compiler to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ To run pub from the Git repository, run:
 
 Before any change is made to pub, all tests should pass. To run a pub test, run:
 
-    dart tool/test.dart test/path/to_test.dart
+    tool/test.sh test/path/to_test.dart
 
 To run all tests at once, run:
 
-    dart tool/test.dart
+    tool/test.sh
+
 
 Changes to pub should be accompanied by one or more tests that exercise the new
 functionality. When adding a test, the best strategy is to find a similar test

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -7,7 +7,6 @@
 /// Unlike typical unit tests, most pub tests are integration tests that stage
 /// some stuff on the file system, run pub, and then validate the results. This
 /// library provides an API to build tests like that.
-import 'dart:async';
 import 'dart:convert';
 import 'dart:core';
 import 'dart:io' hide BytesBuilder;

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -7,6 +7,7 @@
 /// Unlike typical unit tests, most pub tests are integration tests that stage
 /// some stuff on the file system, run pub, and then validate the results. This
 /// library provides an API to build tests like that.
+import 'dart:async';
 import 'dart:convert';
 import 'dart:core';
 import 'dart:io' hide BytesBuilder;
@@ -463,7 +464,10 @@ Future<PubProcess> startPub(
   // recommended to use a temporary file with a unique name for each test run.
   // Note: running tests without a snapshot is significantly slower, use
   // tool/test.dart to generate the snapshot.
-  var pubPath = Platform.environment['_PUB_TEST_SNAPSHOT'] ?? '';
+  var pubPath = Platform.environment['_PUB_TEST_SNAPSHOT'] ??
+      // TODO(sigurdm): avoid hard-coding the snapshot path here.
+      p.absolute('.dart_tool', '_pub', 'pub.dart.snapshot.dart2');
+
   if (pubPath.isEmpty || !fileExists(pubPath)) {
     pubPath = p.absolute(p.join(_pubRoot, 'bin/pub.dart'));
   }

--- a/tool/test.dart
+++ b/tool/test.dart
@@ -3,56 +3,141 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// Test wrapper script.
-/// Many of the integration tests runs the `pub` command, this is slow if every
-/// invocation requires the dart compiler to load all the sources. This script
-/// will create a `pub.XXX.dart.snapshot.dart2` which the tests can utilize.
-/// After creating the snapshot this script will forward arguments to
-/// `pub run test`, and ensure that the snapshot is deleted after tests have been
-/// run.
+/// Test wrapper script. Many of the integration tests runs the `pub` command,
+/// this is slow if every invocation requires the dart compiler to load all the
+/// sources. This script will create a `pub.dart.dill` snapshot which the tests
+/// can utilize. After creating the snapshot this script will forward arguments
+/// to the test runner, and ensure that the snapshot is deleted after tests have
+/// been run.
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 import 'package:path/path.dart' as path;
+import 'package:test/src/executable.dart' as test;
 
-import 'package:pub/src/dart.dart';
-import 'package:pub/src/exceptions.dart';
+/// A connection to a resident compiler.
+///
+/// Either established through the port at [residentInfoFilename] or a new
+/// resident compiler is opened.
+///
+/// The compiler will itself time out after some time of inactivity.
+class _CompilerConnection {
+  static const residentInfoFilename = '.dart_tool/pub/.resident_compiler';
+
+  final StreamIterator<List<int>> output;
+  final Sink<List<int>> input;
+  final Socket socket;
+  _CompilerConnection(this.input, this.output, this.socket);
+
+  Future<void> compile(
+      {required String entrypoint, required String incrementalDill}) async {
+    input.add(utf8.encode(jsonEncode({
+      'command': 'compile',
+      'executable': entrypoint,
+      'output-dill': incrementalDill,
+    })));
+    await output.moveNext();
+    final result = json.decode(utf8.decode(output.current));
+    if (!result['success']) {
+      stderr.writeln('Failed building snapshot: ');
+      stderr.writeln(result['compilerOutputLines'].join('\n'));
+      exit(-1);
+    }
+    if (result['incremental'] ?? false) {
+      stderr.writeln('incremental compilation');
+    }
+    if (result['returnedStoredKernel'] ?? false) {
+      stderr.writeln('No update to pub compilation');
+    }
+  }
+
+  void close() => socket.destroy();
+
+  static Future<void> _startResidentCompiler() async {
+    try {
+      File(residentInfoFilename).deleteSync(recursive: true);
+    } on IOException {
+      // Probably the file didn't exist.
+    }
+    stderr.writeln('Restarting compiler');
+    final process = await Process.start(
+        Platform.resolvedExecutable,
+        [
+          path.join(
+            path.dirname(Platform.resolvedExecutable),
+            'snapshots/frontend_server.dart.snapshot',
+          ),
+          '--resident-info-file-name=$residentInfoFilename',
+        ],
+        mode: ProcessStartMode.detachedWithStdio);
+    // Wait for the first line of output, indicating we can now find the address
+    // of the compiler at [residentInfoFilename]
+    await process.stdout.first;
+  }
+
+  static Future<_CompilerConnection?> _findResidentCompiler() async {
+    String address;
+    try {
+      address = File(residentInfoFilename).readAsStringSync();
+      stderr.writeln('Connecting to existing compiler...');
+    } on IOException {
+      return null;
+    }
+
+    final parts = address.split(' ').map((x) => x.split(':')).toList();
+    final Socket socket;
+    try {
+      socket = await Socket.connect(parts[0][1], int.parse(parts[1][1]));
+    } on IOException {
+      stderr.writeln('Failed connecting to compiler at $address');
+      return null;
+    }
+    return _CompilerConnection(socket, StreamIterator(socket), socket);
+  }
+
+  static Future<_CompilerConnection> getResidentCompiler() async {
+    var connection = await _findResidentCompiler();
+    if (connection == null) {
+      await _startResidentCompiler();
+      connection = await _findResidentCompiler();
+      if (connection == null) {
+        throw Exception('Could not start resident compiler');
+      }
+    }
+
+    return connection;
+  }
+}
+
+Future<void> compileSnapshot() async {
+  final pubSnapshotFilename =
+      path.absolute(path.join('.dart_tool', '_pub', 'pub.dart.dill'));
+  final pubSnapshotIncrementalFilename = '$pubSnapshotFilename.incremental';
+
+  final s = Stopwatch()..start();
+
+  stderr.writeln('Building snapshot...');
+  final compilerConnection = await _CompilerConnection.getResidentCompiler();
+  await compilerConnection.compile(
+      entrypoint: path.absolute('bin/pub.dart'),
+      incrementalDill: pubSnapshotIncrementalFilename);
+  compilerConnection.close();
+  Directory(path.dirname(pubSnapshotFilename)).createSync(recursive: true);
+  File(pubSnapshotIncrementalFilename).copySync(pubSnapshotFilename);
+  stderr.writeln('Building snapshot took: ${s.elapsed.inMilliseconds} ms');
+}
 
 Future<void> main(List<String> args) async {
+  if (args.isNotEmpty && args.first == 'precompiling') {
+    // TODO(https://github.com/dart-lang/sdk/issues/50615): this should not be
+    // needed I think.
+    exit(0);
+  }
   if (Platform.environment['FLUTTER_ROOT'] != null) {
     stderr.writeln(
       'WARNING: The tests will not run correctly with dart from a flutter checkout!',
     );
   }
-  Process? testProcess;
-  final sub = ProcessSignal.sigint.watch().listen((signal) {
-    testProcess?.kill(signal);
-  });
-  final pubSnapshotFilename =
-      path.absolute(path.join('.dart_tool', '_pub', 'pub.dart.snapshot.dart2'));
-  final pubSnapshotIncrementalFilename = '$pubSnapshotFilename.incremental';
-  try {
-    stderr.writeln('Building snapshot');
-    await precompile(
-        executablePath: path.join('bin', 'pub.dart'),
-        outputPath: pubSnapshotFilename,
-        incrementalDillPath: pubSnapshotIncrementalFilename,
-        name: 'bin/pub.dart',
-        packageConfigPath: path.join('.dart_tool', 'package_config.json'));
-    testProcess = await Process.start(
-      Platform.resolvedExecutable,
-      ['run', 'test', ...args],
-      environment: {'_PUB_TEST_SNAPSHOT': pubSnapshotFilename},
-      mode: ProcessStartMode.inheritStdio,
-    );
-    exitCode = await testProcess.exitCode;
-  } on ApplicationException catch (e) {
-    stderr.writeln('Failed building snapshot: $e');
-    exitCode = 1;
-  } finally {
-    try {
-      await File(pubSnapshotFilename).delete();
-      await sub.cancel();
-    } on Exception {
-      // snapshot didn't exist.
-    }
-  }
+  await compileSnapshot();
+  await test.main(args);
 }

--- a/tool/test.dart
+++ b/tool/test.dart
@@ -139,5 +139,5 @@ Future<void> main(List<String> args) async {
     );
   }
   await compileSnapshot();
-  await test.main(args);
+  test.main(args);
 }

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+
+[ tool/test.dart -nt .dart_tool/pub/test.jit ] && dart compile jit-snapshot tool/test.dart precompiling && mv tool/test.jit .dart_tool/pub/test.jit
+dart .dart_tool/pub/test.jit $*


### PR DESCRIPTION
This can be seen as a proof of concept as it is still slightly hacky. But the reduced time overhead makes that we might want to adapt it anyway - it will only affect ourselves.

There are 3 parts to this change:

* Use a resident compiler, such that we can rely on hot restart incremental compilation.
* Compile the tool/test.dart if needed with a small shell wrapper
* Invoke the test runner main directly from tool/test.dart saving another process invocation.

This together takes a "hot" test run of a single test with a single file change in the pub code from ~5 seconds from of ~25 seconds on my machine!

Downsides:
* Invoking the test runner is using private details from package:test
* Using the resident compiler requires us to skip frontend_server_client and talk directly to the compiler. I assume it has less guarantees of not breaking, but I'm not sure.
* Having a shell script on top of the dart script is annoying, but I think needed for now.
  In the future  we might be able to just `dart run` and get precompilation of the script, but that currently doesn't work when running a script not in `bin/`.
* It seems I need to jit-compile, as the test-runner relies on `Isolate.packageConfig` which is not available when aot-compiled.
  * which leads to us having to circumvent: https://github.com/dart-lang/sdk/issues/50615
