### PR TITLE
Remove usage of Isolate.packageRoot from tests

### DIFF
--- a/test/global/run/package_api_test.dart
+++ b/test/global/run/package_api_test.dart
@@ -22,7 +22,6 @@ void main() {
 import 'dart:isolate';
 
 main() async {
-  print(await Isolate.packageRoot);
   print(await Isolate.packageConfig);
   print(await Isolate.resolvePackageUri(
       Uri.parse('package:foo/resource.txt')));
@@ -37,8 +36,6 @@ main() async {
     await runPub(args: ['global', 'activate', 'foo']);
 
     var pub = await pubRun(global: true, args: ['foo:script']);
-
-    expect(pub.stdout, emitsThrough('null'));
 
     var packageConfigPath = p.join(
       d.sandbox,
@@ -72,7 +69,6 @@ main() async {
 import 'dart:isolate';
 
 main() async {
-  print(await Isolate.packageRoot);
   print(await Isolate.packageConfig);
   print(await Isolate.resolvePackageUri(
       Uri.parse('package:myapp/resource.txt')));
@@ -86,8 +82,6 @@ main() async {
     await runPub(args: ['global', 'activate', '-s', 'path', '.']);
 
     var pub = await pubRun(global: true, args: ['myapp:script']);
-
-    expect(pub.stdout, emitsThrough('null'));
 
     var packageConfigPath =
         p.join(d.sandbox, 'myapp/.dart_tool/package_config.json');

--- a/test/global/run/package_api_test.dart
+++ b/test/global/run/package_api_test.dart
@@ -85,7 +85,7 @@ main() async {
 
     var packageConfigPath =
         p.join(d.sandbox, 'myapp/.dart_tool/package_config.json');
-    expect(pub.stdout, emits(p.toUri(packageConfigPath).toString()));
+    expect(pub.stdout, emitsThrough(p.toUri(packageConfigPath).toString()));
 
     var myappResourcePath = p.join(d.sandbox, 'myapp/lib/resource.txt');
     expect(pub.stdout, emits(p.toUri(myappResourcePath).toString()));

--- a/test/run/package_api_test.dart
+++ b/test/run/package_api_test.dart
@@ -12,7 +12,6 @@ const _script = """
   import 'dart:isolate';
 
   main() async {
-    print(await Isolate.packageRoot);
     print(await Isolate.packageConfig);
     print(await Isolate.resolvePackageUri(
         Uri.parse('package:myapp/resource.txt')));
@@ -76,7 +75,6 @@ void main() {
 
     expect(pub.stdout, emitsThrough('Building package executable...'));
     expect(pub.stdout, emits('Built foo:script.'));
-    expect(pub.stdout, emits('null'));
     expect(
       pub.stdout,
       emits(

--- a/test/run/package_api_test.dart
+++ b/test/run/package_api_test.dart
@@ -12,6 +12,7 @@ const _script = """
   import 'dart:isolate';
 
   main() async {
+    print(await Isolate.packageRoot);
     print(await Isolate.packageConfig);
     print(await Isolate.resolvePackageUri(
         Uri.parse('package:myapp/resource.txt')));
@@ -38,7 +39,7 @@ void main() {
 
     expect(
       pub.stdout,
-      emits(
+      emitsThrough(
         p
             .toUri(p.join(d.sandbox, 'myapp/.dart_tool/package_config.json'))
             .toString(),

--- a/test/run/package_api_test.dart
+++ b/test/run/package_api_test.dart
@@ -12,7 +12,6 @@ const _script = """
   import 'dart:isolate';
 
   main() async {
-    print(await Isolate.packageRoot);
     print(await Isolate.packageConfig);
     print(await Isolate.resolvePackageUri(
         Uri.parse('package:myapp/resource.txt')));
@@ -37,7 +36,6 @@ void main() {
     await pubGet();
     var pub = await pubRun(args: ['bin/script']);
 
-    expect(pub.stdout, emitsThrough('null'));
     expect(
       pub.stdout,
       emits(


### PR DESCRIPTION
`Isolate.packageRoot` didn't do anything anymore, and with https://github.com/dart-lang/sdk/commit/e24899bac1964b4e21f8032d0c9ac45fabfe41cc it doesn't even exist.