### PR TITLE
Switch vendor to a dev dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,6 @@ dependencies:
   stack_trace: ^1.10.0
   typed_data: ^1.3.1
   usage: ^4.0.2
-  vendor: ^0.9.2
   yaml: ^3.1.0
   yaml_edit: ^2.0.0
 
@@ -36,4 +35,4 @@ dev_dependencies:
   test: ^1.21.5
   test_descriptor: ^2.0.0
   test_process: ^2.0.0
-
+  vendor: ^0.9.5


### PR DESCRIPTION
I didn't see a reason for this to be a normal dependency.
