### PR TITLE
Adjust report

### DIFF
--- a/lib/src/solver/report.dart
+++ b/lib/src/solver/report.dart
@@ -205,10 +205,8 @@ $contentHashesDocumentationUrl
           log.message('Changed $numChanged dependencies$suffix!');
         }
       }
-      if (_type == SolveType.upgrade) {
-        await reportDiscontinued();
-        reportOutdated();
-      }
+      await reportDiscontinued();
+      reportOutdated();
     }
   }
 
@@ -407,12 +405,11 @@ $contentHashesDocumentationUrl
       }
     }
 
-    if (_type == SolveType.get &&
-        !(alwaysShow ||
-            changed ||
-            addedOrRemoved ||
-            message != null ||
-            isOverridden)) {
+    if (!(alwaysShow ||
+        changed ||
+        addedOrRemoved ||
+        message != null ||
+        isOverridden)) {
       return changed || addedOrRemoved;
     }
 

--- a/test/get/hosted/warn_about_discontinued_test.dart
+++ b/test/get/hosted/warn_about_discontinued_test.dart
@@ -40,6 +40,7 @@ void main() {
 Resolving dependencies...
   foo 1.2.3 (discontinued)
 Got dependencies!
+1 package is discontinued.
 ''',
     );
     expect(fileExists(fooVersionsCache), isTrue);
@@ -55,7 +56,8 @@ Got dependencies!
       output: '''
 Resolving dependencies...
   foo 1.2.3 (discontinued replaced by bar)
-Got dependencies!''',
+Got dependencies!
+1 package is discontinued.''',
     );
     final c2 = json.decode(readTextFile(fooVersionsCache));
     // Make a bad cached value to test that responses are actually from cache.
@@ -72,7 +74,8 @@ Got dependencies!''',
       output: '''
 Resolving dependencies...
   foo 1.2.3 (discontinued replaced by bar)
-Got dependencies!''',
+Got dependencies!
+1 package is discontinued.''',
     );
     // Test that --offline won't try to access the server for retrieving the
     // status.
@@ -82,7 +85,8 @@ Got dependencies!''',
       output: '''
 Resolving dependencies...
   foo 1.2.3 (discontinued replaced by bar)
-Got dependencies!''',
+Got dependencies!
+1 package is discontinued.''',
     );
     deleteEntry(fooVersionsCache);
     deleteEntry(transitiveVersionsCache);
@@ -130,6 +134,7 @@ environment:
 Resolving dependencies...
   foo 1.2.3 (discontinued)
 Got dependencies!
+1 package is discontinued.
 ''',
     );
     expect(fileExists(fooVersionsCache), isTrue);
@@ -143,7 +148,8 @@ Got dependencies!
       output: '''
 Resolving dependencies...
   foo 1.2.3 (discontinued replaced by bar)
-Got dependencies!''',
+Got dependencies!
+1 package is discontinued.''',
     );
     final c2 = json.decode(readTextFile(fooVersionsCache));
     // Make a bad cached value to test that responses are actually from cache.
@@ -160,7 +166,8 @@ Got dependencies!''',
       output: '''
 Resolving dependencies...
   foo 1.2.3 (discontinued replaced by bar)
-Got dependencies!''',
+Got dependencies!
+1 package is discontinued.''',
     );
     // Test that --offline won't try to access the server for retrieving the
     // status.
@@ -170,7 +177,8 @@ Got dependencies!''',
       output: '''
 Resolving dependencies...
   foo 1.2.3 (discontinued replaced by bar)
-Got dependencies!''',
+Got dependencies!
+1 package is discontinued.''',
     );
     deleteEntry(fooVersionsCache);
     await pubGet(

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -104,7 +104,9 @@ Try `dart pub outdated` for more information.$)'''),
   );
   static final downgrade = RunCommand(
     'downgrade',
-    RegExp(r'(No dependencies changed\.|Changed \d+ dependenc(y|ies)!)$'),
+    RegExp(r'''(No dependencies changed\.|Changed \d+ dependenc(y|ies)!)($|
+\d+ packages? (has|have) newer versions incompatible with dependency constraints.
+Try `dart pub outdated` for more information.$)'''),
   );
   static final remove = RunCommand(
     'remove',

--- a/test/testdata/goldens/directory_option_test/commands taking a --directory~-C parameter work.txt
+++ b/test/testdata/goldens/directory_option_test/commands taking a --directory~-C parameter work.txt
@@ -78,7 +78,6 @@ $ pub get bar -C 'myapp/broken_dir'
 ## Section 8
 $ pub downgrade -C myapp
 Resolving dependencies in myapp...
-  foo 1.0.0
 No dependencies changed in myapp.
 Resolving dependencies in myapp/example...
 Got dependencies in myapp/example.
@@ -88,7 +87,6 @@ Got dependencies in myapp/example.
 ## Section 9
 $ pub upgrade bar -C myapp
 Resolving dependencies in myapp...
-  foo 1.0.0
 No dependencies changed in myapp.
 Resolving dependencies in myapp/example...
 Got dependencies in myapp/example.

--- a/test/testdata/goldens/embedding/embedding_test/--color forces colors.txt
+++ b/test/testdata/goldens/embedding/embedding_test/--color forces colors.txt
@@ -4,6 +4,8 @@ $ tool/test-bin/pub_command_runner.dart pub --no-color get
 Resolving dependencies...
 + foo 1.0.0 (2.0.0 available)
 Changed 1 dependency!
+1 package has newer versions incompatible with dependency constraints.
+Try `dart pub outdated` for more information.
 
 -------------------------------- END OF OUTPUT ---------------------------------
 
@@ -11,4 +13,6 @@ $ tool/test-bin/pub_command_runner.dart pub --color get
 Resolving dependencies...
   [1mfoo[0m 1.0.0 [36m(2.0.0 available)[39m
 Got dependencies!
+1 package has newer versions incompatible with dependency constraints.
+Try `dart pub outdated` for more information.
 

--- a/test/testdata/goldens/upgrade/example_warns_about_major_versions_test/pub upgrade --major-versions does not update major versions in example~.txt
+++ b/test/testdata/goldens/upgrade/example_warns_about_major_versions_test/pub upgrade --major-versions does not update major versions in example~.txt
@@ -17,9 +17,7 @@ Got dependencies in ./example.
 ## Section 1
 $ pub upgrade --major-versions --directory example
 Resolving dependencies in example...
-  bar 2.0.0
 > foo 2.0.0 (was 1.0.0)
-  myapp 0.0.0 from path .
 Changed 1 dependency in example!
 
 Changed 1 constraint in pubspec.yaml:

--- a/test/upgrade/hosted/warn_about_discontinued_test.dart
+++ b/test/upgrade/hosted/warn_about_discontinued_test.dart
@@ -23,7 +23,6 @@ void main() {
       output: '''
 Resolving dependencies...
   foo 1.2.3 (discontinued)
-  transitive 1.0.0
   No dependencies changed.
   1 package is discontinued.
 ''',
@@ -34,9 +33,8 @@ Resolving dependencies...
       output: '''
 Resolving dependencies...
   foo 1.2.3 (discontinued replaced by bar)
-  transitive 1.0.0
-  No dependencies changed.
-  1 package is discontinued.
+No dependencies changed.
+1 package is discontinued.
 ''',
     );
   });
@@ -68,7 +66,6 @@ environment:
       output: '''
 Resolving dependencies...
   foo 1.2.3 (discontinued)
-    transitive 1.0.0
   No dependencies changed.
   1 package is discontinued.
 ''',
@@ -79,7 +76,6 @@ Resolving dependencies...
       output: '''
 Resolving dependencies...
   foo 1.2.3 (discontinued replaced by bar)
-  transitive 1.0.0
   No dependencies changed.
   1 package is discontinued.
 ''',

--- a/test/upgrade/report/describes_change_test.dart
+++ b/test/upgrade/report/describes_change_test.dart
@@ -101,7 +101,6 @@ void main() {
         contains(
           '* description_changed 1.0.0 from path ..${separator}description_changed_2 (was 1.0.0 from path ..${separator}description_changed_1)',
         ),
-        contains('  unchanged 1.0.0'),
         contains(
           '* source_changed 2.0.0 from path ..${separator}source_changed (was 1.0.0)',
         ),

--- a/test/upgrade/report/leading_character_shows_change_test.dart
+++ b/test/upgrade/report/leading_character_shows_change_test.dart
@@ -79,7 +79,6 @@ Resolving dependencies\.\.\..*
 < downgraded .*
 ! overridden .*
 \* source_changed .*
-  unchanged .*
 > upgraded .*
 These packages are no longer being depended on:
 - removed .*


### PR DESCRIPTION
* Don't mention unchanged deps in `upgrade` report
* Give summary of changes in `pub get` report

Fixes: https://github.com/dart-lang/pub/issues/2863

Before:
```
> dart pub upgrade
Resolving dependencies... (2.0s)
  _fe_analyzer_shared 61.0.0
  analyzer 5.13.0
  args 2.4.2
  async 2.11.0
> boolean_selector 2.1.1 (was 2.1.0)
  checked_yaml 2.0.3
  cli_util 0.4.0
  collection 1.17.2
  convert 3.1.1
  coverage 1.6.3
  crypto 3.0.3
  file 7.0.0
  frontend_server_client 3.2.0
  glob 2.1.2
  http 1.0.0
  http_multi_server 3.2.1
  http_parser 4.0.2
  io 1.0.4
  js 0.6.7
  json_annotation 4.8.1
  lints 2.1.1
  logging 1.2.0
  matcher 0.12.16
  meta 1.9.1
  mime 1.0.4
  node_preamble 2.0.2
  package_config 2.1.0
  path 1.8.3
  pool 1.5.1
  pub_semver 2.1.4
  pubspec_parse 1.2.3
  retry 3.1.2
  shelf 1.4.1
  shelf_packages_handler 3.0.2
  shelf_static 1.1.2
  shelf_test_handler 2.0.2
  shelf_web_socket 1.0.4
  source_map_stack_trace 2.1.1
  source_maps 0.10.12
  source_span 1.10.0
  stack_trace 1.11.0
  stream_channel 2.1.1
  string_scanner 1.2.0
  tar 0.5.6
  term_glyph 1.2.1
  test 1.24.3
  test_api 0.6.0
  test_core 0.5.3
  test_descriptor 2.0.1
  test_process 2.1.0
  typed_data 1.3.2
  usage 4.1.1
  vendor 0.9.5
  vm_service 11.7.1
  watcher 1.1.0
  web_socket_channel 2.4.0
  webkit_inspection_protocol 1.2.0
  yaml 3.1.2
  yaml_edit 2.1.1
Changed 1 dependency!
```
after
```
> dart pub upgrade
Resolving dependencies... (2.1s)
> boolean_selector 2.1.1 (was 2.1.0)
Changed 1 dependency!
```

Before:
```
> dart pub get
Resolving dependencies... (3.0s)
  _fe_analyzer_shared 31.0.0 (61.0.0 available)
  analyzer 2.8.0 (5.13.0 available)
  archive 3.1.6 (3.3.7 available)
  args 2.3.0 (2.4.2 available)
  async 2.8.2 (2.11.0 available)
  boolean_selector 2.1.0 (2.1.1 available)
  build 2.1.1 (2.4.0 available)
  build_config 1.0.0 (1.1.1 available)
  build_daemon 3.0.1 (4.0.0 available)
  build_resolvers 2.0.5 (2.2.0 available)
  build_runner 2.1.5 (2.4.5 available)
  build_runner_core 7.2.2 (7.2.10 available)
  build_test 2.1.4 (2.1.7 available)
  built_value 8.1.3 (8.6.1 available)
  checked_yaml 2.0.1 (2.0.3 available)
  cli_util 0.3.5 (0.4.0 available)
  code_builder 4.1.0 (4.5.0 available)
  collection 1.15.0 (1.17.2 available)
  convert 3.0.1 (3.1.1 available)
  coverage 1.0.3 (1.6.3 available)
  crypto 3.0.1 (3.0.3 available)
  csslib 0.17.1 (1.0.0 available)
  dart_style 2.2.0 (2.3.1 available)
  file 6.1.2 (7.0.0 available)
  fixnum 1.0.0 (1.1.0 available)
  frontend_server_client 2.1.2 (3.2.0 available)
  glob 2.0.2 (2.1.2 available)
  googleapis_auth 1.3.0 (1.4.1 available)
  graphs 2.1.0 (2.3.1 available)
  html 0.15.0 (0.15.4 available)
  http 0.13.4 (1.0.0 available)
  http2 2.0.0 (2.2.0 available)
  http_multi_server 3.0.1 (3.2.1 available)
  http_parser 4.0.0 (4.0.2 available)
  io 1.0.3 (1.0.4 available)
  js 0.6.3 (0.6.7 available)
  json_annotation 4.4.0 (4.8.1 available)
  logging 1.0.2 (1.2.0 available)
  matcher 0.12.11 (0.12.16 available)
  meta 1.7.0 (1.9.1 available)
  mime 1.0.1 (1.0.4 available)
  mockito 5.0.16 (5.4.2 available)
  node_preamble 2.0.1 (2.0.2 available)
  package_config 2.0.2 (2.1.0 available)
  path 1.8.0 (1.8.3 available)
  pool 1.5.0 (1.5.1 available)
  protobuf 2.0.1 (3.0.0 available)
  pub_semver 2.1.0 (2.1.4 available)
  pubspec_parse 1.2.0 (1.2.3 available)
  shelf 1.2.0 (1.4.1 available)
  shelf_packages_handler 3.0.0 (3.0.2 available)
  shelf_static 1.1.0 (1.1.2 available)
  shelf_web_socket 1.0.1 (1.0.4 available)
  source_gen 1.2.0 (1.3.2 available)
  source_map_stack_trace 2.1.0 (2.1.1 available)
  source_maps 0.10.10 (0.10.12 available)
  source_span 1.8.1 (1.10.0 available)
  stack_trace 1.10.0 (1.11.0 available)
  stream_channel 2.1.0 (2.1.1 available)
  stream_transform 2.0.0 (2.1.0 available)
  string_scanner 1.1.0 (1.2.0 available)
  term_glyph 1.2.0 (1.2.1 available)
  test 1.19.5 (1.24.3 available)
  test_api 0.4.8 (0.6.0 available)
  test_core 0.4.9 (0.5.3 available)
  timing 1.0.0 (1.0.1 available)
  typed_data 1.3.0 (1.3.2 available)
  vm_service 7.5.0 (11.7.1 available)
  watcher 1.0.1 (1.1.0 available)
  web_socket_channel 2.1.0 (2.4.0 available)
  webkit_inspection_protocol 1.0.0 (1.2.0 available)
  yaml 3.1.0 (3.1.2 available)
```
After:
```
> dart pub get
Resolving dependencies... 
  _fe_analyzer_shared 31.0.0 (61.0.0 available)
  analyzer 2.8.0 (5.13.0 available)
  archive 3.1.6 (3.3.7 available)
  args 2.3.0 (2.4.2 available)
  async 2.8.2 (2.11.0 available)
  boolean_selector 2.1.0 (2.1.1 available)
  build 2.1.1 (2.4.0 available)
  build_config 1.0.0 (1.1.1 available)
  build_daemon 3.0.1 (4.0.0 available)
  build_resolvers 2.0.5 (2.2.0 available)
  build_runner 2.1.5 (2.4.5 available)
  build_runner_core 7.2.2 (7.2.10 available)
  build_test 2.1.4 (2.1.7 available)
  built_value 8.1.3 (8.6.1 available)
  checked_yaml 2.0.1 (2.0.3 available)
  cli_util 0.3.5 (0.4.0 available)
  code_builder 4.1.0 (4.5.0 available)
  collection 1.15.0 (1.17.2 available)
  convert 3.0.1 (3.1.1 available)
  coverage 1.0.3 (1.6.3 available)
  crypto 3.0.1 (3.0.3 available)
  csslib 0.17.1 (1.0.0 available)
  dart_style 2.2.0 (2.3.1 available)
  file 6.1.2 (7.0.0 available)
  fixnum 1.0.0 (1.1.0 available)
  frontend_server_client 2.1.2 (3.2.0 available)
  glob 2.0.2 (2.1.2 available)
  googleapis_auth 1.3.0 (1.4.1 available)
  graphs 2.1.0 (2.3.1 available)
  html 0.15.0 (0.15.4 available)
  http 0.13.4 (1.0.0 available)
  http2 2.0.0 (2.2.0 available)
  http_multi_server 3.0.1 (3.2.1 available)
  http_parser 4.0.0 (4.0.2 available)
  io 1.0.3 (1.0.4 available)
  js 0.6.3 (0.6.7 available)
  json_annotation 4.4.0 (4.8.1 available)
  logging 1.0.2 (1.2.0 available)
  matcher 0.12.11 (0.12.16 available)
  meta 1.7.0 (1.9.1 available)
  mime 1.0.1 (1.0.4 available)
  mockito 5.0.16 (5.4.2 available)
  node_preamble 2.0.1 (2.0.2 available)
  package_config 2.0.2 (2.1.0 available)
  path 1.8.0 (1.8.3 available)
  pool 1.5.0 (1.5.1 available)
  protobuf 2.0.1 (3.0.0 available)
  pub_semver 2.1.0 (2.1.4 available)
  pubspec_parse 1.2.0 (1.2.3 available)
  shelf 1.2.0 (1.4.1 available)
  shelf_packages_handler 3.0.0 (3.0.2 available)
  shelf_static 1.1.0 (1.1.2 available)
  shelf_web_socket 1.0.1 (1.0.4 available)
  source_gen 1.2.0 (1.3.2 available)
  source_map_stack_trace 2.1.0 (2.1.1 available)
  source_maps 0.10.10 (0.10.12 available)
  source_span 1.8.1 (1.10.0 available)
  stack_trace 1.10.0 (1.11.0 available)
  stream_channel 2.1.0 (2.1.1 available)
  stream_transform 2.0.0 (2.1.0 available)
  string_scanner 1.1.0 (1.2.0 available)
  term_glyph 1.2.0 (1.2.1 available)
  test 1.19.5 (1.24.3 available)
  test_api 0.4.8 (0.6.0 available)
  test_core 0.4.9 (0.5.3 available)
  timing 1.0.0 (1.0.1 available)
  typed_data 1.3.0 (1.3.2 available)
  vm_service 7.5.0 (11.7.1 available)
  watcher 1.0.1 (1.1.0 available)
  web_socket_channel 2.1.0 (2.4.0 available)
  webkit_inspection_protocol 1.0.0 (1.2.0 available)
  yaml 3.1.0 (3.1.2 available)
Got dependencies!
72 packages have newer versions incompatible with dependency constraints.
Try `dart pub outdated` for more information.
```