### PR TITLE
have the analyze portion of publishing validation only analyze bin/ and lib/

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -23,7 +23,6 @@ linter:
     - avoid_unused_constructor_parameters
     - avoid_void_async
     - cancel_subscriptions
-    - dangling_library_doc_comments
     - directives_ordering
     - library_annotations
     - missing_whitespace_between_adjacent_strings
@@ -44,8 +43,6 @@ linter:
     - unawaited_futures
     - unnecessary_lambdas
     - unnecessary_library_directive
-    - unnecessary_null_aware_assignments
     - unnecessary_parenthesis
     - unnecessary_statements
     - use_enums
-    - use_super_parameters

--- a/lib/src/validator/analyze.dart
+++ b/lib/src/validator/analyze.dart
@@ -14,15 +14,17 @@ import '../validator.dart';
 
 /// Runs `dart analyze` and gives a warning if it returns non-zero.
 class AnalyzeValidator extends Validator {
-  /// Only analyze dart code in the following sub-folders.
+  // Only analyze dart code in the following sub-folders.
+  static const List<String> _dirsToAnalyze = ['bin', 'lib'];
+
   @override
   Future<void> validate() async {
-    final dirsToAnalyze = ['lib', 'test', 'bin']
+    final dirs = _dirsToAnalyze
         .map((dir) => p.join(entrypoint.rootDir, dir))
         .where(dirExists);
     final result = await runProcess(
       Platform.resolvedExecutable,
-      ['analyze', ...dirsToAnalyze, p.join(entrypoint.rootDir, 'pubspec.yaml')],
+      ['analyze', ...dirs, p.join(entrypoint.rootDir, 'pubspec.yaml')],
     );
     if (result.exitCode != 0) {
       final limitedOutput = limitLength(result.stdout.join('\n'), 1000);

--- a/lib/src/validator/compiled_dartdoc.dart
+++ b/lib/src/validator/compiled_dartdoc.dart
@@ -9,8 +9,7 @@ import 'package:path/path.dart' as path;
 import '../io.dart';
 import '../validator.dart';
 
-/// Validates that a package doesn't contain compiled Dartdoc
-/// output.
+/// Validates that a package doesn't contain compiled Dartdoc output.
 class CompiledDartdocValidator extends Validator {
   @override
   Future validate() {


### PR DESCRIPTION
- have the analyze portion of publishing validation only analyze `bin/` and `lib/`
- separately, remove lints that are duplicative of package:lints/recommended.yaml

Having the validation step analyze code can be pretty problematic with publishing automation. This preserves the validation static analysis, but scopes it to the portion of a package that's consumed by clients - lib/ and bin/ (removing test/).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
