### PR TITLE
Suggest environment constraint based on language-version of current sdk

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -935,13 +935,10 @@ Unable to satisfy `$pubspecPath` using `$lockFilePath`$suffix.${forDetails()}$su
   void _checkSdkConstraint(Pubspec pubspec) {
     final dartSdkConstraint = pubspec.dartSdkConstraint.effectiveConstraint;
     if (dartSdkConstraint is! VersionRange || dartSdkConstraint.min == null) {
-      // Suggest version range '>=2.12.0 <3.0.0', we avoid using:
-      // [CompatibleWithVersionRange] because some pub versions don't support
-      // caret syntax (e.g. '^2.12.0')
-      var suggestedConstraint = VersionRange(
-        min: Version.parse('2.12.0'),
-        max: Version.parse('2.12.0').nextBreaking,
-        includeMin: true,
+      // Suggest an sdk constraint giving the same language version as the
+      // current sdk.
+      var suggestedConstraint = VersionConstraint.compatibleWith(
+        Version(sdk.version.major, sdk.version.minor, 0),
       );
       // But if somehow that doesn't work, we fallback to safe sanity, mostly
       // important for tests, or if we jump to 3.x without patching this code.

--- a/test/get/sdk_constraint_required_test.dart
+++ b/test/get/sdk_constraint_required_test.dart
@@ -19,10 +19,10 @@ void main() {
     await pubGet(
         error: allOf(
           contains('pubspec.yaml has no lower-bound SDK constraint.'),
-          contains("sdk: '^2.12.0'"),
+          contains("sdk: '^2.19.0'"),
         ),
         exitCode: exit_codes.DATA,
-        environment: {'_PUB_TEST_SDK_VERSION': '2.19.0'});
+        environment: {'_PUB_TEST_SDK_VERSION': '2.19.1'});
 
     await d.dir(appPath, [
       // The lockfile should not be created.


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub/issues/3661