### PR TITLE
`dart pub remove`: Remove top-level key if empty after operation.

### DIFF
--- a/lib/src/command/remove.dart
+++ b/lib/src/command/remove.dart
@@ -147,7 +147,7 @@ class RemoveCommand extends PubCommand {
           found = true;
           // Check if the dependencies or dev_dependencies map is now empty
           // If it is empty, remove the key as well
-          if (dependenciesNode.isEmpty) {
+          if ((yamlEditor.parseAt([dependencyKey]) as YamlMap).isEmpty) {
             yamlEditor.remove([dependencyKey]);
           }
         }

--- a/lib/src/command/remove.dart
+++ b/lib/src/command/remove.dart
@@ -143,13 +143,13 @@ class RemoveCommand extends PubCommand {
 
         if (dependenciesNode is YamlMap &&
             dependenciesNode.containsKey(package)) {
-          if (dependenciesNode.length == 1) {
-            yamlEditor.remove([dependencyKey]);
-          } else {
-            yamlEditor.remove([dependencyKey, package]);
-          }
-
+          yamlEditor.remove([dependencyKey, package]);
           found = true;
+          // Check if the dependencies or dev_dependencies map is now empty
+          // If it is empty, remove the key as well
+          if (dependenciesNode.isEmpty) {
+            yamlEditor.remove([dependencyKey]);
+          }
         }
       }
 

--- a/test/remove/remove_test.dart
+++ b/test/remove/remove_test.dart
@@ -273,4 +273,28 @@ environment:
       ]),
     );
   });
+  test('removes dependencies or dev_dependencies key if empty', () async {
+    await servePackages()
+      ..serve('foo', '1.2.3')
+      ..serve('bar', '2.3.4');
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+        'dependencies': {'bar': '>=2.3.4'},
+        'dev_dependencies': {'foo': '^1.2.3'}
+      })
+    ]).create();
+    await pubGet();
+
+    await pubRemove(args: ['foo', 'bar']);
+
+    await d.appPackageConfigFile([]).validate();
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'myapp',
+      })
+    ]).validate();
+  });
 }


### PR DESCRIPTION
The changes made to this code improve the way dependencies are removed from the pubspec.yaml file. The previous version of the code only removed the package from the dependencies or dev_dependencies key, but it didn't check if the key was now empty after the removal. The updated version now also checks if the key is empty after the removal, and if it is empty, it removes the key as well. This ensures that the pubspec.yaml file is kept clean and organized.

Fixes https://github.com/dart-lang/pub/issues/3530