### PR TITLE
Avoid retrying queries after closing client

### DIFF
--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -440,4 +440,7 @@ extension RequestSending on http.Client {
 /// Thrown by [_PubHttpClient.send] if the client was closed while the request
 /// was being processed. Notably it doesn't implement [http.ClientException],
 /// and thus does not trigger a retry by [retryForHttp].
-class _ClientClosedException implements Exception {}
+class _ClientClosedException implements Exception {
+  @override
+  String toString() => 'Request was made after http client was closed';
+}


### PR DESCRIPTION
Fix of https://github.com/dart-lang/pub/issues/4094

Keeps track of whether we have closed the global http-client (indicating processing is done, and we are ready to exit the program, and avoid doing retries at that point), in that case avoid doing restarts.

Would be more elegant to have this as a method on the client itself - avoiding a reference to the global client, but many times we wrap the global client in an Oauth2 client.

Would be more elegant if we could distinguish the ClientException we get when a request times out, from the one we get when the client is closed. (And not rely on parsing the message string).

Hard to write a good test for, but manual testing has shown that the hanging problem goes away with this fix.

### The problem:
When doing http requests with retries we retry on all `http.ClientExceptions`. Since https://github.com/dart-lang/pub/issues/3317. This is necessary because a client can time out (eg after a long upload), resulting in a ClientException.

Problem is that we do speculative requesting of version-listings, but if the solver can detect a solve failure early, it will be reported, pub will close the shared http client.

Closing the client causes any ongoing speculative requests to fail immediately - with a `ClientException` - and thus retried 7 times, each time failing with another `ClientException` because the client is closed.

These retries prevent the dartdev process from exiting.

I have only been able to reproduce reliable on mac-os (tried also on linux). Using a pubspec with an unresolvable constraint. My guess is that on linux the ClientExceptions are thrown faster or something...

```
# pubspec.yaml
name: a
environment:
  sdk: ^3.0.0
  
homepage: 'http://abc.def'

dev_dependencies:
  test: ^0.2.0
```

```
> dart --version
Dart SDK version: 3.2.3 (stable) (Tue Dec 5 17:58:33 2023 +0000) on "macos_arm64"
> dart pub get 
Resolving dependencies... 
Because a depends on test ^0.2.0 which doesn't match any versions, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Try upgrading your constraint on test: dart pub add dev:test:^1.25.0
[....hanging for 10 seconds...]
>
```

