### PR TITLE
Support lfs and submodules

### DIFF
--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -288,8 +288,15 @@ Descriptor tokensFile([Map<String, dynamic> contents = const {}]) {
 
 /// Describes the application directory, containing only a pubspec specifying
 /// the given [dependencies].
-DirectoryDescriptor appDir({Map? dependencies, Map<String, Object>? pubspec}) =>
-    dir(appPath, [appPubspec(dependencies: dependencies, extras: pubspec)]);
+DirectoryDescriptor appDir({
+  Map? dependencies,
+  Map<String, Object>? pubspec,
+  Iterable<Descriptor>? contents,
+}) =>
+    dir(
+      appPath,
+      [appPubspec(dependencies: dependencies, extras: pubspec), ...?contents],
+    );
 
 /// Describes a `.dart_tools/package_config.json` file.
 ///

--- a/test/get/git/git_submodule_test.dart
+++ b/test/get/git/git_submodule_test.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('Can use and upgrade git dependency with submodule', () async {
+    ensureGit();
+
+    final submodule = d.git(
+      'lib.git',
+      [d.file('foo.dart', 'main() => print("hi");')],
+    );
+    await submodule.create();
+    final port = await submodule.serve();
+
+    final foo = d.git('foo.git', [d.libPubspec('foo', '1.0.0')]);
+    await foo.create();
+    await foo.runGit(['submodule', 'add', 'git://localhost:$port/', 'lib']);
+    await foo.commit();
+
+    await d.appDir(
+      dependencies: {
+        'foo': {
+          'git': {'url': '../foo.git'}
+        }
+      },
+      contents: [
+        d.dir('bin', [d.file('main.dart', 'export "package:foo/foo.dart";')]),
+      ],
+    ).create();
+    await pubGet();
+
+    await runPub(
+      args: ['run', 'myapp:main'],
+      output: contains('hi'),
+    );
+
+    await d.git(
+      'lib.git',
+      [d.file('foo.dart', 'main() => print("bye");')],
+    ).commit();
+
+    await foo.runGit(['submodule', 'update', '--remote', '--merge']);
+    await foo.commit();
+
+    await pubUpgrade();
+    await runPub(
+      args: ['run', 'myapp:main'],
+      output: contains('bye'),
+    );
+  });
+}


### PR DESCRIPTION
Use a worktree instead of a full clone to check out each revision for a git source.

This seems to enable git lfs to just work somehow
This should also reduce the disk consumption, as we don't have to repeat the `.git` folder.

Also run `git submodule update --init --recursive` in each worktree after checking it out.

This should enable submodules. It is a nop, and quite fast if there are no submodules.

Still some kinks to work out with backwards compatibility, but I think it could be made to work at least upwards. (doing `cache repair` with an older dart sdk will probably break).
