### PR TITLE
Update to package:lints v3 and fix a few more lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -24,6 +24,8 @@ linter:
     - avoid_unused_constructor_parameters
     - avoid_void_async
     - cancel_subscriptions
+    - conditional_uri_does_not_exist
+    - combinators_ordering
     - dangling_library_doc_comments
     - directives_ordering
     - library_annotations
@@ -45,8 +47,8 @@ linter:
     - unawaited_futures
     - unnecessary_lambdas
     - unnecessary_library_directive
-    - unnecessary_null_aware_assignments
     - unnecessary_parenthesis
     - unnecessary_statements
+    - unreachable_from_main
     - use_enums
-    - use_super_parameters
+    - use_is_even_rather_than_modulo

--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -11,10 +11,10 @@ import 'src/system_cache.dart';
 
 export 'src/executable.dart'
     show
-        getExecutableForCommand,
         CommandResolutionFailedException,
         CommandResolutionIssue,
-        DartExecutableWithPackageConfig;
+        DartExecutableWithPackageConfig,
+        getExecutableForCommand;
 export 'src/pub_embeddable_command.dart' show PubAnalytics;
 
 /// Returns a [Command] for pub functionality that can be used by an embedding

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   yaml_edit: ^2.0.0
 
 dev_dependencies:
-  lints: ^2.0.0
+  lints: ^3.0.0
   shelf_test_handler: ^2.0.0
   test: ^1.21.5
   test_descriptor: ^2.0.0

--- a/test/ascii_tree_test.dart
+++ b/test/ascii_tree_test.dart
@@ -11,11 +11,6 @@ import 'descriptor.dart';
 import 'golden_file.dart';
 import 'test_pub.dart';
 
-/// Removes ansi color codes from [s].
-String stripColors(String s) {
-  return s.replaceAll(RegExp('\u001b\\[.*?m'), '');
-}
-
 void main() {
   setUp(() {
     forceColors = ForceColorOption.always;

--- a/test/golden_file.dart
+++ b/test/golden_file.dart
@@ -11,7 +11,6 @@ import 'package:pub/src/io.dart';
 import 'package:stack_trace/stack_trace.dart' show Trace;
 import 'package:test/test.dart';
 
-import 'ascii_tree_test.dart';
 import 'descriptor.dart' as d;
 import 'test_pub.dart';
 
@@ -194,7 +193,7 @@ class GoldenTestContext {
       baseDir: target,
       showFileSizes: false,
     );
-    s.writeln(colors ? tree : stripColors(tree));
+    s.writeln(colors ? tree : _stripColors(tree));
 
     _expectSection(sectionIndex, s.toString());
   }
@@ -231,4 +230,9 @@ void testWithGolden(
     await fn(ctx);
     ctx._writeGoldenFile();
   });
+}
+
+/// Removes ansi color codes from [s].
+String _stripColors(String s) {
+  return s.replaceAll(RegExp('\u001b\\[.*?m'), '');
 }

--- a/test/testdata/goldens/embedding/embedding_test/--help.txt
+++ b/test/testdata/goldens/embedding/embedding_test/--help.txt
@@ -17,7 +17,6 @@ Available subcommands:
   cache   Work with the system cache.
   deps   Print package dependencies.
   downgrade   Downgrade the current package's dependencies to oldest versions.
-  fail   Throws an exception
   get   Get the current package's dependencies.
   global   Work with global packages.
   login   Log into pub.dev.

--- a/test/testdata/goldens/embedding/embedding_test/--help.txt
+++ b/test/testdata/goldens/embedding/embedding_test/--help.txt
@@ -17,6 +17,7 @@ Available subcommands:
   cache   Work with the system cache.
   deps   Print package dependencies.
   downgrade   Downgrade the current package's dependencies to oldest versions.
+  fail   Throws an exception.
   get   Get the current package's dependencies.
   global   Work with global packages.
   login   Log into pub.dev.

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -299,7 +299,7 @@ $ tool/test-bin/pub_command_runner.dart pub fail
 [E] package:pub/src/command.dart $LINE:$COL   PubCommand.run
 [E] package:args/command_runner.dart $LINE:$COL   CommandRunner.runCommand
 [E]  tool/test-bin/pub_command_runner.dart $LINE:$COL  Runner.runCommand
-[E]  tool/test-bin/pub_command_runner.dart $LINE:$COL  Runner.run
+[E]  tool/test-bin/pub_command_runner.dart $LINE:$COL   Runner.run
 [E]  tool/test-bin/pub_command_runner.dart $LINE:$COL  main
 [E] This is an unexpected error. The full log and other details are collected in:
 [E] 
@@ -344,7 +344,7 @@ ERR : tool/test-bin/pub_command_runner.dart $LINE:$COL   ThrowingCommand.runProt
    | package:pub/src/command.dart $LINE:$COL   PubCommand.run
    | package:args/command_runner.dart $LINE:$COL   CommandRunner.runCommand
    | tool/test-bin/pub_command_runner.dart $LINE:$COL  Runner.runCommand
-   | tool/test-bin/pub_command_runner.dart $LINE:$COL  Runner.run
+   | tool/test-bin/pub_command_runner.dart $LINE:$COL   Runner.run
    | tool/test-bin/pub_command_runner.dart $LINE:$COL  main
 ERR : This is an unexpected error. The full log and other details are collected in:
    | 

--- a/test/validator/file_case_test.dart
+++ b/test/validator/file_case_test.dart
@@ -24,8 +24,6 @@ Future<void> expectValidation(Matcher error, int exitCode) async {
   );
 }
 
-late d.DirectoryDescriptor fakeFlutterRoot;
-
 void main() {
   test('Recognizes files that only differ in capitalization.', () async {
     await d.validPackage().create();

--- a/tool/test-bin/pub_command_runner.dart
+++ b/tool/test-bin/pub_command_runner.dart
@@ -28,7 +28,8 @@ class ThrowingCommand extends PubCommand {
   @override
   String get description => 'Throws an exception';
 
-  bool get hide => true;
+  @override
+  bool get hidden => true;
 
   @override
   Future<int> runProtected() async {

--- a/tool/test-bin/pub_command_runner.dart
+++ b/tool/test-bin/pub_command_runner.dart
@@ -22,10 +22,7 @@ class ThrowingCommand extends PubCommand {
   String get name => 'fail';
 
   @override
-  String get description => 'Throws an exception';
-
-  @override
-  bool get hidden => true;
+  String get description => 'Throws an exception.';
 
   @override
   Future<int> runProtected() async {


### PR DESCRIPTION
- Updates to `package:lints` v3
- Removes now duplicated lints
- Adds and fixes a few more lints from `package:dart_flutter_team_lints` working towards the switch.