### PR TITLE
Fix tests to work in context of 3.1

### DIFF
--- a/test/testdata/goldens/directory_option_test/commands taking a --directory~-C parameter work.txt
+++ b/test/testdata/goldens/directory_option_test/commands taking a --directory~-C parameter work.txt
@@ -98,11 +98,8 @@ Got dependencies in myapp/example.
 ## Section 10
 $ pub run -C myapp 'bin/app.dart'
 Building package executable...
-[STDERR] Failed to build test_pkg:app:
-[STDERR] myapp/bin/app.dart:1:1: Error: The specified language version is too high. The highest supported language version is 3.0.
-[STDERR] main() => print('Hi');
-[STDERR] ^
-[EXIT CODE] 1
+Built test_pkg:app.
+Hi
 
 -------------------------------- END OF OUTPUT ---------------------------------
 

--- a/test/validator/language_version_test.dart
+++ b/test/validator/language_version_test.dart
@@ -2,6 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:pub/src/language_version.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
@@ -57,9 +61,12 @@ void main() {
 
   group('should warn if it', () {
     test('opts in to a newer version.', () async {
+      final nextVersion =
+          Version.parse(Platform.version.split(' ').first).nextMajor;
       await setup(
         sdkConstraint: '^3.0.0',
-        libraryLanguageVersion: '3.1',
+        libraryLanguageVersion:
+            LanguageVersion.fromVersion(nextVersion).toString(),
       );
       await expectValidationWarning(
         'The language version override can\'t specify a version greater than the latest known language version',


### PR DESCRIPTION
The broken `langugage_version_test` was not written with much forethought (not that surprising it would be broken by 3.1).

The broken `directory_option_test` was actually broken in https://github.com/dart-lang/pub/pull/3695 (but missed) and now started working again.