### PR TITLE
Adjust topic pubspec field in list of valid pubspec keys

### DIFF
--- a/lib/src/validator/pubspec_typo.dart
+++ b/lib/src/validator/pubspec_typo.dart
@@ -69,5 +69,5 @@ const _validPubspecKeys = [
   'screenshots',
   'platforms',
   'funding',
-  'topics',
+  'topic',
 ];


### PR DESCRIPTION
According to https://github.com/dart-lang/pana/commit/d5ef51f3466289ee8f545ff93de9b69775b32ed6, it seems the field was intended to be singular (`topic:`).