### PR TITLE
Remove support for PUB_CACHE in APPDATA on windows

### DIFF
--- a/lib/src/system_cache.dart
+++ b/lib/src/system_cache.dart
@@ -23,6 +23,7 @@ import 'source/hosted.dart';
 import 'source/path.dart';
 import 'source/sdk.dart';
 import 'source/unknown.dart';
+import 'utils.dart';
 
 /// The system-wide cache of downloaded packages.
 ///
@@ -41,21 +42,26 @@ class SystemCache {
     if (Platform.environment.containsKey('PUB_CACHE')) {
       return Platform.environment['PUB_CACHE']!;
     } else if (Platform.isWindows) {
-      // %LOCALAPPDATA% is preferred as the cache location over %APPDATA%, because the latter is synchronised between
-      // devices when the user roams between them, whereas the former is not.
-      // The default cache dir used to be in %APPDATA%, so to avoid breaking old installs,
-      // we use the old dir in %APPDATA% if it exists. Else, we use the new default location
-      // in %LOCALAPPDATA%.
-      //  TODO(sigurdm): handle missing APPDATA.
-      var appData = Platform.environment['APPDATA']!;
-      var appDataCacheDir = p.join(appData, 'Pub', 'Cache');
-      if (dirExists(appDataCacheDir)) {
-        return appDataCacheDir;
+      // %LOCALAPPDATA% is used as the cache location over %APPDATA%, because
+      // the latter is synchronised between devices when the user roams between
+      // them, whereas the former is not.
+      final localAppData = Platform.environment['LOCALAPPDATA'];
+      if (localAppData == null) {
+        dataError('''
+Could not find the pub cache. No `LOCALAPPDATA` environment variable exists.
+Consider setting the `PUB_CACHE` variable manually.
+''');
       }
-      var localAppData = Platform.environment['LOCALAPPDATA']!;
       return p.join(localAppData, 'Pub', 'Cache');
     } else {
-      return '${Platform.environment['HOME']}/.pub-cache';
+      final home = Platform.environment['HOME'];
+      if (home == null) {
+        dataError('''
+Could not find the pub cache. No `HOME` environment variable exists.
+Consider setting the `PUB_CACHE` variable manually.
+''');
+      }
+      return p.join(home, '.pub-cache');
     }
   })();
 


### PR DESCRIPTION
We stopped creating this 3 years ago: https://github.com/dart-lang/pub/pull/2297. ~dart 2.8.

