### PR TITLE
Remove unnecessary imports of 'package:collection' `IterableExtension`

### DIFF
--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml_edit/yaml_edit.dart';
@@ -203,7 +202,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
         : [
             for (final name in _packagesToUpgrade)
               pubspec.dependencies[name] ?? pubspec.devDependencies[name],
-          ].whereNotNull();
+          ].nonNulls;
     for (final range in toTighten) {
       final constraint = (result[range] ?? range).constraint;
       final resolvedVersion =

--- a/lib/src/solver/failure.dart
+++ b/lib/src/solver/failure.dart
@@ -110,7 +110,7 @@ class _Writer {
     // installed, if an SDK is incompatible with a dependency.
     final notices = _root.externalIncompatibilities
         .map((c) => c.cause.notice)
-        .whereNotNull()
+        .nonNulls
         .toSet() // Avoid duplicates
         .sortedBy((n) => n); // sort for consistency
     for (final n in notices) {
@@ -156,7 +156,7 @@ class _Writer {
     // understand how to fix the issue.
     _root.externalIncompatibilities
         .map((c) => c.cause.hint)
-        .whereNotNull()
+        .nonNulls
         .toSet() // avoid duplicates
         .sortedBy((hint) => hint) // sort hints for consistent ordering.
         .forEach((hint) {

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:collection/collection.dart' show IterableNullableExtension;
 import 'package:path/path.dart' as p;
 import 'package:pool/pool.dart';
 import 'package:pub_semver/pub_semver.dart';
@@ -444,7 +443,7 @@ class GitSource extends CachedSource {
             }
           });
         })
-        .whereNotNull()
+        .nonNulls
         .toList();
 
     // Note that there may be multiple packages with the same name and version

--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -8,8 +8,7 @@ import 'dart:io' as io;
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:collection/collection.dart'
-    show IterableExtension, IterableNullableExtension, maxBy;
+import 'package:collection/collection.dart' show IterableExtension, maxBy;
 import 'package:crypto/crypto.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
@@ -1349,7 +1348,7 @@ class HostedSource extends CachedSource {
             return null;
           }
         })
-        .whereNotNull()
+        .nonNulls
         .toList();
   }
 

--- a/lib/src/system_cache.dart
+++ b/lib/src/system_cache.dart
@@ -4,7 +4,6 @@
 
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 
@@ -206,7 +205,7 @@ Consider setting the `PUB_CACHE` variable manually.
         return null;
       }),
     ))
-        .whereNotNull()
+        .nonNulls
         .toList();
 
     return versions;


### PR DESCRIPTION
* Replace `.whereNotNull()` with `.nonNulls` which is now in Dart core.
* `.firstOrNull`, `.lastOrNull`, `.singleOrNull` and `.elementAtOrNull(i)` are also in Dart core and even under the same name, so simply drop the import of 'package:collection' whenever possible.

Not updating the changelog because there's 0 visible change to users.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
