### PR TITLE
Handle non-default hosts in `upgrade --major-versions`

### DIFF
--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -211,7 +211,7 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
     for (final dep in declaredHostedDependencies) {
       final resolvedPackage = resolvedPackages[dep.name]!;
       if (!toUpgrade.contains(dep.name)) {
-        // If we're not to upgrade this package, or it wasn't in the
+        // If we're not trying to upgrade this package, or it wasn't in the
         // resolution somehow, then we ignore it.
         continue;
       }
@@ -296,25 +296,16 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
     Map<PackageRange, PackageRange> changes,
   ) {
     ArgumentError.checkNotNull(changes, 'changes');
-
     final yamlEditor = YamlEditor(readTextFile(entrypoint.pubspecPath));
     final deps = entrypoint.root.pubspec.dependencies.keys;
-    final devDeps = entrypoint.root.pubspec.devDependencies.keys;
 
     for (final change in changes.values) {
-      if (deps.contains(change.name)) {
-        yamlEditor.update(
-          ['dependencies', change.name],
-          // TODO(jonasfj): Fix support for third-party pub servers.
-          change.constraint.toString(),
-        );
-      } else if (devDeps.contains(change.name)) {
-        yamlEditor.update(
-          ['dev_dependencies', change.name],
-          // TODO: Fix support for third-party pub servers
-          change.constraint.toString(),
-        );
-      }
+      final section =
+          deps.contains(change.name) ? 'dependencies' : 'dev_dependencies';
+      yamlEditor.update(
+        [section, change.name],
+        pubspecDescription(change, cache, entrypoint),
+      );
     }
     return yamlEditor.toString();
   }

--- a/test/add/hosted/non_default_pub_server_test.dart
+++ b/test/add/hosted/non_default_pub_server_test.dart
@@ -219,7 +219,7 @@ void main() {
     ]).validate();
     await d.appDir(
       dependencies: {
-        'foo': {'version': 'any', 'hosted': url}
+        'foo': {'hosted': url}
       },
     ).validate();
   });

--- a/test/upgrade/upgrade_major_versions_test.dart
+++ b/test/upgrade/upgrade_major_versions_test.dart
@@ -307,5 +307,32 @@ void main() {
         ]),
       );
     });
+
+    test('works with an explicit "hosted" description:', () async {
+      await servePackages();
+      final alternativeServer = await startPackageServer();
+      alternativeServer.serve('foo', '1.0.0');
+      alternativeServer.serve('foo', '2.0.0');
+      await d.appDir(
+        dependencies: {
+          'foo': {'hosted': alternativeServer.url, 'version': '^1.0.0'},
+        },
+      ).create();
+
+      await pubGet();
+
+      await pubUpgrade(
+        args: ['--major-versions'],
+        output: allOf([
+          contains('Changed 1 constraint in pubspec.yaml:'),
+          contains('foo: ^1.0.0 -> ^2.0.0'),
+        ]),
+      );
+      await d.appDir(
+        dependencies: {
+          'foo': {'hosted': alternativeServer.url, 'version': '^2.0.0'},
+        },
+      ).validate();
+    });
   });
 }


### PR DESCRIPTION
Fix of: https://github.com/dart-lang/pub/issues/3942

Turns out there even was an old todo to do this :)