### PR TITLE
Allow synonyms 'pkg' and 'packages' for the pub command

### DIFF
--- a/lib/src/pub_embeddable_command.dart
+++ b/lib/src/pub_embeddable_command.dart
@@ -48,6 +48,9 @@ class PubEmbeddableCommand extends PubCommand implements PubTopLevel {
   @override
   String get name => 'pub';
   @override
+  get aliases => const ['packages', 'pkg'];
+
+  @override
   String get description => 'Work with packages.';
   @override
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-global';

--- a/test/embedding/embedding_test.dart
+++ b/test/embedding/embedding_test.dart
@@ -392,6 +392,30 @@ main() {
       ),
     );
   });
+
+  test('synonyms "pkg" and "packages" work', () async {
+    await servePackages();
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+      }),
+    ]).create();
+
+    for (final command in ['pkg', 'packages']) {
+      final buffer = StringBuffer();
+      await runEmbeddingToBuffer(
+        [command, 'get'],
+        buffer,
+        workingDirectory: d.path(appPath),
+      );
+      expect(
+        buffer.toString(),
+        allOf(
+          contains('Got dependencies'),
+        ),
+      );
+    }
+  });
 }
 
 String _filter(String input) {


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/sdk/issues/50971