### PR TITLE
Faster ensureUpToDate with path-dependencies

### DIFF
--- a/test/embedding/ensure_pubspec_resolved.dart
+++ b/test/embedding/ensure_pubspec_resolved.dart
@@ -378,8 +378,9 @@ void testEnsurePubspecResolved() {
           ),
         ]).create();
 
-        await _implicitPubGet('../bar/pubspec.yaml has changed '
-            'since the pubspec.lock file was generated.');
+        await _implicitPubGet(
+          '../bar/pubspec.yaml was modified after .dart_tool/package_config.json was generated.',
+        );
       });
     });
 


### PR DESCRIPTION
By comparing the timestamp of the pubspec.yaml of dependencies with that of the package_config.json that points to them we avoid parsing the pubspec.lock and pubspec.yaml just because there are path-dependencies.