### PR TITLE
Analyze `build.dart` and `link.dart`

### DIFF
--- a/lib/src/validator/analyze.dart
+++ b/lib/src/validator/analyze.dart
@@ -14,17 +14,22 @@ import '../validator.dart';
 
 /// Runs `dart analyze` and gives a warning if it returns non-zero.
 class AnalyzeValidator extends Validator {
-  // Only analyze dart code in the following sub-folders.
-  static const List<String> _dirsToAnalyze = ['lib', 'bin'];
+  // Only analyze dart code in the following sub-folders and files.
+  static const List<String> _entriesToAnalyze = [
+    'bin',
+    'lib',
+    'build.dart',
+    'link.dart',
+  ];
 
   @override
   Future<void> validate() async {
-    final dirs = _dirsToAnalyze
+    final entries = _entriesToAnalyze
         .map((dir) => p.join(entrypoint.rootDir, dir))
-        .where(dirExists);
+        .where(entryExists);
     final result = await runProcess(
       Platform.resolvedExecutable,
-      ['analyze', ...dirs, p.join(entrypoint.rootDir, 'pubspec.yaml')],
+      ['analyze', ...entries, p.join(entrypoint.rootDir, 'pubspec.yaml')],
     );
     if (result.exitCode != 0) {
       final limitedOutput = limitLength(result.stdout.join('\n'), 1000);

--- a/test/validator/analyze_test.dart
+++ b/test/validator/analyze_test.dart
@@ -119,6 +119,8 @@ void main() {
       d.file('LICENSE', 'Eh, do what you want.'),
       d.file('README.md', "This package isn't real."),
       d.file('CHANGELOG.md', '# 1.0.0\nFirst version\n'),
+      d.file('build.dart', 'void main(){}'),
+      d.file('link.dart', 'void main(){}'),
       d.dir('lib', [d.file('test_pkg.dart', 'int i = 1;')]),
       d.dir('bin', [
         d.file('test_pkg.dart', '''
@@ -131,7 +133,7 @@ void main() {
     await expectValidation(
       error: allOf([
         contains('`dart analyze` found the following issue(s):'),
-        contains('Analyzing bin, lib, pubspec.yaml...'),
+        contains('Analyzing bin, lib, build.dart, link.dart, pubspec.yaml...'),
         contains('error -'),
         contains("Expected to find '}'."),
         contains('Package has 1 warning.'),

--- a/test/validator/analyze_test.dart
+++ b/test/validator/analyze_test.dart
@@ -131,7 +131,7 @@ void main() {
     await expectValidation(
       error: allOf([
         contains('`dart analyze` found the following issue(s):'),
-        contains('Analyzing lib, bin, pubspec.yaml...'),
+        contains('Analyzing bin, lib, pubspec.yaml...'),
         contains('error -'),
         contains("Expected to find '}'."),
         contains('Package has 1 warning.'),


### PR DESCRIPTION
`build.dart` (and later `link.dart`) are used by dependencies, so they are part of the set of files of a package which dependencies use (besides just `lib/` and `bin/`).

For more info about `build.dart` and `link.dart` see https://github.com/dart-lang/native.

Follow up of: https://github.com/dart-lang/pub/pull/4068

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
