### PR TITLE
Normalize pub.dartlang.org to pub.dev when reading lockfile

### DIFF
--- a/lib/src/command/global_activate.dart
+++ b/lib/src/command/global_activate.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 import 'package:pub_semver/pub_semver.dart';
 
 import '../command.dart';
-import '../source/hosted.dart';
+import '../package_name.dart';
 import '../utils.dart';
 
 /// Handles the `global activate` pub command.
@@ -91,14 +91,6 @@ class GlobalActivateCommand extends PubCommand {
     }
 
     final overwrite = argResults['overwrite'] as bool;
-    Uri? hostedUrl;
-    if (argResults.wasParsed('hosted-url')) {
-      try {
-        hostedUrl = validateAndNormalizeHostedUrl(argResults['hosted-url']);
-      } on FormatException catch (e) {
-        usageException('Invalid hosted-url: $e');
-      }
-    }
 
     Iterable<String> args = argResults.rest;
 
@@ -138,6 +130,13 @@ class GlobalActivateCommand extends PubCommand {
       case 'hosted':
         var package = readArg('No package to activate given.');
 
+        PackageRef ref;
+        try {
+          ref = cache.hosted.refFor(package, url: argResults['hosted-url']);
+        } on FormatException catch (e) {
+          usageException('Invalid hosted-url: $e');
+        }
+
         // Parse the version constraint, if there is one.
         var constraint = VersionConstraint.any;
         if (args.isNotEmpty) {
@@ -150,11 +149,9 @@ class GlobalActivateCommand extends PubCommand {
 
         validateNoExtraArgs();
         return globals.activateHosted(
-          package,
-          constraint,
+          ref.withConstraint(constraint),
           executables,
           overwriteBinStubs: overwrite,
-          url: hostedUrl?.toString(),
         );
 
       case 'path':

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -140,14 +140,13 @@ class GlobalPackages {
   /// [url] is an optional custom pub server URL. If not null, the package to be
   /// activated will be fetched from this URL instead of the default pub URL.
   Future<void> activateHosted(
-    String name,
-    VersionConstraint constraint,
+    PackageRange range,
     List<String>? executables, {
     required bool overwriteBinStubs,
     String? url,
   }) async {
     await _installInCache(
-      cache.hosted.refFor(name, url: url).withConstraint(constraint),
+      range,
       executables,
       overwriteBinStubs: overwriteBinStubs,
     );

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -51,7 +51,7 @@ const contentHashesDocumentationUrl = 'https://dart.dev/go/content-hashes';
 /// backwards compatibility with `pubspec.lock`-files which contain
 /// `https://pub.dartlang.org`.
 ///
-/// Throws [FormatException] if there is anything wrong [hostedUrl].
+/// Throws [FormatException] if there is anything wrong with [hostedUrl].
 ///
 /// [1]: ../../../doc/repository-spec-v2.md
 Uri validateAndNormalizeHostedUrl(String hostedUrl) {
@@ -195,8 +195,8 @@ class HostedSource extends CachedSource {
   /// Returns a reference to a hosted package named [name].
   ///
   /// If [url] is passed, it's the URL of the pub server from which the package
-  /// should be downloaded. [url] most be normalized and validated using
-  /// [validateAndNormalizeHostedUrl].
+  /// should be downloaded. [url] will be normalized and validated using
+  /// [validateAndNormalizeHostedUrl]. This can throw a [FormatException].
   PackageRef refFor(String name, {String? url}) {
     final d = HostedDescription(name, url ?? defaultUrl);
     return PackageRef(name, d);
@@ -269,7 +269,7 @@ class HostedSource extends CachedSource {
       name,
       version,
       ResolvedHostedDescription(
-        HostedDescription(name, Uri.parse(url).toString()),
+        HostedDescription(name, url),
         sha256: sha256 == null ? null : hexDecode(sha256),
       ),
     );
@@ -302,10 +302,7 @@ class HostedSource extends CachedSource {
       // environment, we throw an error if something that looks like a URI is
       // used as a package name.
       if (canUseShorthandSyntax) {
-        return HostedDescription(
-          packageName,
-          validateAndNormalizeHostedUrl(description).toString(),
-        );
+        return HostedDescription(packageName, description);
       } else {
         if (_looksLikePackageName.hasMatch(description)) {
           // Valid use of `hosted: package` dependency with an old SDK
@@ -332,14 +329,11 @@ class HostedSource extends CachedSource {
           'a minimum Dart SDK constraint of ${LanguageVersion.firstVersionWithShorterHostedSyntax}.0 or higher.');
     }
 
-    var url = defaultUrl;
     final u = description['url'];
-    if (u != null) {
-      if (u is! String) {
-        throw FormatException("The 'url' key must be a string value.");
-      }
-      url = validateAndNormalizeHostedUrl(u).toString();
+    if (u != null && u is! String) {
+      throw FormatException("The 'url' key must be a string value.");
     }
+    final url = u ?? defaultUrl;
 
     return HostedDescription(name, url);
   }
@@ -963,7 +957,7 @@ class HostedSource extends CachedSource {
                   package.name,
                   package.version,
                   ResolvedHostedDescription(
-                    HostedDescription(package.name, url),
+                    HostedDescription._(package.name, url),
                     sha256: null,
                   ),
                 );
@@ -1244,10 +1238,7 @@ See $contentHashesDocumentationUrl.
         pubspec.name,
         pubspec.version,
         ResolvedHostedDescription(
-          HostedDescription(
-            pubspec.name,
-            validateAndNormalizeHostedUrl(cache.hosted.defaultUrl).toString(),
-          ),
+          HostedDescription(pubspec.name, defaultUrl),
           sha256: contentHash,
         ),
       );
@@ -1360,7 +1351,12 @@ class HostedDescription extends Description {
   final String packageName;
   final String url;
 
-  HostedDescription(this.packageName, this.url);
+  HostedDescription._(this.packageName, this.url);
+  factory HostedDescription(String packageName, String url) =>
+      HostedDescription._(
+        packageName,
+        validateAndNormalizeHostedUrl(url).toString(),
+      );
 
   @override
   int get hashCode => Object.hash(packageName, url);

--- a/test/lock_file_test.dart
+++ b/test/lock_file_test.dart
@@ -287,6 +287,41 @@ packages:
         );
       });
 
+      test('Reads pub.dartlang.org as pub.dev in hosted descriptions', () {
+        final lockfile = LockFile.parse(
+          '''
+packages:
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.1"
+  retry:
+    dependency: transitive
+    description:
+      name: retry
+      url: "https://pub.dev"
+      sha256:
+    source: hosted
+    version: "1.0.0"
+''',
+          sources,
+        );
+        void expectComesFromPubDev(String name) {
+          final description = lockfile.packages[name]!.description.description
+              as HostedDescription;
+          expect(
+            description.url,
+            'https://pub.dev',
+          );
+        }
+
+        expectComesFromPubDev('characters');
+        expectComesFromPubDev('retry');
+      });
+
       test('ignores extra stuff in file', () {
         LockFile.parse(
           '''


### PR DESCRIPTION
Fix of https://github.com/flutter/flutter/issues/119091

This PR ensures that HostedDescription is always created with a validated and normalized url. That was missing when creating a description from a pubspec.lock file - causing pub to consider the locked package coming from an unrelated host, and thus unlocking it.
