### PR TITLE
Add a spinner while validating before publishing

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -17,6 +17,7 @@ import '../http.dart';
 import '../io.dart';
 import '../log.dart' as log;
 import '../oauth2.dart' as oauth2;
+import '../progress.dart';
 import '../solver/type.dart';
 import '../source/hosted.dart' show validateAndNormalizeHostedUrl;
 import '../utils.dart';
@@ -298,14 +299,17 @@ the \$PUB_HOSTED_URL environment variable.''',
     final warnings = <String>[];
     final errors = <String>[];
 
-    await Validator.runAll(
-      entrypoint,
-      packageSize,
-      host,
-      files,
-      hints: hints,
-      warnings: warnings,
-      errors: errors,
+    await log.spinner(
+      'Validating package',
+      () async => await Validator.runAll(
+        entrypoint,
+        packageSize,
+        host,
+        files,
+        hints: hints,
+        warnings: warnings,
+        errors: errors,
+      ),
     );
 
     if (errors.isNotEmpty) {

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -17,7 +17,6 @@ import '../http.dart';
 import '../io.dart';
 import '../log.dart' as log;
 import '../oauth2.dart' as oauth2;
-import '../progress.dart';
 import '../solver/type.dart';
 import '../source/hosted.dart' show validateAndNormalizeHostedUrl;
 import '../utils.dart';

--- a/test/testdata/goldens/directory_option_test/commands taking a --directory~-C parameter work.txt
+++ b/test/testdata/goldens/directory_option_test/commands taking a --directory~-C parameter work.txt
@@ -111,6 +111,7 @@ Publishing test_pkg 1.0.0 to http://localhost:$PORT:
 ├── lib
 │   └── test_pkg.dart (<1 KB)
 └── pubspec.yaml (<1 KB)
+Validating package...
 The server may enforce additional checks.
 [STDERR] 
 [STDERR] Package has 0 warnings.

--- a/test/testdata/goldens/lish/many_files_test/displays all files.txt
+++ b/test/testdata/goldens/lish/many_files_test/displays all files.txt
@@ -29,6 +29,7 @@ Publishing test_pkg 1.0.0 to http://localhost:$PORT:
 │   ├── file_9.dart (<1 KB)
 │   └── test_pkg.dart (<1 KB)
 └── pubspec.yaml (<1 KB)
+Validating package...
 
 Publishing is forever; packages cannot be unpublished.
 Policy details are available at https://pub.dev/policy


### PR DESCRIPTION
We are now (purposefully) doing a full `dart analyze` before publication - and that potentially takes a long time.

Fixes: https://github.com/dart-lang/pub/issues/2012