### PR TITLE
Throw catchable exception from ensurePubspecResolved

### DIFF
--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:args/command_runner.dart';
+import 'package:pub/src/exceptions.dart';
 import 'src/entrypoint.dart';
 import 'src/pub_embeddable_command.dart';
 import 'src/system_cache.dart';
@@ -39,6 +40,8 @@ Command<int> pubCommand({
 ///
 /// If [onlyOutputWhenTerminal] is `true` (the default) there will be no
 /// output if no terminal is attached.
+///
+/// Throws a [ResolutionFailedException] if resolution fails.
 Future<void> ensurePubspecResolved(
   String dir, {
   PubAnalytics? analytics,
@@ -47,10 +50,19 @@ Future<void> ensurePubspecResolved(
   bool summaryOnly = true,
   bool onlyOutputWhenTerminal = true,
 }) async {
-  await Entrypoint(dir, SystemCache(isOffline: isOffline)).ensureUpToDate(
-    analytics: analytics,
-    checkForSdkUpdate: checkForSdkUpdate,
-    summaryOnly: summaryOnly,
-    onlyOutputWhenTerminal: onlyOutputWhenTerminal,
-  );
+  try {
+    await Entrypoint(dir, SystemCache(isOffline: isOffline)).ensureUpToDate(
+      analytics: analytics,
+      checkForSdkUpdate: checkForSdkUpdate,
+      summaryOnly: summaryOnly,
+      onlyOutputWhenTerminal: onlyOutputWhenTerminal,
+    );
+  } on ApplicationException catch (e) {
+    throw ResolutionFailedException._(e.toString());
+  }
+}
+
+class ResolutionFailedException implements Exception {
+  String message;
+  ResolutionFailedException._(this.message);
 }

--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -3,10 +3,12 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:args/command_runner.dart';
-import 'package:pub/src/exceptions.dart';
+
 import 'src/entrypoint.dart';
+import 'src/exceptions.dart';
 import 'src/pub_embeddable_command.dart';
 import 'src/system_cache.dart';
+
 export 'src/executable.dart'
     show
         getExecutableForCommand,


### PR DESCRIPTION
Otherwise we cannot handle failure from the embeddings side.