### PR TITLE
Flag `pub publish --skip-validation` to publish without resolution and validation

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -66,6 +66,8 @@ class LishCommand extends PubCommand {
   /// Whether the publish requires confirmation.
   bool get force => argResults['force'];
 
+  bool get skipValidation => argResults['skip-validation'];
+
   LishCommand() {
     argParser.addFlag(
       'dry-run',
@@ -257,7 +259,7 @@ the \$PUB_HOSTED_URL environment variable.''',
           'pubspec.');
     }
 
-    if (!argResults['skip-validation']) {
+    if (!skipValidation) {
       await entrypoint.acquireDependencies(SolveType.get, analytics: analytics);
     } else {
       log.warning(
@@ -279,7 +281,7 @@ the \$PUB_HOSTED_URL environment variable.''',
         createTarGz(files, baseDir: entrypoint.rootDir).toBytes();
 
     // Validate the package.
-    var isValid = argResults['skip-validation']
+    var isValid = skipValidation
         ? true
         : await _validate(
             packageBytesFuture.then((bytes) => bytes.length),

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -82,7 +82,8 @@ class LishCommand extends PubCommand {
     argParser.addFlag(
       'skip-validation',
       negatable: false,
-      help: "Don't do any validations or resolution, just publish.",
+      help:
+          'Publish without validation and resolution (this will ignore errors).',
     );
     argParser.addOption(
       'server',

--- a/test/testdata/goldens/help_test/pub publish --help.txt
+++ b/test/testdata/goldens/help_test/pub publish --help.txt
@@ -8,6 +8,7 @@ Usage: pub publish [options]
 -h, --help               Print this usage information.
 -n, --dry-run            Validate but do not publish the package.
 -f, --force              Publish without confirmation if there are no errors.
+    --skip-validation    Publish without validation and resolution (this will ignore errors).
 -C, --directory=<dir>    Run this in the directory <dir>.
 
 Run "pub help" to see global options.


### PR DESCRIPTION
An escape-hook if we have mistakes in our validations.

Fixes https://github.com/dart-lang/pub/issues/3901

