### PR TITLE
Handle malformatted content-hashes in cache, version listing or pubspec.lock

### DIFF
--- a/test/lock_file_test.dart
+++ b/test/lock_file_test.dart
@@ -322,6 +322,32 @@ packages:
         expectComesFromPubDev('retry');
       });
 
+      test('Reads pub.dartlang.org as pub.dev in hosted descriptions', () {
+        expect(
+          () => LockFile.parse(
+            '''
+packages:
+  retry:
+    dependency: transitive
+    description:
+      name: retry
+      url: "https://pub.dev"
+      sha256: abc # Not long enough
+    source: hosted
+    version: "1.0.0"
+''',
+            sources,
+          ),
+          throwsA(
+            isA<FormatException>().having(
+              (e) => e.message,
+              'message',
+              contains('Content-hash has incorrect length'),
+            ),
+          ),
+        );
+      });
+
       test('ignores extra stuff in file', () {
         LockFile.parse(
           '''

--- a/test/lock_file_test.dart
+++ b/test/lock_file_test.dart
@@ -322,7 +322,7 @@ packages:
         expectComesFromPubDev('retry');
       });
 
-      test('Reads pub.dartlang.org as pub.dev in hosted descriptions', () {
+      test('Complains about malformed content-hashes', () {
         expect(
           () => LockFile.parse(
             '''


### PR DESCRIPTION
Fix of https://github.com/dart-lang/pub/issues/3816