### PR TITLE
Expand constraint for `http`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: pub
 
 environment:
-  sdk: '^3.0.0-0'
+  sdk: ^3.0.0
 
 dependencies:
   # Note: Pub's test infrastructure assumes that any dependencies used in tests
@@ -14,7 +14,7 @@ dependencies:
   convert: ^3.0.2
   crypto: ^3.0.1
   frontend_server_client: ^3.2.0
-  http: ^0.13.3
+  http: ">=0.13.3 <2.0.0"
   http_multi_server: ^3.0.1
   http_parser: ^4.0.1
   meta: ^1.3.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   convert: ^3.0.2
   crypto: ^3.0.1
   frontend_server_client: ^3.2.0
-  http: ">=0.13.3 <2.0.0"
+  http: "^1.0.0"
   http_multi_server: ^3.0.1
   http_parser: ^4.0.1
   meta: ^1.3.0


### PR DESCRIPTION
The 1.0.0 release does not have breaking changes.

Remove the pre-release suffix from the SDK constraint now that the
stable SDK is published. Remove unneeded quotes from SDK constraint.
