### PR TITLE
Migrate pub to use package:unified_analytics

### DIFF
--- a/lib/src/pub_embeddable_command.dart
+++ b/lib/src/pub_embeddable_command.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:usage/usage.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import 'command.dart' show PubCommand, PubTopLevel;
 import 'command.dart';
@@ -27,17 +27,11 @@ import 'utils.dart';
 
 /// The information needed for the embedded pub command to send analytics.
 final class PubAnalytics {
-  /// Name of the custom dimension of the dependency kind.
-  final String dependencyKindCustomDimensionName;
-
   final Analytics? Function() _analyticsGetter;
 
   Analytics? get analytics => _analyticsGetter();
 
-  PubAnalytics(
-    this._analyticsGetter, {
-    required this.dependencyKindCustomDimensionName,
-  });
+  PubAnalytics(this._analyticsGetter);
 }
 
 /// Exposes the `pub` commands as a command to be embedded in another command

--- a/lib/src/solver/result.dart
+++ b/lib/src/solver/result.dart
@@ -4,6 +4,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:pub_semver/pub_semver.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import '../http.dart';
 import '../io.dart';
@@ -158,29 +159,17 @@ class SolveResult {
         DependencyType.direct: 'direct',
         DependencyType.none: 'transitive',
       }[_root.pubspec.dependencyType(package.name)]!;
-      analytics.sendEvent(
-        'pub-get',
-        package.name,
-        label: package.version.canonicalizedVersion,
-        value: 1,
-        parameters: {
-          'ni': '1', // We consider a pub-get a non-interactive event.
-          pubAnalytics.dependencyKindCustomDimensionName: dependencyKind,
-        },
+      analytics.send(
+        Event.pubGet(
+          packageName: package.name,
+          version: package.version.canonicalizedVersion,
+          dependencyType: dependencyKind,
+        ),
       );
       log.fine(
         'Sending analytics hit for "pub-get" of ${package.name} version ${package.version} as dependency-kind $dependencyKind',
       );
     }
-
-    analytics.sendTiming(
-      'resolution',
-      resolutionTime.inMilliseconds,
-      category: 'pub-get',
-    );
-    log.fine(
-      'Sending analytics timing "pub-get" took ${resolutionTime.inMilliseconds} milliseconds',
-    );
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   stack_trace: ^1.10.0
   tar: ^1.0.1
   typed_data: ^1.3.1
-  usage: ^4.0.2
+  unified_analytics: ^4.0.1
   yaml: ^3.1.0
   yaml_edit: ^2.0.0
 

--- a/tool/test-bin/pub_command_runner.dart
+++ b/tool/test-bin/pub_command_runner.dart
@@ -5,7 +5,6 @@
 /// A trivial embedding of the pub command. Used from tests.
 library;
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
@@ -15,9 +14,6 @@ import 'package:pub/src/command.dart';
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/log.dart' as log;
 import 'package:pub/src/utils.dart';
-import 'package:usage/usage.dart';
-
-final Analytics loggingAnalytics = _LoggingAnalytics();
 
 /// A command for explicitly throwing an exception, to test the handling of
 /// unexpected exceptions.
@@ -83,15 +79,8 @@ class Runner extends CommandRunner<int> {
   late ArgResults _results;
 
   Runner() : super('pub_command_runner', 'Tests the embeddable pub command.') {
-    final analytics = Platform.environment['_PUB_LOG_ANALYTICS'] == 'true'
-        ? PubAnalytics(
-            () => loggingAnalytics,
-            dependencyKindCustomDimensionName: 'cd1',
-          )
-        : null;
     addCommand(
       pubCommand(
-        analytics: analytics,
         isVerbose: () => _results.flag('verbose'),
       )
         ..addSubcommand(ThrowingCommand())
@@ -123,62 +112,4 @@ class Runner extends CommandRunner<int> {
 
 Future<void> main(List<String> arguments) async {
   exitCode = await Runner().run(arguments);
-}
-
-class _LoggingAnalytics extends AnalyticsMock {
-  _LoggingAnalytics() {
-    onSend.listen((event) {
-      stderr.writeln('[analytics]${json.encode(event)}');
-    });
-  }
-
-  @override
-  bool get firstRun => false;
-
-  @override
-  Future sendScreenView(String viewName, {Map<String, String>? parameters}) {
-    parameters ??= <String, String>{};
-    parameters['viewName'] = viewName;
-    return _log('screenView', parameters);
-  }
-
-  @override
-  Future sendEvent(
-    String category,
-    String action, {
-    String? label,
-    int? value,
-    Map<String, String>? parameters,
-  }) {
-    parameters ??= <String, String>{};
-    return _log(
-      'event',
-      {'category': category, 'action': action, 'label': label, 'value': value}
-        ..addAll(parameters),
-    );
-  }
-
-  @override
-  Future sendSocial(String network, String action, String target) =>
-      _log('social', {'network': network, 'action': action, 'target': target});
-
-  @override
-  Future sendTiming(
-    String variableName,
-    int time, {
-    String? category,
-    String? label,
-  }) {
-    return _log('timing', {
-      'variableName': variableName,
-      'time': time,
-      'category': category,
-      'label': label,
-    });
-  }
-
-  Future<void> _log(String hitType, Map message) async {
-    final encoded = json.encode({'hitType': hitType, 'message': message});
-    stderr.writeln('[analytics]: $encoded');
-  }
 }


### PR DESCRIPTION
This is some prerequisite work for migrating package:dartdev to use package:unified_analytics.

I've removed the single analytics test here in favour of the dart pub get analytics test in dartdev for simplicity, as package:unified_analytics adds a FakeAnalytics class that tracks analytics events for easy validation in tests without needing to manually serialize all the analytics events. It's not possible to serialize / deserialize FakeAnalytics so the results can't be verified from a separate process at this point, so this testing is easier to do in dartdev. If you'd prefer we keep this testing here, please let me know if you have ideas on how to move forward 😊