### PR TITLE
Only create SourceFile for leak on demand

### DIFF
--- a/lib/src/validator/leak_detection.dart
+++ b/lib/src/validator/leak_detection.dart
@@ -171,7 +171,6 @@ final class LeakPattern {
   ///  * Captured group have a entropy higher than [_entropyThresholds] requires
   ///    for the given _group identifier_, and,
   Iterable<LeakMatch> findPossibleLeaks(String file, String content) sync* {
-    final source = SourceFile.fromString(content, url: file);
     for (final m in _pattern.allMatches(content)) {
       if (_allowed.any((s) => m.group(0)!.contains(s))) {
         continue;
@@ -180,7 +179,7 @@ final class LeakPattern {
           .any((entry) => _entropy(m.group(entry.key)!) < entry.value)) {
         continue;
       }
-
+      final source = SourceFile.fromString(content, url: file);
       yield LeakMatch(
         this,
         source.span(m.start, m.start + m.group(0)!.length),

--- a/test/validator/leak_detection_test.dart
+++ b/test/validator/leak_detection_test.dart
@@ -132,22 +132,18 @@ void main() {
       group('for "${pattern.kind}"', () {
         for (var i = 0; i < pattern.testsWithLeaks.length; i++) {
           test('finds leak in testWithLeaks[$i]', () {
-            final leaks = pattern.findPossibleLeaks(
-              'source.dart',
-              pattern.testsWithLeaks[i],
-              {},
-            ).toList(growable: false);
+            final leaks = pattern
+                .findPossibleLeaks('source.dart', pattern.testsWithLeaks[i])
+                .toList(growable: false);
             expect(leaks, hasLength(equals(1)));
           });
         }
 
         for (var i = 0; i < pattern.testsWithNoLeaks.length; i++) {
           test('finds no leak in testsWithNoLeaks[$i]', () {
-            final leaks = pattern.findPossibleLeaks(
-              'source.dart',
-              pattern.testsWithNoLeaks[i],
-              {},
-            ).toList(growable: false);
+            final leaks = pattern
+                .findPossibleLeaks('source.dart', pattern.testsWithNoLeaks[i])
+                .toList(growable: false);
             expect(leaks, isEmpty);
           });
         }

--- a/test/validator/leak_detection_test.dart
+++ b/test/validator/leak_detection_test.dart
@@ -132,18 +132,22 @@ void main() {
       group('for "${pattern.kind}"', () {
         for (var i = 0; i < pattern.testsWithLeaks.length; i++) {
           test('finds leak in testWithLeaks[$i]', () {
-            final leaks = pattern
-                .findPossibleLeaks('source.dart', pattern.testsWithLeaks[i])
-                .toList(growable: false);
+            final leaks = pattern.findPossibleLeaks(
+              'source.dart',
+              pattern.testsWithLeaks[i],
+              {},
+            ).toList(growable: false);
             expect(leaks, hasLength(equals(1)));
           });
         }
 
         for (var i = 0; i < pattern.testsWithNoLeaks.length; i++) {
           test('finds no leak in testsWithNoLeaks[$i]', () {
-            final leaks = pattern
-                .findPossibleLeaks('source.dart', pattern.testsWithNoLeaks[i])
-                .toList(growable: false);
+            final leaks = pattern.findPossibleLeaks(
+              'source.dart',
+              pattern.testsWithNoLeaks[i],
+              {},
+            ).toList(growable: false);
             expect(leaks, isEmpty);
           });
         }


### PR DESCRIPTION
Timing each `LeakPattern` and the creation of `SourceFile` separately in a repo with a single 150MB file of random bytes revealed this:

```
AWS Access Key: 190 ms
AWS Secret Key: 1434 ms
Google API Key: 143 ms
Google OAuth ID: 337 ms
Google OAuth Refresh Token: 244 ms
Google OAuth Access Token: 97 ms
Private Key: 169 ms
RSA Private Key: 156 ms
EC Private Key: 179 ms
PGP Private Key: 227 ms
creating source files: 45777 ms
```

With this change, leak detection for big files will look like:
````
Publishing _dummy_pkg 0.0.1-toobig to https://pub.dev:
├── CHANGELOG.md (<1 KB)
├── LICENSE (<1 KB)
├── README.md (<1 KB)
├── pubspec.yaml (<1 KB)
└── testfile (146 MB)
Validating package... (14.3s)
Package validation found the following errors:
* Potential leak of Private Key in testfile at offset 153600000:153600106.
  
  ```
  -----BEGIN PRIVATE KEY-----
  H0M6xpM2q+53wmsN/eYLdgtjgBd3DBmHtPilCkiFICXyaA8z9LkJ
  -----END PRIVATE KEY-----
  ```
  
  Add a git-ignore style pattern to `false_secrets` in `pubspec.yaml`
  to ignore this. See https://dart.dev/go/false-secrets
  ````
