### PR TITLE
Refactor change-detection for --enforce-lockfile

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -1028,7 +1028,6 @@ See https://dart.dev/go/sdk-constraint
   ///  * for each package
   ///    * same version number
   ///    * same resolved description (same content-hash, git hash, path)
-  ///    * same dependency-type (dependency, dev-dependency)
   bool _lockfilesMatch(LockFile previousLockFile, LockFile newLockFile) {
     if (previousLockFile.packages.length != newLockFile.packages.length) {
       return false;

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -392,8 +392,8 @@ Try running `$topLevelProgram pub get` to create `$lockFilePath`.''');
       quiet: summaryOnly,
     );
 
-    final hasChanges = await report.show(summary: true);
-    if (enforceLockfile && hasChanges) {
+    await report.show(summary: true);
+    if (enforceLockfile && !_lockfilesMatch(lockFile, newLockFile)) {
       dataError('''
 Unable to satisfy `$pubspecPath` using `$lockFilePath`$suffix.
 
@@ -1021,4 +1021,24 @@ See https://dart.dev/go/sdk-constraint
   /// results.
   bool get _summaryOnlyEnvironment =>
       (Platform.environment['PUB_SUMMARY_ONLY'] ?? '0') != '0';
+
+  /// Returns true if the packages in [newLockFile] and [previousLockFile] are
+  /// all the same, meaning:
+  ///  * same set of package-names
+  ///  * for each package
+  ///    * same version number
+  ///    * same resolved description (same content-hash, git hash, path)
+  ///    * same dependency-type (dependency, dev-dependency)
+  bool _lockfilesMatch(LockFile previousLockFile, LockFile newLockFile) {
+    if (previousLockFile.packages.length != newLockFile.packages.length) {
+      return false;
+    }
+    for (final package in newLockFile.packages.values) {
+      final oldPackage = previousLockFile.packages[package.name];
+      if (oldPackage == null) return false; // Package added to resolution.
+      if (oldPackage.version != package.version) return false;
+      if (oldPackage.description != package.description) return false;
+    }
+    return true;
+  }
 }

--- a/lib/src/solver/report.dart
+++ b/lib/src/solver/report.dart
@@ -69,14 +69,11 @@ class SolveReport {
   ///
   /// If [summary] is `true` a count of changes and number of
   /// discontinued/retracted packages will be shown at the end of the report.
-  ///
-  /// Returns `true` if there was any change of dependencies relative to the old
-  /// lockfile.
-  Future<bool> show({required bool summary}) async {
+
+  Future<void> show({required bool summary}) async {
     final changes = await _reportChanges();
     _checkContentHashesMatchOldLockfile();
     if (summary) await summarize(changes);
-    return changes != 0;
   }
 
   void _checkContentHashesMatchOldLockfile() {
@@ -494,7 +491,7 @@ $contentHashesDocumentationUrl
         dependencyTypeChanged ||
         message != null ||
         isOverridden)) {
-      return changed || addedOrRemoved;
+      return changed || addedOrRemoved || dependencyTypeChanged;
     }
 
     output.write(icon);


### PR DESCRIPTION
Should make it more obvious that `--enforce-lockfile` does the right thing.

(Notable there was a discrepancy such that in some cases changing a dependency to a dev-dependency would count as a change, and sometimes not. Now it is not considered a change.)

Fixes: https://github.com/dart-lang/pub/issues/4075