### PR TITLE
Remove obsolete comment about test infrastructure

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,6 @@ environment:
   sdk: ^3.0.0
 
 dependencies:
-  # Note: Pub's test infrastructure assumes that any dependencies used in tests
-  # will be hosted dependencies.
   analyzer: ^6.2.0
   args: ^2.4.0
   async: ^2.6.1


### PR DESCRIPTION
Was added back in the days: https://codereview.chromium.org/1147233002 .

I'm not sure what it means, but I doubt it is relevant for us now.