### PR TITLE
remove an extra period from a publish message

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -320,10 +320,11 @@ the \$PUB_HOSTED_URL environment variable.''',
     if (force) return true;
 
     String formatWarningCount() {
-      final hs = hints.length == 1 ? '' : 's';
-      final hintText = hints.isEmpty ? '' : ' and ${hints.length} hint$hs.';
-      final ws = warnings.length == 1 ? '' : 's';
-      return '\nPackage has ${warnings.length} warning$ws$hintText.';
+      final hintText = hints.isEmpty
+          ? ''
+          : ' and ${hints.length} ${pluralize('hint', hints.length)}';
+      return '\nPackage has ${warnings.length} '
+          '${pluralize('warning', warnings.length)}$hintText.';
     }
 
     if (dryRun) {

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -324,10 +324,9 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
       final wouldBe = _dryRun ? 'would be made to' : 'to';
       log.message('\nNo changes $wouldBe pubspec.yaml!');
     } else {
-      final s = changes.length == 1 ? '' : 's';
-
       final changed = _dryRun ? 'Would change' : 'Changed';
-      log.message('\n$changed ${changes.length} constraint$s in pubspec.yaml:');
+      log.message('\n$changed ${changes.length} '
+          '${pluralize('constraint', changes.length)} in pubspec.yaml:');
       changes.forEach((from, to) {
         log.message('  ${from.name}: ${from.constraint} -> ${to.constraint}');
       });

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -206,8 +206,7 @@ String toSentence(Iterable iter, {String conjunction = 'and'}) {
 /// [plural] is passed, that's used instead.
 String pluralize(String name, int number, {String? plural}) {
   if (number == 1) return name;
-  if (plural != null) return plural;
-  return '${name}s';
+  return plural ?? '${name}s';
 }
 
 /// Returns [text] with the first letter capitalized.


### PR DESCRIPTION
- remove an extra period from a publish message
- use the `pluralize` method in a few places

This fixes the message `'Package has 0 warnings and 1 hint..'` on a pub publish.
