### PR TITLE
Don't touch package_config.json when not needed

### DIFF
--- a/test/embedding/ensure_pubspec_resolved.dart
+++ b/test/embedding/ensure_pubspec_resolved.dart
@@ -433,6 +433,34 @@ void testEnsurePubspecResolved() {
         await _noImplicitPubGet();
       });
 
+      test('has a path dependency, and nothing changed', () async {
+        await d.dir('foo', [
+          d.libPubspec(
+            'foo',
+            '1.0.0',
+          ),
+        ]).create();
+
+        await d.dir(appPath, [
+          d.appPubspec(
+            dependencies: {
+              'foo': {'path': '../foo'},
+            },
+          ),
+        ]).create();
+
+        await pubGet();
+        // package_config.json should not be touched as nothing changed.
+        final packageConfig = File(
+          p.join(d.sandbox, appPath, '.dart_tool', 'package_config.json'),
+        );
+        final beforeStamp = packageConfig.statSync().modified;
+
+        await _noImplicitPubGet();
+
+        expect(packageConfig.statSync().modified, beforeStamp);
+      });
+
       test(
           "the lockfile is newer than package_config.json, but it's up-to-date",
           () async {


### PR DESCRIPTION
We revalidate the contents of pubspec.lock and package_config when either:

* "Modified" timestamps are out of order (eg. pubspec.yaml is newer than pubspec.lock)
* We have path-dependencies

In both of these cases we currently touch the files if the contents is valid, to make the "modified" timestamps in the right order. This is unnecessary in the second case - because they are already ordered correctly, and it trips up other processes relying on the "modified" timestamps or listens for changes.

Fixes https://github.com/dart-lang/pub/issues/3016