### PR TITLE
Enable lints to use new language features

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -22,6 +22,7 @@ linter:
     - avoid_unused_constructor_parameters
     - avoid_void_async
     - cancel_subscriptions
+    - dangling_library_doc_comments
     - directives_ordering
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
@@ -38,6 +39,9 @@ linter:
     - throw_in_finally
     - unawaited_futures
     - unnecessary_lambdas
+    - unnecessary_library_directive
     - unnecessary_null_aware_assignments
     - unnecessary_parenthesis
     - unnecessary_statements
+    - use_enums
+    - use_super_parameters

--- a/lib/src/ascii_tree.dart
+++ b/lib/src/ascii_tree.dart
@@ -4,6 +4,8 @@
 
 /// A simple library for rendering tree-like structures in Unicode symbols with
 /// a fallback to ASCII.
+library;
+
 import 'dart:io';
 
 import 'package:path/path.dart' as path;

--- a/lib/src/command/dependency_services.dart
+++ b/lib/src/command/dependency_services.dart
@@ -2,8 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-/// This implements support for dependency-bot style automated upgrades.
+/// Implements support for dependency-bot style automated upgrades.
 /// It is still work in progress - do not rely on the current output.
+library;
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A library for compiling Dart code and manipulating analyzer parse trees.
+library;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -30,7 +30,7 @@ class ApplicationException implements Exception {
 /// A subclass of [ApplicationException] that occurs when running a subprocess
 /// has failed.
 class RunProcessException extends ApplicationException {
-  RunProcessException(String message) : super(message);
+  RunProcessException(super.message);
 }
 
 /// An exception class for exceptions that are intended to be seen by the user
@@ -56,9 +56,8 @@ class WrappedException extends ApplicationException {
   /// The stack chain for [innerError] if it exists.
   final Chain? innerChain;
 
-  WrappedException(String message, this.innerError, [StackTrace? innerTrace])
-      : innerChain = innerTrace == null ? null : Chain.forTrace(innerTrace),
-        super(message);
+  WrappedException(super.message, this.innerError, [StackTrace? innerTrace])
+      : innerChain = innerTrace == null ? null : Chain.forTrace(innerTrace);
 }
 
 /// A class for exceptions that shouldn't be printed at the top level.
@@ -74,14 +73,14 @@ class SilentException extends WrappedException {
 ///
 /// This corresponds to the `data` exit code.
 class DataException extends ApplicationException {
-  DataException(String message) : super(message);
+  DataException(super.message);
 }
 
 /// An exception indicating that the users configuration is invalid.
 ///
 /// This corresponds to the `config` exit code;
 class ConfigException extends ApplicationException {
-  ConfigException(String message) : super(message);
+  ConfigException(super.message);
 }
 
 /// An class for exceptions where a package could not be found in a [Source].
@@ -108,8 +107,7 @@ class PackageNotFoundException extends WrappedException {
 
 /// A class for exceptions where a package's checksum could not be validated.
 class PackageIntegrityException extends PubHttpException {
-  PackageIntegrityException(String message)
-      : super(message, isIntermittent: true);
+  PackageIntegrityException(super.message) : super(isIntermittent: true);
 }
 
 /// Returns whether [error] is a user-facing error object.
@@ -141,11 +139,11 @@ class SourceSpanApplicationException extends SourceSpanFormatException
   final String? hint;
 
   SourceSpanApplicationException(
-    String message,
-    SourceSpan? span, {
+    super.message,
+    super.span, {
     this.hint,
     this.explanation,
-  }) : super(message, span);
+  });
 
   @override
   String toString({color}) {

--- a/lib/src/git.dart
+++ b/lib/src/git.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Helper functionality for invoking Git.
+library;
+
 import 'dart:async';
 
 import 'package:collection/collection.dart';

--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Helpers for dealing with HTTP.
+library;
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/lib/src/ignore.dart
+++ b/lib/src/ignore.dart
@@ -25,6 +25,8 @@
 /// [Ignore.listFiles].
 ///
 /// [1]: https://git-scm.com/docs/gitignore
+library;
+
 import 'package:meta/meta.dart';
 
 /// A set of ignore rules representing a single ignore file.

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Helper functionality to make working with IO easier.
+library;
+
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';

--- a/lib/src/isolate.dart
+++ b/lib/src/isolate.dart
@@ -3,11 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A library for utility functions for dealing with isolates.
+library;
+
 import 'dart:async';
 import 'dart:io';
 import 'dart:isolate';
 
-/// Like [Isolate.spanwUri], except that this only returns once the Isolate has
+/// Like [Isolate.spawnUri], except that this only returns once the Isolate has
 /// exited.
 ///
 /// If the isolate produces an unhandled exception, it's printed to stderr and

--- a/lib/src/log.dart
+++ b/lib/src/log.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Message logging.
+library;
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -60,36 +62,36 @@ final _bold = getAnsi('\u001b[1m');
 /// An enum type for defining the different logging levels a given message can
 /// be associated with.
 ///
-/// By default, [error] and [warning] messages are printed to sterr. [message]
-/// messages are printed to stdout, and others are ignored.
-class Level {
+/// By default, [error] and [warning] messages are printed to stderr.
+/// [message] messages are printed to stdout, and others are ignored.
+enum Level {
   /// An error occurred and an operation could not be completed.
   ///
   /// Usually shown to the user on stderr.
-  static const error = Level._('ERR ');
+  error('ERR '),
 
   /// Something unexpected happened, but the program was able to continue,
   /// though possibly in a degraded fashion.
-  static const warning = Level._('WARN');
+  warning('WARN'),
 
   /// A message intended specifically to be shown to the user.
-  static const message = Level._('MSG ');
+  message('MSG '),
 
   /// Some interaction with the external world occurred, such as a network
   /// operation, process spawning, or file IO.
-  static const io = Level._('IO  ');
+  io('IO  '),
 
   /// Incremental output during pub's version constraint solver.
-  static const solver = Level._('SLVR');
+  solver('SLVR'),
 
   /// Fine-grained and verbose additional information.
   ///
   /// Used to provide program state context for other logs (such as what pub
   /// was doing when an IO operation occurred) or just more detail for an
   /// operation.
-  static const fine = Level._('FINE');
+  fine('FINE');
 
-  const Level._(this.name);
+  const Level(this.name);
 
   final String name;
 
@@ -99,69 +101,79 @@ class Level {
 
 /// An enum type to control which log levels are displayed and how they are
 /// displayed.
-class Verbosity {
+enum Verbosity {
   /// Silence all logging.
-  static const none = Verbosity._('none', {
+  none('none', {
     Level.error: null,
     Level.warning: null,
     Level.message: null,
     Level.io: null,
     Level.solver: null,
     Level.fine: null,
-  });
+  }),
 
   /// Shows only errors.
-  static const error = Verbosity._('error', {
+  error('error', {
     Level.error: _logToStderr,
     Level.warning: null,
     Level.message: null,
     Level.io: null,
     Level.solver: null,
     Level.fine: null,
-  });
+  }),
 
   /// Shows only errors and warnings.
-  static const warning = Verbosity._('warning', {
+  warning('warning', {
     Level.error: _logToStderr,
     Level.warning: _logToStderr,
     Level.message: null,
     Level.io: null,
     Level.solver: null,
     Level.fine: null,
-  });
+  }),
 
   /// The default verbosity which shows errors, warnings, and messages.
-  static const normal = Verbosity._('normal', {
+  normal('normal', {
     Level.error: _logToStderr,
     Level.warning: _logToStderr,
     Level.message: _logToStdout,
     Level.io: null,
     Level.solver: null,
     Level.fine: null,
-  });
+  }),
 
   /// Shows errors, warnings, messages, and IO event logs.
-  static const io = Verbosity._('io', {
+  io('io', {
     Level.error: _logToStderrWithLabel,
     Level.warning: _logToStderrWithLabel,
     Level.message: _logToStdoutWithLabel,
     Level.io: _logToStderrWithLabel,
     Level.solver: null,
     Level.fine: null,
-  });
+  }),
 
   /// Shows errors, warnings, messages, and version solver logs.
-  static const solver = Verbosity._('solver', {
+  solver('solver', {
     Level.error: _logToStderr,
     Level.warning: _logToStderr,
     Level.message: _logToStdout,
     Level.io: null,
     Level.solver: _logToStdout,
     Level.fine: null,
-  });
+  }),
 
   /// Shows all logs.
-  static const all = Verbosity._('all', {
+  all('all', {
+    Level.error: _logToStderrWithLabel,
+    Level.warning: _logToStderrWithLabel,
+    Level.message: _logToStdoutWithLabel,
+    Level.io: _logToStderrWithLabel,
+    Level.solver: _logToStderrWithLabel,
+    Level.fine: _logToStderrWithLabel,
+  }),
+
+  /// Shows all logs.
+  testing('testing', {
     Level.error: _logToStderrWithLabel,
     Level.warning: _logToStderrWithLabel,
     Level.message: _logToStdoutWithLabel,
@@ -170,17 +182,7 @@ class Verbosity {
     Level.fine: _logToStderrWithLabel,
   });
 
-  /// Shows all logs.
-  static const testing = Verbosity._('testing', {
-    Level.error: _logToStderrWithLabel,
-    Level.warning: _logToStderrWithLabel,
-    Level.message: _logToStdoutWithLabel,
-    Level.io: _logToStderrWithLabel,
-    Level.solver: _logToStderrWithLabel,
-    Level.fine: _logToStderrWithLabel,
-  });
-
-  const Verbosity._(this.name, this._loggers);
+  const Verbosity(this.name, this._loggers);
 
   final String name;
   final Map<Level, void Function(_Entry entry)?> _loggers;
@@ -409,7 +411,7 @@ Platform: ${Platform.operatingSystem}
 
 /// Filter out normal pub output when not attached to a terminal
 ///
-/// Unless the user has overriden the verbosity,
+/// Unless the user has overridden the verbosity,
 ///
 /// This is useful to not pollute stdout when the output is piped somewhere.
 Future<T> errorsOnlyUnlessTerminal<T>(FutureOr<T> Function() callback) async {

--- a/lib/src/solver/assignment.dart
+++ b/lib/src/solver/assignment.dart
@@ -30,10 +30,10 @@ class Assignment extends Term {
   /// Creates a derivation: an assignment that's automatically propagated from
   /// incompatibilities.
   Assignment.derivation(
-    PackageRange package,
-    bool isPositive,
+    super.package,
+    super.isPositive,
     this.cause,
     this.decisionLevel,
     this.index,
-  ) : super(package, isPositive);
+  );
 }

--- a/lib/src/solver/set_relation.dart
+++ b/lib/src/solver/set_relation.dart
@@ -3,24 +3,24 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// An enum of possible relationships between two sets.
-class SetRelation {
+enum SetRelation {
   /// The second set contains all elements of the first, as well as possibly
   /// more.
-  static const subset = SetRelation._('subset');
+  subset('subset'),
 
   /// Neither set contains any elements of the other.
-  static const disjoint = SetRelation._('disjoint');
+  disjoint('disjoint'),
 
   /// The sets have elements in common, but the first is not a superset of the
   /// second.
   ///
   /// This is also used when the first set is a superset of the first, but in
   /// practice we don't need to distinguish that from overlapping sets.
-  static const overlapping = SetRelation._('overlapping');
+  overlapping('overlapping');
 
   final String _name;
 
-  const SetRelation._(this._name);
+  const SetRelation(this._name);
 
   @override
   String toString() => _name;

--- a/lib/src/solver/type.dart
+++ b/lib/src/solver/type.dart
@@ -3,22 +3,22 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// An enum for types of version resolution.
-class SolveType {
+enum SolveType {
   /// As few changes to the lockfile as possible to be consistent with the
   /// pubspec.
-  static const get = SolveType._('get');
+  get('get'),
 
   /// Upgrade all packages or specific packages to the highest versions
   /// possible, regardless of the lockfile.
-  static const upgrade = SolveType._('upgrade');
+  upgrade('upgrade'),
 
   /// Downgrade all packages or specific packages to the lowest versions
   /// possible, regardless of the lockfile.
-  static const downgrade = SolveType._('downgrade');
+  downgrade('downgrade');
 
   final String _name;
 
-  const SolveType._(this._name);
+  const SolveType(this._name);
 
   @override
   String toString() => _name;

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -812,8 +812,8 @@ class GitResolvedDescription extends ResolvedDescription {
   GitDescription get description => super.description as GitDescription;
 
   final String resolvedRef;
-  GitResolvedDescription(GitDescription description, this.resolvedRef)
-      : super(description);
+
+  GitResolvedDescription(GitDescription super.description, this.resolvedRef);
 
   @override
   String format() {

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -1447,9 +1447,9 @@ class ResolvedHostedDescription extends ResolvedDescription {
   final Uint8List? sha256;
 
   ResolvedHostedDescription(
-    HostedDescription description, {
+    HostedDescription super.description, {
     required this.sha256,
-  }) : super(description);
+  });
 
   @override
   Object? serializeForLockfile({required String? containingDir}) {

--- a/lib/src/source/path.dart
+++ b/lib/src/source/path.dart
@@ -258,7 +258,7 @@ class ResolvedPathDescription extends ResolvedDescription {
   @override
   PathDescription get description => super.description as PathDescription;
 
-  ResolvedPathDescription(PathDescription description) : super(description);
+  ResolvedPathDescription(PathDescription super.description);
 
   @override
   Object? serializeForLockfile({required String? containingDir}) {

--- a/lib/src/source/root.dart
+++ b/lib/src/source/root.dart
@@ -76,7 +76,7 @@ class RootSource extends Source {
 }
 
 class ResolvedRootDescription extends ResolvedDescription {
-  ResolvedRootDescription(RootDescription description) : super(description);
+  ResolvedRootDescription(RootDescription super.description);
 
   @override
   Object? serializeForLockfile({required String? containingDir}) {

--- a/lib/src/source/sdk.dart
+++ b/lib/src/source/sdk.dart
@@ -169,7 +169,7 @@ class ResolvedSdkDescription extends ResolvedDescription {
   @override
   SdkDescription get description => super.description as SdkDescription;
 
-  ResolvedSdkDescription(SdkDescription description) : super(description);
+  ResolvedSdkDescription(SdkDescription super.description);
 
   @override
   Object? serializeForLockfile({required String? containingDir}) {

--- a/lib/src/source/unknown.dart
+++ b/lib/src/source/unknown.dart
@@ -114,8 +114,7 @@ class UnknownDescription extends Description {
 }
 
 class ResolvedUnknownDescription extends ResolvedDescription {
-  ResolvedUnknownDescription(UnknownDescription description)
-      : super(description);
+  ResolvedUnknownDescription(UnknownDescription super.description);
 
   @override
   Object? serializeForLockfile({required String? containingDir}) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Generic utility functions. Stuff that should possibly be in core.
+library;
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// Pub-specific test descriptors.
+library;
+
 import 'dart:convert';
 
 import 'package:path/path.dart' as p;

--- a/test/descriptor/git.dart
+++ b/test/descriptor/git.dart
@@ -10,8 +10,7 @@ import 'package:test_descriptor/test_descriptor.dart';
 
 /// Describes a Git repository and its contents.
 class GitRepoDescriptor extends DirectoryDescriptor {
-  GitRepoDescriptor(String name, List<Descriptor> contents)
-      : super(name, contents);
+  GitRepoDescriptor(super.name, List<Descriptor> super.contents);
 
   /// Creates the Git repository and commits the contents.
   @override

--- a/test/descriptor/tar.dart
+++ b/test/descriptor/tar.dart
@@ -14,9 +14,9 @@ import 'package:test_descriptor/test_descriptor.dart';
 class TarFileDescriptor extends FileDescriptor {
   final List<Descriptor> contents;
 
-  TarFileDescriptor(String name, Iterable<Descriptor> contents)
+  TarFileDescriptor(super.name, Iterable<Descriptor> contents)
       : contents = contents.toList(),
-        super.protected(name);
+        super.protected();
 
   /// Creates the files and directories within this tar file, then archives
   /// them, compresses them, and saves the result to [parentDir].

--- a/test/descriptor/yaml.dart
+++ b/test/descriptor/yaml.dart
@@ -17,7 +17,7 @@ import '../descriptor.dart';
 class YamlDescriptor extends FileDescriptor {
   final String _contents;
 
-  YamlDescriptor(String name, this._contents) : super.protected(name);
+  YamlDescriptor(super.name, this._contents) : super.protected();
 
   @override
   Future<String> read() async => _contents;

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -7,6 +7,8 @@
 /// Unlike typical unit tests, most pub tests are integration tests that stage
 /// some stuff on the file system, run pub, and then validate the results. This
 /// library provides an API to build tests like that.
+library;
+
 import 'dart:convert';
 import 'dart:core';
 import 'dart:io' hide BytesBuilder;
@@ -598,16 +600,11 @@ class PubProcess extends TestProcess {
 
   /// This is protected.
   PubProcess(
-    Process process,
-    String description, {
-    Encoding encoding = utf8,
-    bool forwardStdio = false,
-  }) : super(
-          process,
-          description,
-          encoding: encoding,
-          forwardStdio: forwardStdio,
-        );
+    super.process,
+    super.description, {
+    super.encoding,
+    super.forwardStdio,
+  });
 
   final _logLineRegExp = RegExp(r'^([A-Z ]{4})[:|] (.*)$');
   final Map<String, log.Level> _logLevels = [

--- a/tool/extract_all_pub_dev.dart
+++ b/tool/extract_all_pub_dev.dart
@@ -5,6 +5,7 @@
 /// This is a manual test that can be run to test the .tar.gz decoding.
 /// It will save progress in [statusFileName] such that it doesn't have to be
 /// finished in a single run.
+library;
 
 import 'dart:async';
 import 'dart:convert';

--- a/tool/test-bin/pub_command_runner.dart
+++ b/tool/test-bin/pub_command_runner.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 /// A trivial embedding of the pub command. Used from tests.
+library;
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/tool/test.dart
+++ b/tool/test.dart
@@ -8,8 +8,10 @@
 /// invocation requires the dart compiler to load all the sources. This script
 /// will create a `pub.XXX.dart.snapshot.dart2` which the tests can utilize.
 /// After creating the snapshot this script will forward arguments to
-/// `pub run test`, and ensure that the snapshot is deleted after tests have been
-/// run.
+/// `pub run test`, and ensure that the snapshot is deleted after tests have
+/// been run.
+library;
+
 import 'dart:io';
 import 'package:path/path.dart' as path;
 


### PR DESCRIPTION
Simplifies code while bringing the repository closer to being able to switch to [`package:dart_flutter_team_lints`](https://github.com/dart-lang/ecosystem/tree/main/pkgs/dart_flutter_team_lints) for analysis.