### PR TITLE
Info when publishing <3.0.0 constraint that is interpreted as <4.0.0

### DIFF
--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -201,9 +201,7 @@ class Pubspec extends PubspecBase {
     var yaml = parent['environment'];
     final VersionConstraint originalDartSdkConstraint;
     if (yaml == null) {
-      originalDartSdkConstraint = _includeDefaultSdkConstraint
-          ? _defaultUpperBoundSdkConstraint
-          : VersionConstraint.any;
+      originalDartSdkConstraint = VersionConstraint.any;
     } else if (yaml is! YamlMap) {
       _error(
         '"environment" field must be a map.',
@@ -216,7 +214,6 @@ class Pubspec extends PubspecBase {
         _FileType.pubspec,
       );
     }
-
     var constraints = {
       'dart': _interpretDartSdkConstraint(
         originalDartSdkConstraint,

--- a/lib/src/validator/sdk_constraint.dart
+++ b/lib/src/validator/sdk_constraint.dart
@@ -53,9 +53,9 @@ class SdkConstraintValidator extends Validator {
               errors.isEmpty &&
               originalConstraint != effectiveConstraint) {
         hints.add('''
-The declared sdk constraint is '$originalConstraint', this is interpreted as '$effectiveConstraint'.
+The declared SDK constraint is '$originalConstraint', this is interpreted as '$effectiveConstraint'.
 
-Consider updating the sdk constraint to:
+Consider updating the SDK constraint to:
 
 environment:
   sdk: '$effectiveConstraint'

--- a/lib/src/validator/sdk_constraint.dart
+++ b/lib/src/validator/sdk_constraint.dart
@@ -46,9 +46,13 @@ class SdkConstraintValidator extends Validator {
             'See https://dart.dev/tools/pub/publishing#publishing-prereleases '
             'For more information on pre-releases.');
       }
-      if (effectiveConstraint is VersionRange) {
-        if (originalConstraint != effectiveConstraint) {
-          hints.add('''
+      if (
+          // We only want to give this hint if there was no other problems with
+          // the sdk constraint.
+          warnings.isEmpty &&
+              errors.isEmpty &&
+              originalConstraint != effectiveConstraint) {
+        hints.add('''
 The declared sdk constraint is '$originalConstraint', this is interpreted as '$effectiveConstraint'.
 
 Consider updating the sdk constraint to:
@@ -56,7 +60,6 @@ Consider updating the sdk constraint to:
 environment:
   sdk: '$effectiveConstraint'
 ''');
-        }
       }
     }
 

--- a/test/validator/sdk_constraint_test.dart
+++ b/test/validator/sdk_constraint_test.dart
@@ -167,5 +167,30 @@ void main() {
         ),
       );
     });
+
+    test(
+        'Gives a hint if package has a <3.0.0 constraint that is interpreted as <4.0.0',
+        () async {
+      await d.dir(appPath, [
+        d.rawPubspec({
+          'name': 'test_pkg',
+          'version': '1.0.0',
+          'environment': {'sdk': '^2.19.0'}
+        })
+      ]).create();
+      await expectValidation(
+        sdkConstraint,
+        hints: anyElement(
+          '''
+The declared sdk constraint is '^2.19.0', this is interpreted as '>=2.19.0 <4.0.0'.
+
+Consider updating the sdk constraint to:
+
+environment:
+  sdk: '>=2.19.0 <4.0.0'
+''',
+        ),
+      );
+    });
   });
 }

--- a/test/validator/sdk_constraint_test.dart
+++ b/test/validator/sdk_constraint_test.dart
@@ -182,9 +182,9 @@ void main() {
         sdkConstraint,
         hints: anyElement(
           '''
-The declared sdk constraint is '^2.19.0', this is interpreted as '>=2.19.0 <4.0.0'.
+The declared SDK constraint is '^2.19.0', this is interpreted as '>=2.19.0 <4.0.0'.
 
-Consider updating the sdk constraint to:
+Consider updating the SDK constraint to:
 
 environment:
   sdk: '>=2.19.0 <4.0.0'


### PR DESCRIPTION
Fix of https://github.com/dart-lang/pub/issues/3552
