### PR TITLE
Remove support for legacy credentials file

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -210,7 +210,7 @@ class LishCommand extends PubCommand {
         //
         // This allows us to use `dart pub token add` to inject a token for use
         // with the official servers.
-        await oauth2.withClient(cache, (client) {
+        await oauth2.withClient((client) {
           return _publishUsingClient(packageBytes, client);
         });
       } else {

--- a/lib/src/command/login.dart
+++ b/lib/src/command/login.dart
@@ -23,7 +23,7 @@ class LoginCommand extends PubCommand {
 
   @override
   Future<void> runProtected() async {
-    final credentials = oauth2.loadCredentials(cache);
+    final credentials = oauth2.loadCredentials();
     if (credentials == null) {
       final userInfo = await _retrieveUserInfo();
       if (userInfo == null) {
@@ -44,7 +44,7 @@ class LoginCommand extends PubCommand {
   }
 
   Future<_UserInfo?> _retrieveUserInfo() async {
-    return await oauth2.withClient(cache, (client) async {
+    return await oauth2.withClient((client) async {
       final discovery = await oauth2.fetchOidcDiscoveryDocument();
       final userInfoEndpoint = discovery['userinfo_endpoint'];
       final userInfoRequest = await client.get(Uri.parse(userInfoEndpoint));

--- a/lib/src/command/logout.dart
+++ b/lib/src/command/logout.dart
@@ -20,6 +20,6 @@ class LogoutCommand extends PubCommand {
 
   @override
   Future<void> runProtected() async {
-    oauth2.logout(cache);
+    oauth2.logout();
   }
 }

--- a/lib/src/oauth2.dart
+++ b/lib/src/oauth2.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:collection/collection.dart' show IterableExtension;
 import 'package:http/http.dart' as http;
 import 'package:http/retry.dart';
 import 'package:path/path.dart' as path;
@@ -99,12 +98,6 @@ void logout(SystemCache cache) {
     log.message('Logging out of pub.dev.');
     log.message('Deleting $credentialsFile');
     _clearCredentials(cache);
-    // Test if we also have a legacy credentials file.
-    final legacyCredentialsFile = _legacyCredentialsFile(cache);
-    if (entryExists(legacyCredentialsFile)) {
-      log.message('Also deleting legacy credentials at $legacyCredentialsFile');
-      deleteEntry(legacyCredentialsFile);
-    }
   } else {
     log.message(
       'No existing credentials file $credentialsFile. Cannot log out.',
@@ -211,26 +204,12 @@ void _saveCredentials(SystemCache cache, Credentials credentials) {
 
 /// The path to the file in which the user's OAuth2 credentials are stored.
 ///
-/// This used to be PUB_CACHE/credentials.json. But the pub cache is not the
-/// best place for storing secrets, as it might be shared.
-///
-/// To provide backwards compatibility we use the legacy file if only it exists.
-///
 /// Returns `null` if there is no good place for the file.
 String? _credentialsFile(SystemCache cache) {
   final configDir = dartConfigDir;
-
-  final newCredentialsFile =
-      configDir == null ? null : path.join(configDir, 'pub-credentials.json');
-  var file = [
-    if (newCredentialsFile != null) newCredentialsFile,
-    _legacyCredentialsFile(cache)
-  ].firstWhereOrNull(fileExists);
-  return file ?? newCredentialsFile;
-}
-
-String _legacyCredentialsFile(SystemCache cache) {
-  return path.join(cache.rootDir, 'credentials.json');
+  return configDir == null
+      ? null
+      : path.join(configDir, 'pub-credentials.json');
 }
 
 /// Gets the user to authorize pub as a client of pub.dev via oauth2.

--- a/lib/src/oauth2.dart
+++ b/lib/src/oauth2.dart
@@ -83,21 +83,21 @@ final _scopes = ['openid', 'https://www.googleapis.com/auth/userinfo.email'];
 Credentials? _credentials;
 
 /// Delete the cached credentials, if they exist.
-void _clearCredentials(SystemCache cache) {
+void _clearCredentials() {
   _credentials = null;
-  var credentialsFile = _credentialsFile(cache);
+  var credentialsFile = _credentialsFile();
   if (credentialsFile != null && entryExists(credentialsFile)) {
     deleteEntry(credentialsFile);
   }
 }
 
 /// Try to delete the cached credentials.
-void logout(SystemCache cache) {
-  var credentialsFile = _credentialsFile(cache);
+void logout() {
+  var credentialsFile = _credentialsFile();
   if (credentialsFile != null && entryExists(credentialsFile)) {
     log.message('Logging out of pub.dev.');
     log.message('Deleting $credentialsFile');
-    _clearCredentials(cache);
+    _clearCredentials();
   } else {
     log.message(
       'No existing credentials file $credentialsFile. Cannot log out.',
@@ -133,7 +133,7 @@ Future<T> withClient<T>(SystemCache cache, Future<T> Function(Client) fn) {
         message = '$message (${error.description})';
       }
       log.error('$message.');
-      _clearCredentials(cache);
+      _clearCredentials();
       return withClient(cache, fn);
     } else {
       throw error;
@@ -172,7 +172,7 @@ Credentials? loadCredentials(SystemCache cache) {
   try {
     if (_credentials != null) return _credentials;
 
-    var path = _credentialsFile(cache);
+    var path = _credentialsFile();
     if (path == null || !fileExists(path)) return null;
 
     var credentials = Credentials.fromJson(readTextFile(path));
@@ -195,7 +195,7 @@ Credentials? loadCredentials(SystemCache cache) {
 void _saveCredentials(SystemCache cache, Credentials credentials) {
   log.fine('Saving OAuth2 credentials.');
   _credentials = credentials;
-  var credentialsPath = _credentialsFile(cache);
+  var credentialsPath = _credentialsFile();
   if (credentialsPath != null) {
     ensureDir(path.dirname(credentialsPath));
     writeTextFile(credentialsPath, credentials.toJson(), dontLogContents: true);
@@ -205,7 +205,7 @@ void _saveCredentials(SystemCache cache, Credentials credentials) {
 /// The path to the file in which the user's OAuth2 credentials are stored.
 ///
 /// Returns `null` if there is no good place for the file.
-String? _credentialsFile(SystemCache cache) {
+String? _credentialsFile() {
   final configDir = dartConfigDir;
   return configDir == null
       ? null

--- a/test/oauth2/logout_test.dart
+++ b/test/oauth2/logout_test.dart
@@ -24,6 +24,41 @@ void main() {
     await configDir([d.nothing('pub-credentials.json')]).validate();
   });
 
+  test(
+      'with an existing credentials file stored in the legacy location, deletes both.',
+      () async {
+    await servePackages();
+    await d
+        .credentialsFile(
+          globalServer,
+          'access-token',
+          refreshToken: 'refresh token',
+          expiration: DateTime.now().add(Duration(hours: 1)),
+        )
+        .create();
+
+    await d
+        .legacyCredentialsFile(
+          globalServer,
+          'access-token',
+          refreshToken: 'refresh token',
+          expiration: DateTime.now().add(Duration(hours: 1)),
+        )
+        .create();
+
+    await runPub(
+      args: ['logout'],
+      output: allOf(
+        [
+          contains('Logging out of pub.dev.'),
+          contains('Also deleting legacy credentials at ')
+        ],
+      ),
+    );
+
+    await d.dir(cachePath, [d.nothing('credentials.json')]).validate();
+    await d.dir(configPath, [d.nothing('pub-credentials.json')]).validate();
+  });
   test('with no existing credentials.json, notifies.', () async {
     await d.dir(configPath, [d.nothing('pub-credentials.json')]).create();
     await runPub(

--- a/test/oauth2/logout_test.dart
+++ b/test/oauth2/logout_test.dart
@@ -24,41 +24,6 @@ void main() {
     await configDir([d.nothing('pub-credentials.json')]).validate();
   });
 
-  test(
-      'with an existing credentials file stored in the legacy location, deletes both.',
-      () async {
-    await servePackages();
-    await d
-        .credentialsFile(
-          globalServer,
-          'access-token',
-          refreshToken: 'refresh token',
-          expiration: DateTime.now().add(Duration(hours: 1)),
-        )
-        .create();
-
-    await d
-        .legacyCredentialsFile(
-          globalServer,
-          'access-token',
-          refreshToken: 'refresh token',
-          expiration: DateTime.now().add(Duration(hours: 1)),
-        )
-        .create();
-
-    await runPub(
-      args: ['logout'],
-      output: allOf(
-        [
-          contains('Logging out of pub.dev.'),
-          contains('Also deleting legacy credentials at ')
-        ],
-      ),
-    );
-
-    await d.dir(cachePath, [d.nothing('credentials.json')]).validate();
-    await d.dir(configPath, [d.nothing('pub-credentials.json')]).validate();
-  });
   test('with no existing credentials.json, notifies.', () async {
     await d.dir(configPath, [d.nothing('pub-credentials.json')]).create();
     await runPub(


### PR DESCRIPTION
We stopped creating this in dart 2.15

https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md#pub-4

One might say we should support this longer - but I think Dart 3.0 is a good place to make this change. And also the consequence is only the user would have to log in again.