### PR TITLE
Fix calculation version number without build part

### DIFF
--- a/lib/src/validator/relative_version_numbering.dart
+++ b/lib/src/validator/relative_version_numbering.dart
@@ -107,6 +107,10 @@ Consider one of:
 }
 
 extension on Version {
-  Version withoutBuild() =>
-      Version(major, minor, patch, pre: preRelease.join('.'));
+  Version withoutBuild() => Version(
+        major,
+        minor,
+        patch,
+        pre: preRelease.isEmpty ? null : preRelease.join('.'),
+      );
 }

--- a/test/validator/relative_version_numbering_test.dart
+++ b/test/validator/relative_version_numbering_test.dart
@@ -143,6 +143,16 @@ The latest published version is 2.0.2.
     await expectValidation();
   });
 
+  test('Releasing a build-release causes no hint', () async {
+    final server = await servePackages();
+    server.serve(
+      'test_pkg',
+      '1.0.0',
+    );
+    await d.validPackage(version: '1.0.0+0').create();
+    await expectValidation();
+  });
+
   group('should consider a package valid if it', () {
     test('is opting in to null-safety with previous null-safe version',
         () async {


### PR DESCRIPTION
Fixes: https://github.com/dart-lang/pub/issues/4051
When there was no prerelease component, we would produce an empty-string prerelease component instead of null.
