### PR TITLE
Remove obsolete TODO in exceptions.dart

### DIFF
--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -116,8 +116,6 @@ class PackageIntegrityException extends PubHttpException {
 ///
 /// This includes both [ApplicationException] and any dart:io errors.
 bool isUserFacingException(error) {
-  // TODO(nweiz): unify this list with _userFacingExceptions when issue 5897 is
-  // fixed.
   return error is ApplicationException ||
       error is AnalyzerErrorGroup ||
       error is IsolateSpawnException ||


### PR DESCRIPTION
This should have been removed with https://github.com/dart-lang/pub/commit/5ca86eb6e7be45ade4e44cbb7402d296cdf8b32f#diff-feaf8fcc8863df13f93c4869c5c1fb17438852a29819581aa1eeb12c26603a2fL87 .