### PR TITLE
Fix path-matching expression

### DIFF
--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -219,7 +219,7 @@ abstract class Validator {
     return files
         .where(
           recursive
-              ? (file) => p.canonicalize(file).startsWith('base${p.separator}')
+              ? (file) => p.isWithin(base, p.canonicalize(file))
               : (file) => p.canonicalize(p.dirname(file)) == base,
         )
         .toList();

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -219,7 +219,7 @@ abstract class Validator {
     return files
         .where(
           recursive
-              ? (file) => p.canonicalize(file).startsWith(base)
+              ? (file) => p.canonicalize(file).startsWith('base${p.separator}')
               : (file) => p.canonicalize(p.dirname(file)) == base,
         )
         .toList();

--- a/test/validator/strict_dependencies_test.dart
+++ b/test/validator/strict_dependencies_test.dart
@@ -55,6 +55,25 @@ void main() {
       await expectValidationDeprecated(strictDeps);
     });
 
+// Regression test of https://github.com/dart-lang/pub/issues/4115 .
+    test('imports a dev_dependency in bindings_generator/', () async {
+      await d.dir(appPath, [
+        d.libPubspec(
+          'test_pkg',
+          '1.0.0',
+          devDeps: {'silly_monkey': '^1.2.3'},
+          sdk: '>=1.8.0 <2.0.0',
+        ),
+        d.dir('bindings_generator', [
+          d.file('library.dart', r'''
+            export 'package:silly_monkey/silly_monkey.dart';
+          '''),
+        ]),
+      ]).create();
+
+      await expectValidationDeprecated(strictDeps);
+    });
+
     test('declares an "import" as a dependency in bin/', () async {
       await d.dir(appPath, [
         d.libPubspec(


### PR DESCRIPTION
Fix of https://github.com/dart-lang/pub/issues/4115

We checked if the normalized path (without the final path seperator) was a prefix of the file path

Therefore we were told that `bindings_generator/abc.dart` is inside `bin/`.
