### PR TITLE
Drop --use-data-isolate-strategy flag for tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,5 +70,5 @@ jobs:
           cat "$_TESTS_FILE.${{ matrix.shard }}"
         shell: bash
       - name: Run tests
-        run: dart test --use-data-isolate-strategy --preset travis $(cat $_TESTS_FILE.${{ matrix.shard }})
+        run: dart test --preset travis $(cat $_TESTS_FILE.${{ matrix.shard }})
         shell: bash


### PR DESCRIPTION
This flag is being deprecated, and it will make tests load much slower. I tried running locally without it and the tests pass now so I think we can drop it.

Note that we will have the `--compiler source` flag which is similar to this, if indeed the bots are failing we can try that.