### PR TITLE
Fix test expectation

### DIFF
--- a/test/version_solver_test.dart
+++ b/test/version_solver_test.dart
@@ -1445,12 +1445,10 @@ void sdkConstraint() {
 
       await expectResolves(
         environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')},
-        error: equalsIgnoringWhitespace('''
-            The current Dart SDK version is 3.1.2+3.
+        error: contains('''
+The current Dart SDK version is 3.1.2+3.
 
-            Because myapp requires SDK version >3.1.2+3, version solving
-            failed.
-          '''),
+Because myapp requires SDK version >3.1.2+3, version solving failed.'''),
       );
     });
 


### PR DESCRIPTION
The output changed after dart 3.2 came out.

Perhaps we should also fake the flutter version listings during testing...