### PR TITLE
If pinned to an exact version, keep the pin when bumping

### DIFF
--- a/lib/src/command/dependency_services.dart
+++ b/lib/src/command/dependency_services.dart
@@ -606,6 +606,9 @@ Map<String, PackageRange>? _dependencySetOfPackage(
           : null;
 }
 
+/// Return a constraint compatible with [newVersion].
+///
+/// By convention if the original constraint is pinned we return [newVersion]. Otherwise use [VersionConstraint.compatibleWith].
 VersionConstraint _bumpConstraint(
   VersionConstraint original,
   Version newVersion,

--- a/lib/src/command/dependency_services.dart
+++ b/lib/src/command/dependency_services.dart
@@ -627,6 +627,9 @@ VersionConstraint _bumpConstraint(
   );
 }
 
+/// Return a constraint compatible with [newVersion], but including [original] as well.
+///
+/// By convention if the original constraint is pinned, we don't widen the constraint but return [newVersion] instead.
 VersionConstraint _widenConstraint(
   VersionConstraint original,
   Version newVersion,

--- a/lib/src/command/dependency_services.dart
+++ b/lib/src/command/dependency_services.dart
@@ -130,7 +130,7 @@ class DependencyServicesReportCommand extends PubCommand {
                 ? null
                 : upgradeType == _UpgradeType.compatible
                     ? originalConstraint.toString()
-                    : VersionConstraint.compatibleWith(p.version).toString(),
+                    : _bumpConstraint(originalConstraint, p.version).toString(),
             'constraintWidened': originalConstraint == null
                 ? null
                 : upgradeType == _UpgradeType.compatible
@@ -143,7 +143,7 @@ class DependencyServicesReportCommand extends PubCommand {
                     ? originalConstraint.toString()
                     : originalConstraint.allows(p.version)
                         ? originalConstraint.toString()
-                        : VersionConstraint.compatibleWith(p.version)
+                        : _bumpConstraint(originalConstraint, p.version)
                             .toString(),
             'previousVersion': currentPackage?.versionOrHash(),
             'previousConstraint': originalConstraint?.toString(),
@@ -604,6 +604,24 @@ Map<String, PackageRange>? _dependencySetOfPackage(
       : pubspec.devDependencies.containsKey(package.name)
           ? pubspec.devDependencies
           : null;
+}
+
+VersionConstraint _bumpConstraint(
+  VersionConstraint original,
+  Version newVersion,
+) {
+  if (original.isEmpty) return newVersion;
+  if (original is VersionRange) {
+    if (original.min == original.max) return newVersion;
+
+    return VersionConstraint.compatibleWith(newVersion);
+  }
+
+  throw ArgumentError.value(
+    original,
+    'original',
+    'Must be a Version range or empty',
+  );
 }
 
 VersionConstraint _widenConstraint(

--- a/lib/src/command/dependency_services.dart
+++ b/lib/src/command/dependency_services.dart
@@ -635,6 +635,7 @@ VersionConstraint _widenConstraint(
   if (original is VersionRange) {
     final min = original.min;
     final max = original.max;
+    if (min == max) return newVersion;
     if (max != null && newVersion >= max) {
       return _compatibleWithIfPossible(
         VersionRange(

--- a/test/testdata/goldens/dependency_services/dependency_services_test/Can update a git package.txt
+++ b/test/testdata/goldens/dependency_services/dependency_services_test/Can update a git package.txt
@@ -179,7 +179,7 @@ $ dependency_services report
               "path": "."
             }
           },
-          "constraintBumped": "^2.0.0",
+          "constraintBumped": "2.0.0",
           "constraintWidened": "any",
           "constraintBumpedIfNeeded": "any",
           "previousVersion": "9e8b8ad5091bec2c4724b1e0c8ff9d6e32a7eaa4",

--- a/test/testdata/goldens/dependency_services/dependency_services_test/multibreaking.txt
+++ b/test/testdata/goldens/dependency_services/dependency_services_test/multibreaking.txt
@@ -188,9 +188,9 @@ $ dependency_services report
               "sha256": "f1a51ba864d7ef5702590e96167b812443ace67e15a82a0e064e735ac1376ec5"
             }
           },
-          "constraintBumped": "^1.1.0",
+          "constraintBumped": "1.1.0",
           "constraintWidened": "^1.0.0",
-          "constraintBumpedIfNeeded": "^1.1.0",
+          "constraintBumpedIfNeeded": "1.1.0",
           "previousVersion": "1.0.0",
           "previousConstraint": "1.0.0",
           "previousSource": {
@@ -216,9 +216,9 @@ $ dependency_services report
               "sha256": "f1a51ba864d7ef5702590e96167b812443ace67e15a82a0e064e735ac1376ec5"
             }
           },
-          "constraintBumped": "^1.1.0",
+          "constraintBumped": "1.1.0",
           "constraintWidened": "^1.0.0",
-          "constraintBumpedIfNeeded": "^1.1.0",
+          "constraintBumpedIfNeeded": "1.1.0",
           "previousVersion": "1.0.0",
           "previousConstraint": "1.0.0",
           "previousSource": {

--- a/test/testdata/goldens/dependency_services/dependency_services_test/multibreaking.txt
+++ b/test/testdata/goldens/dependency_services/dependency_services_test/multibreaking.txt
@@ -189,7 +189,7 @@ $ dependency_services report
             }
           },
           "constraintBumped": "1.1.0",
-          "constraintWidened": "^1.0.0",
+          "constraintWidened": "1.1.0",
           "constraintBumpedIfNeeded": "1.1.0",
           "previousVersion": "1.0.0",
           "previousConstraint": "1.0.0",
@@ -217,7 +217,7 @@ $ dependency_services report
             }
           },
           "constraintBumped": "1.1.0",
-          "constraintWidened": "^1.0.0",
+          "constraintWidened": "1.1.0",
           "constraintBumpedIfNeeded": "1.1.0",
           "previousVersion": "1.0.0",
           "previousConstraint": "1.0.0",


### PR DESCRIPTION
We got the following issue reported at dependabot-core: https://github.com/dependabot/dependabot-core/issues/6446.

I think the request is reasonable and I believe it's what we do in other ecosystems.

I researched a bit and I fixed it by special casing exact pinning in pub's dependency services.