### PR TITLE
Allow addition of tokens for insecure localhost repositories

### DIFF
--- a/lib/src/command/token_add.dart
+++ b/lib/src/command/token_add.dart
@@ -48,7 +48,8 @@ class TokenAddCommand extends PubCommand {
 
     try {
       var hostedUrl = validateAndNormalizeHostedUrl(rawHostedUrl);
-      var isLocalhost = ['localhost', '127.0.0.1', '::1'].contains(hostedUrl.host);
+      var isLocalhost =
+          ['localhost', '127.0.0.1', '::1'].contains(hostedUrl.host);
       if (!hostedUrl.isScheme('HTTPS') && !isLocalhost) {
         throw FormatException('url must be https://, '
             'insecure repositories cannot use authentication.');

--- a/lib/src/command/token_add.dart
+++ b/lib/src/command/token_add.dart
@@ -48,7 +48,8 @@ class TokenAddCommand extends PubCommand {
 
     try {
       var hostedUrl = validateAndNormalizeHostedUrl(rawHostedUrl);
-      if (!hostedUrl.isScheme('HTTPS')) {
+      var isLocalhost = ['localhost', '127.0.0.1', '::1'].contains(hostedUrl.host);
+      if (!hostedUrl.isScheme('HTTPS') && !isLocalhost) {
         throw FormatException('url must be https://, '
             'insecure repositories cannot use authentication.');
       }

--- a/test/token/add_token_test.dart
+++ b/test/token/add_token_test.dart
@@ -153,6 +153,22 @@ void main() {
     await d.dir(configPath, [d.nothing('pub-tokens.json')]).validate();
   });
 
+  test('with non-secure localhost url creates pub-tokens.json that contains token', () async {
+    await d.dir(configPath).create();
+
+    await runPub(
+      args: ['token', 'add', 'http://localhost/'],
+      input: ['auth-token'],
+    );
+
+    await d.tokensFile({
+      'version': 1,
+      'hosted': [
+        {'url': 'http://localhost', 'token': 'auth-token'}
+      ]
+    }).validate();
+  });
+
   test('with empty environment gives error message', () async {
     await runPub(
       args: ['token', 'add', 'https://mypub.com'],

--- a/test/token/add_token_test.dart
+++ b/test/token/add_token_test.dart
@@ -153,7 +153,9 @@ void main() {
     await d.dir(configPath, [d.nothing('pub-tokens.json')]).validate();
   });
 
-  test('with non-secure localhost url creates pub-tokens.json that contains token', () async {
+  test(
+      'with non-secure localhost url creates pub-tokens.json that contains token',
+      () async {
     await d.dir(configPath).create();
 
     await runPub(


### PR DESCRIPTION
This PR fixes an issue with a use case I have and apparently also some other people (like https://github.com/dart-lang/pub/issues/3286).

It allows the addition of authorization tokens for `localhost` package repositories. It also works with IPv4 and IPv6 addresses.