### PR TITLE
Larger size limit for caching package listings

### DIFF
--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -438,7 +438,7 @@ class HostedSource extends CachedSource {
 
     // Cache the response on disk.
     // Don't cache overly big responses.
-    if (bodyText.length < 100 * 1024) {
+    if (bodyText.length < 500 * 1024) {
       await _cacheVersionListingResponse(body, ref, cache);
     }
     return result;


### PR DESCRIPTION
Informal benchmarks locally have shown that a pub-get on pub itself (already resolved - with warm cache) goes from ~2.0 secs to ~ 1.3 secs.

Examining the top 100 packages from https://pub.dev/help/api#package-names-for-name-completion 29 of them are larger than 100k. None of them are larger than 500k.

If we look at the next 400 packages, no more have listings > 100k.

That means the extra space "wasted" is expected to be pretty small.

So I suggest that we increase this limit.

Here are the top 100 packages with their package-listing sizes (sorted by size):
```
firebase_auth.json                243K
cloud_firestore.json              218K
build_runner.json                 201K
firebase_messaging.json           184K
googleapis.json                   164K
firebase_storage.json             155K
image_picker.json                 154K
firebase_analytics.json           148K
camera.json                       146K
video_player.json                 133K
dart_code_metrics.json            133K
firebase_crashlytics.json         130K
firebase_core.json                129K
sqflite.json                      128K
sentry_flutter.json               122K
url_launcher.json                 120K
just_audio.json                   119K
firebase_remote_config.json       116K
firebase_dynamic_links.json       116K
geolocator.json                   113K
flutter_facebook_auth.json        106K
go_router.json                    101K
printing.json                     100K
flutter_bloc.json                 94K
json_serializable.json            92K
flutter_native_splash.json        91K
freezed.json                      90K
built_value.json                  89K
upgrader.json                     87K
extended_image.json               85K
bloc.json                         80K
permission_handler.json           79K
image.json                        77K
pdf.json                          70K
logging.json                      68K
path_provider.json                68K
hooks_riverpod.json               67K
audioplayers.json                 65K
http.json                         64K
flutter_riverpod.json             61K
device_info_plus.json             58K
fl_chart.json                     57K
local_auth.json                   56K
shelf.json                        53K
wakelock.json                     53K
flutter_mobx.json                 51K
xml.json                          49K
path.json                         47K
pinput.json                       46K
cached_network_image.json         46K
provider.json                     44K
package_info_plus.json            43K
flutter_secure_storage.json       42K
get_it.json                       40K
map_launcher.json                 40K
table_calendar.json               39K
crypto.json                       39K
flutter_markdown.json             39K
google_fonts.json                 38K
lottie.json                       36K
font_awesome_flutter.json         35K
flutter_keyboard_visibility.json  35K
photo_view.json                   34K
equatable.json                    34K
chewie.json                       33K
built_collection.json             33K
percent_indicator.json            32K
sign_in_with_apple.json           32K
flutter_hooks.json                32K
mime.json                         29K
qr_code_scanner.json              29K
uuid.json                         28K
in_app_review.json                25K
flutter_image_compress.json       24K
animated_text_kit.json            24K
grouped_list.json                 23K
another_flushbar.json             23K
app_settings.json                 22K
keyboard_actions.json             22K
flutter_barcode_scanner.json      20K
flutter_easyloading.json          19K
responsive_builder.json           19K
badges.json                       18K
expandable.json                   18K
injectable.json                   17K
auto_size_text.json               16K
overlay_support.json              15K
get_storage.json                  15K
animations.json                   15K
flutter_rating_bar.json           14K
showcaseview.json                 14K
flutter_animate.json              14K
logger.json                       14K
flutter_switch.json               13K
smooth_page_indicator.json        11K
email_validator.json              11K
uni_links.json                    9.6K
shimmer.json                      9.2K
card_swiper.json                  7.2K
flutter_lints.json                5.9K
```
