### PR TITLE
Remove dead code

### DIFF
--- a/lib/src/solver/incompatibility.dart
+++ b/lib/src/solver/incompatibility.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:pub_semver/pub_semver.dart';
-
 import '../package_name.dart';
 import 'incompatibility_cause.dart';
 import 'term.dart';
@@ -108,15 +106,6 @@ class Incompatibility {
 
       return '${_terse(depender, details, allowEvery: true)} depends on '
           '${_terse(dependee, details)}';
-    } else if (cause == IncompatibilityCause.useLatest) {
-      assert(terms.length == 1);
-
-      var forbidden = terms.last;
-      assert(forbidden.isPositive);
-
-      return 'the latest version of ${_terseRef(forbidden, details)} '
-          '(${VersionConstraint.any.difference(forbidden.constraint)}) '
-          'is required';
     } else if (cause is SdkCause) {
       assert(terms.length == 1);
       assert(terms.first.isPositive);
@@ -429,11 +418,7 @@ class Incompatibility {
     buffer.write('${_terse(latter.terms.first, details)} ');
     if (priorLine != null) buffer.write('($priorLine) ');
 
-    if (latter.cause == IncompatibilityCause.useLatest) {
-      var latest =
-          VersionConstraint.any.difference(latter.terms.single.constraint);
-      buffer.write('but the latest version ($latest) is required');
-    } else if (latter.cause is SdkCause) {
+    if (latter.cause is SdkCause) {
       var cause = latter.cause as SdkCause;
       if (cause.noNullSafetyCause) {
         buffer.write('which doesn\'t support null safety');

--- a/lib/src/solver/incompatibility_cause.dart
+++ b/lib/src/solver/incompatibility_cause.dart
@@ -20,10 +20,6 @@ abstract class IncompatibilityCause {
   /// The incompatibility represents a package's dependency.
   static const IncompatibilityCause dependency = _Cause('dependency');
 
-  /// The incompatibility represents the user's request that we use the latest
-  /// version of a given package.
-  static const IncompatibilityCause useLatest = _Cause('use latest');
-
   /// The incompatibility indicates that the package has no versions that match
   /// the given constraint.
   static const IncompatibilityCause noVersions = _Cause('no versions');


### PR DESCRIPTION
Usage of `IncompatibilityCause.useLatest` was removed in https://github.com/dart-lang/pub/pull/2781