### PR TITLE
Lazy construction of cache path.

### DIFF
--- a/lib/src/system_cache.dart
+++ b/lib/src/system_cache.dart
@@ -32,7 +32,8 @@ import 'utils.dart';
 /// cache.
 class SystemCache {
   /// The root directory where this package cache is located.
-  final String rootDir;
+  String get rootDir => _rootDir ??= defaultDir;
+  String? _rootDir;
 
   String rootDirForSource(CachedSource source) => p.join(rootDir, source.name);
 
@@ -101,7 +102,7 @@ Consider setting the `PUB_CACHE` variable manually.
   /// If [isOffline] is `true`, then the offline hosted source will be used.
   /// Defaults to `false`.
   SystemCache({String? rootDir, this.isOffline = false})
-      : rootDir = rootDir ?? SystemCache.defaultDir,
+      : _rootDir = rootDir,
         tokenStore = TokenStore(dartConfigDir);
 
   /// Loads the package identified by [id].

--- a/lib/src/system_cache.dart
+++ b/lib/src/system_cache.dart
@@ -91,6 +91,7 @@ Consider setting the `PUB_CACHE` variable manually.
   SdkSource get sdk => SdkSource.instance;
 
   /// The default credential store.
+  /// TODO(sigurdm): this does not really belong in the cache.
   final TokenStore tokenStore;
 
   /// If true, cached sources will attempt to use the cached packages for

--- a/test/golden_file.dart
+++ b/test/golden_file.dart
@@ -157,7 +157,7 @@ class GoldenTestContext {
   /// log stdout/stderr and exit code to golden file.
   Future<void> run(
     List<String> args, {
-    Map<String, String>? environment,
+    Map<String, String?>? environment,
     String? workingDirectory,
     String? stdin,
   }) async {

--- a/test/help_test.dart
+++ b/test/help_test.dart
@@ -46,7 +46,9 @@ Future<void> main() async {
         [...c, '--help'],
         environment: {
           // Use more columns to avoid unintended line breaking.
-          '_PUB_TEST_TERMINAL_COLUMNS': '200'
+          '_PUB_TEST_TERMINAL_COLUMNS': '200',
+          'HOME': null,
+          'PUB_CACHE': null,
         },
       );
     });

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -968,7 +968,7 @@ String filterUnstableText(String input) {
 Future<void> runPubIntoBuffer(
   List<String> args,
   StringBuffer buffer, {
-  Map<String, String>? environment,
+  Map<String, String?>? environment,
   String? workingDirectory,
   String? stdin,
 }) async {


### PR DESCRIPTION
We don't want to access the system cache before we need it.

That way we can write the `dart pub token --help` text without having $HOME set.