### PR TITLE
Improve message when sdk constraint is not null-safety enabled

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -988,14 +988,7 @@ See https://dart.dev/go/sdk-constraint
 The lower bound of "sdk: '$dartSdkConstraint'" must be 2.12.0'
 or higher to enable null safety.
 
-The current version of the Dart SDK (${sdk.version}) does not support non-null
-safety code.
-
-Consider using an older, compatible Dart SDK or try the following sdk
-constraint:
-
-environment:
-  sdk: '${suggestedConstraint.asCompatibleWithIfPossible()}'
+The current Dart SDK (${sdk.version}) only supports null safety.
 
 For details, see https://dart.dev/null-safety
 ''');

--- a/test/dart3_sdk_constraint_hack_test.dart
+++ b/test/dart3_sdk_constraint_hack_test.dart
@@ -19,7 +19,7 @@ void main() {
 
     await pubGet(
       error: contains(
-        'The current version of the Dart SDK (3.5.0) does not support non-null\nsafety code.',
+        'The current Dart SDK (3.5.0) only supports null safety.',
       ),
       environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
       exitCode: DATA,
@@ -51,7 +51,7 @@ void main() {
 
     await pubGet(
       error: contains(
-        'The current version of the Dart SDK (3.5.0) does not support non-null\nsafety code.',
+        'The current Dart SDK (3.5.0) only supports null safety.',
       ),
       environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
       exitCode: DATA,
@@ -68,7 +68,7 @@ void main() {
 
     await pubGet(
       error: contains(
-        'The current version of the Dart SDK (3.5.0) does not support non-null\nsafety code.',
+        'The current Dart SDK (3.5.0) only supports null safety.',
       ),
       environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
       exitCode: DATA,

--- a/test/get/sdk_constraint_required_test.dart
+++ b/test/get/sdk_constraint_required_test.dart
@@ -50,14 +50,7 @@ void main() {
 The lower bound of "sdk: '>=2.9.0 <4.0.0'" must be 2.12.0'
 or higher to enable null safety.
 
-The current version of the Dart SDK (3.1.2+3) does not support non-null
-safety code.
-
-Consider using an older, compatible Dart SDK or try the following sdk
-constraint:
-
-environment:
-  sdk: '^3.1.0'
+The current Dart SDK (3.1.2+3) only supports null safety.
 
 For details, see https://dart.dev/null-safety
 ''',


### PR DESCRIPTION
Trying to be less convoluted, and avoiding suggestions that are not really helpful.