### PR TITLE
Use bold to distinguish package names in solve-traces

### DIFF
--- a/lib/src/package_name.dart
+++ b/lib/src/package_name.dart
@@ -4,6 +4,7 @@
 
 import 'package:pub_semver/pub_semver.dart';
 
+import 'log.dart';
 import 'package.dart';
 import 'source.dart';
 import 'source/hosted.dart';
@@ -153,10 +154,10 @@ class PackageRange {
   PackageRef toRef() => _ref;
 
   @override
-  String toString([PackageDetail? detail]) {
+  String toString({PackageDetail? detail, bool boldName = false}) {
     detail ??= PackageDetail.defaults;
 
-    var buffer = StringBuffer(name);
+    var buffer = StringBuffer(boldName ? bold(name) : name);
     if (detail.showVersion ?? _showVersionConstraint) {
       buffer.write(' $constraint');
     }

--- a/lib/src/solver/incompatibility.dart
+++ b/lib/src/solver/incompatibility.dart
@@ -476,10 +476,11 @@ class Incompatibility {
   }
 
   /// Returns a terse representation of [term]'s package ref.
-  String _terseRef(Term term, Map<String, PackageDetail>? details) =>
-      bold(term.package
-          .toRef()
-          .toString(details == null ? null : details[term.package.name]));
+  String _terseRef(Term term, Map<String, PackageDetail>? details) => bold(
+        term.package
+            .toRef()
+            .toString(details == null ? null : details[term.package.name]),
+      );
 
   /// Returns a terse representation of [term]'s package.
   ///

--- a/lib/src/solver/incompatibility.dart
+++ b/lib/src/solver/incompatibility.dart
@@ -4,6 +4,7 @@
 
 import 'package:pub_semver/pub_semver.dart';
 
+import '../log.dart';
 import '../package_name.dart';
 import 'incompatibility_cause.dart';
 import 'term.dart';
@@ -476,9 +477,9 @@ class Incompatibility {
 
   /// Returns a terse representation of [term]'s package ref.
   String _terseRef(Term term, Map<String, PackageDetail>? details) =>
-      term.package
+      bold(term.package
           .toRef()
-          .toString(details == null ? null : details[term.package.name]);
+          .toString(details == null ? null : details[term.package.name]));
 
   /// Returns a terse representation of [term]'s package.
   ///
@@ -492,8 +493,10 @@ class Incompatibility {
     if (allowEvery && term!.constraint.isAny) {
       return 'every version of ${_terseRef(term, details)}';
     } else {
-      return term!.package
-          .toString(details == null ? null : details[term.package.name]);
+      return term!.package.toString(
+        detail: details == null ? null : details[term.package.name],
+        boldName: true,
+      );
     }
   }
 }


### PR DESCRIPTION
Attempt at fixing: https://github.com/dart-lang/pub/issues/3363 by using ansi colors to highlight package names in the solve-trace. This should make it a bit easier to read - especially if packages have keyword-like names.

An alternative would be to prefix package names with `package:`...

This has an issue with how we cannot nest colorization of ansi colors...

Draft to get feedback for the idea if it is worth handling implementing ansi-colorization.

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/8613953/213752183-639ad123-49d4-4603-ab2a-f593ff4f3e13.png">
