### PR TITLE
Only rewrite sdk constraints after dart 3

### DIFF
--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -13,6 +13,7 @@ import 'io.dart';
 import 'language_version.dart';
 import 'package_name.dart';
 import 'pubspec_parse.dart';
+import 'sdk.dart';
 import 'system_cache.dart';
 
 export 'pubspec_parse.dart' hide PubspecBase;
@@ -160,7 +161,10 @@ class Pubspec extends PubspecBase {
     // If a package is null safe it should also be compatible with dart 3.
     // Therefore we rewrite a null-safety enabled constraint with the upper
     // bound <3.0.0 to be have upper bound <4.0.0
-    if (constraint is VersionRange &&
+    //
+    // Only do this rewrite after dart 3.
+    if (sdk.version.major >= 3 &&
+        constraint is VersionRange &&
         LanguageVersion.fromSdkConstraint(constraint) >=
             LanguageVersion.firstVersionWithNullSafety &&
         // <3.0.0 is parsed into a max of 3.0.0-0, so that is what we look for

--- a/test/dart3_sdk_constraint_hack_test.dart
+++ b/test/dart3_sdk_constraint_hack_test.dart
@@ -156,4 +156,20 @@ void main() {
       ),
     );
   });
+
+  test('Rewrite only happens after Dart 3', () async {
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'environment': {'sdk': '>=2.19.1 <3.0.0'}
+      }),
+    ]).create();
+
+    await pubGet(
+      error: contains(
+        'Because myapp requires SDK version >=2.19.1 <3.0.0, version solving failed.',
+      ),
+      environment: {'_PUB_TEST_SDK_VERSION': '2.19.0'},
+    );
+  });
 }


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub/issues/3738

This should be hot-fixed onto 2.19 if we can make it (otherwise it'll have no effect)