### PR TITLE
`upgrade --tighten`

### DIFF
--- a/test/testdata/goldens/help_test/pub upgrade --help.txt
+++ b/test/testdata/goldens/help_test/pub upgrade --help.txt
@@ -9,6 +9,7 @@ Usage: pub upgrade [dependencies...]
     --[no-]offline       Use cached packages instead of accessing the network.
 -n, --dry-run            Report what dependencies would change but don't change any.
     --[no-]precompile    Precompile executables in immediate dependencies.
+    --tighten            Updates lower bounds in pubspec.yaml to match the resolved version.
     --major-versions     Upgrades packages to their latest resolvable versions, and updates pubspec.yaml.
 -C, --directory=<dir>    Run this in the directory <dir>.
 

--- a/test/upgrade/upgrade_tighten_test.dart
+++ b/test/upgrade/upgrade_tighten_test.dart
@@ -1,0 +1,172 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+void main() {
+  group('pub upgrade --tighten', () {
+    test('updates dependency constraints lower bounds and shows summary report',
+        () async {
+      final server = await servePackages();
+
+      server.serve('foo', '1.0.0');
+      server.serve('bar', '0.2.0');
+      server.serve('baz', '0.2.0');
+      server.serve('boo', '1.0.0');
+
+      await d.dir('boom', [d.libPubspec('boom', '1.0.0')]).create();
+      await d.dir('boom2', [d.libPubspec('boom2', '1.5.0')]).create();
+
+      await d.appDir(
+        dependencies: {
+          'foo': '^1.0.0',
+          'bar': '>=0.1.2 <3.0.0',
+          'baz': '0.2.0',
+          'boo': 'any',
+          'boom': {'path': '../boom'},
+          'boom2': {'path': '../boom2', 'version': '^1.0.0'},
+        },
+      ).create();
+
+      await pubGet();
+
+      server.serve('foo', '1.5.0');
+      server.serve('bar', '1.5.0');
+
+      await pubUpgrade(
+        args: ['--tighten', '--dry-run'],
+        output: allOf([
+          contains('Would change 4 constraints in pubspec.yaml:'),
+          contains('foo: ^1.0.0 -> ^1.5.0'),
+          contains('bar: >=0.1.2 <3.0.0 -> >=1.5.0 <3.0.0'),
+          contains('boo: any -> ^1.0.0'),
+          contains('boom2: ^1.0.0 -> ^1.5.0'),
+        ]),
+      );
+
+      await pubUpgrade(
+        args: ['--tighten'],
+        output: allOf([
+          contains('Changed 4 constraints in pubspec.yaml:'),
+          contains('foo: ^1.0.0 -> ^1.5.0'),
+          contains('bar: >=0.1.2 <3.0.0 -> >=1.5.0 <3.0.0'),
+          contains('boo: any -> ^1.0.0'),
+          contains('boom2: ^1.0.0 -> ^1.5.0'),
+        ]),
+      );
+
+      await d.appDir(
+        dependencies: {
+          'foo': '^1.5.0',
+          'bar': '>=1.5.0 <3.0.0',
+          'baz': '0.2.0',
+          'boo': '^1.0.0',
+          'boom': {'path': '../boom'},
+          'boom2': {'path': '../boom2', 'version': '^1.5.0'},
+        },
+      ).validate();
+      await d.appPackageConfigFile([
+        d.packageConfigEntry(name: 'foo', version: '1.5.0'),
+        d.packageConfigEntry(name: 'bar', version: '1.5.0'),
+        d.packageConfigEntry(name: 'baz', version: '0.2.0'),
+        d.packageConfigEntry(name: 'boo', version: '1.0.0'),
+        d.packageConfigEntry(name: 'boom', path: '../boom'),
+        d.packageConfigEntry(name: 'boom2', path: '../boom2'),
+      ]).validate();
+    });
+
+    test(
+        '--major-versions updates dependency constraints lower bounds and shows summary report',
+        () async {
+      final server = await servePackages();
+
+      server.serve('foo', '1.0.0');
+      server.serve('bar', '1.0.0');
+
+      await d.appDir(
+        dependencies: {
+          'foo': '^1.0.0',
+          'bar': '^1.0.0',
+        },
+      ).create();
+
+      await pubGet();
+
+      server.serve('foo', '2.0.0');
+      server.serve('bar', '1.5.0');
+
+      await pubUpgrade(
+        args: ['--tighten', '--major-versions'],
+        output: allOf([
+          contains('Changed 2 constraints in pubspec.yaml:'),
+          contains('foo: ^1.0.0 -> ^2.0.0'),
+          contains('bar: ^1.0.0 -> ^1.5.0'),
+        ]),
+      );
+
+      await d.appDir(
+        dependencies: {
+          'foo': '^2.0.0',
+          'bar': '^1.5.0',
+        },
+      ).validate();
+      await d.appPackageConfigFile([
+        d.packageConfigEntry(name: 'foo', version: '2.0.0'),
+        d.packageConfigEntry(name: 'bar', version: '1.5.0'),
+      ]).validate();
+    });
+
+    test('can tighten a specific package', () async {
+      final server = await servePackages();
+
+      server.serve('foo', '1.0.0');
+      server.serve('bar', '1.0.0');
+
+      await d.appDir(
+        dependencies: {
+          'foo': '^1.0.0',
+          'bar': '^1.0.0',
+        },
+      ).create();
+
+      await pubGet();
+
+      server.serve('foo', '1.5.0');
+      server.serve('bar', '1.5.0');
+
+      await pubUpgrade(
+        args: ['--tighten', 'foo'],
+        output: allOf([
+          contains('Changed 1 constraint in pubspec.yaml:'),
+          contains('foo: ^1.0.0 -> ^1.5.0'),
+        ]),
+      );
+
+      await d.appDir(
+        dependencies: {
+          'foo': '^1.5.0',
+          'bar': '^1.0.0',
+        },
+      ).validate();
+      await d.appPackageConfigFile([
+        d.packageConfigEntry(name: 'foo', version: '1.5.0'),
+        d.packageConfigEntry(name: 'bar', version: '1.0.0'),
+      ]).validate();
+
+      server.serve('foo', '2.0.0');
+      server.serve('bar', '2.0.0');
+
+      await pubUpgrade(
+        args: ['--tighten', 'bar', '--major-versions'],
+        output: allOf([
+          contains('Changed 1 constraint in pubspec.yaml:'),
+          contains('bar: ^1.0.0 -> ^2.0.0'),
+        ]),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Used to programmatically tighten lower bounds on dependencies in pubspec.yaml

## Motivation

For a Dart project pubspec.yaml gives the version constraints of a project's dependencies. And pubspec.lock contains the current resolution of concrete versions to fulfill those constraints.
Currently the command dart pub upgrade can help the user upgrade the version of a dependency that a user is locked on in pubspec.lock within the current constraint from pubspec.yaml.
dart pub upgrade --major-versions can help upgrade the constraint to bump the constraint to a later version range. It will also upgrade the lower bound, but only of those packages that needed a breaking change.
When you are authoring a package for others to consume, it makes sense to have as wide constraints as possible to minimize version conflicts. To test compatibility with lower bounds one can use dart pub downgrade to get a resolution with as low versions as possible.
However, for some uses, for example when making an app, it makes little sense to keep the support for older versions of dependencies. Therefore we propose dart pub upgrade --tighten as a way to bump the constraints to match the versions actually resolved.
A feature like this has been requested by the community.

## Example

Here is an example transcript (slightly simplified for clarity):

```
$ cat pubspec.yaml
name: sample
environment:
  sdk: ^3.0.0
dependencies:
  dio: ^4.0.0

$ dart pub get
Resolving dependencies... 
  dio 4.0.1 (5.3.2 available) # Already locked to 4.0.1

$ dart pub upgrade --dry-run # Current upgrade only touches lock-file
> dio 4.0.6 (was 4.0.1) (5.3.2 available)
Would change 1 dependency.

$ dart pub upgrade --tighten --dry-run
> dio 4.0.6 (was 4.0.1) (5.3.2 available)
Would change 1 dependency.
Would change 1 constraint in pubspec.yaml:
  dio: ^4.0.1 -> ^4.0.6

$ dart pub upgrade --tighten --major-versions # Allows breaking version changes
+ async 2.11.0
> dio 5.3.2 (was 4.0.1)
+ meta 1.9.1
Changed 3 dependencies!

Changed 1 constraint in pubspec.yaml:
  dio: ^4.0.1 -> ^5.3.2

$ cat pubspec.yaml
name: sample
environment:
  sdk: ^3.0.0
dependencies:
  dio: ^5.3.2
```

## Details: 

### any constraints:

A hosted dependency that is currently constrained to any version (this is the default if no constraint is given) will be modified to be constrained to ^current. (That is, they will also get an upper bound).
A non-hosted dependency with no constraints will not be modified by --tighten.

### Dry run

When run with --dry-run a list of proposed changes will be written to the terminal.
Combined with --major-versions
dart pub --major-versions --tighten will result in the same resolutions as dart pub --major-versions, but all dependencies will have their constraint lower bound tightened, not only those that have their upper bound modified.

### Upgrading only selected packages:

The `upgrade --tighten` and `upgrade --tighten --major-versions` can be combined with one or more package-names. In that case only those packages are upgraded. (Just like the current `upgrade` and `upgrade --major-versions`.)

### Alternative names:

Several names have been considered
* `--atleast-locked`
* `--tight-lower-bounds`

## After this has landed, we need to:

TODO(sigurdm): roll to SDK
TODO(sigurdm): Documentation section on https://dart.dev/tools/pub/cmd/pub-upgrade
TODO(sigurdm): ensure the --tighten argument is passed through flutter pub upgrade (add argument to allowlist [here](https://github.com/flutter/flutter/blob/ca0596e41da32b51891a026756a5eae123861092/packages/flutter_tools/lib/src/commands/packages.dart#L216)).

Fixes: https://github.com/dart-lang/pub/issues/3924
