### PR TITLE
Don't ignore a folder called 'packages' when publishing

### DIFF
--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -195,9 +195,6 @@ class Package {
   static final _basicIgnoreRules = [
     '.*', // Don't include dot-files.
     '!.htaccess', // Include .htaccess anyways.
-    // TODO(sigurdm): consider removing this. `packages` folders are not used
-    // anymore.
-    'packages/',
     'pubspec.lock',
     '!pubspec.lock/', // We allow a directory called pubspec lock.
     '/pubspec_overrides.yaml',

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -262,23 +262,6 @@ void main() {
       });
     });
 
-    test("Don't ignore packages/ before the package root", () async {
-      await d.dir(appPath, [
-        d.dir('packages', [
-          d.dir('app', [
-            d.appPubspec(),
-            d.dir('packages', [d.file('a.txt')]),
-          ]),
-        ]),
-      ]).create();
-
-      createEntrypoint(p.join(appPath, 'packages', 'app'));
-
-      expect(entrypoint!.root.listFiles(), {
-        p.join(root, 'pubspec.yaml'),
-      });
-    });
-
     group('with a submodule', () {
       setUp(() async {
         await d.git('submodule', [
@@ -312,17 +295,6 @@ void main() {
       await d.dir(appPath, [
         d.file('pubspec.lock'),
         d.dir('subdir', [d.file('pubspec.lock')])
-      ]).create();
-
-      expect(entrypoint!.root.listFiles(), {p.join(root, 'pubspec.yaml')});
-    });
-
-    test('ignores packages directories', () async {
-      await d.dir(appPath, [
-        d.dir('packages', [d.file('file.txt', 'contents')]),
-        d.dir('subdir', [
-          d.dir('packages', [d.file('subfile.txt', 'subcontents')]),
-        ])
       ]).create();
 
       expect(entrypoint!.root.listFiles(), {p.join(root, 'pubspec.yaml')});


### PR DESCRIPTION
Pub has not created such a folder since https://github.com/dart-lang/pub/pull/1960 (2018)