### PR TITLE
Remove support for .pub package-local cache

### DIFF
--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -67,8 +67,6 @@ Future<int> runExecutable(
     }
   }
 
-  entrypoint.migrateCache();
-
   var snapshotPath = entrypoint.pathOfExecutable(executable);
 
   // Don't compile snapshots for mutable packages, since their code may


### PR DESCRIPTION
We stopped creating this in https://github.com/dart-lang/pub/pull/1796 (5 years ago, dart v. 2.0.0)
