### PR TITLE
Support for workspace syntax in pubspec.yaml

### DIFF
--- a/lib/src/language_version.dart
+++ b/lib/src/language_version.dart
@@ -70,6 +70,8 @@ class LanguageVersion implements Comparable<LanguageVersion> {
 
   bool get supportsNullSafety => this >= firstVersionWithNullSafety;
 
+  bool get supportsWorkspaces => this >= firstVersionWithWorkspaces;
+
   /// Minimum language version at which short hosted syntax is supported.
   ///
   /// This allows `hosted` dependencies to be expressed as:
@@ -106,6 +108,8 @@ class LanguageVersion implements Comparable<LanguageVersion> {
   static const defaultLanguageVersion = LanguageVersion(2, 7);
   static const firstVersionWithNullSafety = LanguageVersion(2, 12);
   static const firstVersionWithShorterHostedSyntax = LanguageVersion(2, 15);
+  // TODO(https://github.com/dart-lang/pub/issues/4127) update when we know actual version.
+  static const firstVersionWithWorkspaces = LanguageVersion(3, 7);
 
   /// Transform language version to string that can be parsed with
   /// [LanguageVersion.parse].

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -15,7 +15,6 @@ import 'package_name.dart';
 import 'pubspec_parse.dart';
 import 'sdk.dart';
 import 'system_cache.dart';
-import 'utils.dart';
 
 export 'pubspec_parse.dart' hide PubspecBase;
 
@@ -67,10 +66,16 @@ class Pubspec extends PubspecBase {
 
   /// Directories of packages that should resolve together with this package.
   late List<String> workspace = () {
-    if (!enableWorkspaces) return <String>[];
     final result = <String>[];
     final r = fields.nodes['workspace'];
+    if (r != null && !languageVersion.supportsWorkspaces) {
+      _error(
+        '`workspace` and `resolution` requires at least language version ${LanguageVersion.firstVersionWithWorkspaces}',
+        r.span,
+      );
+    }
     if (r == null || r.value == null) return <String>[];
+
     if (r is! YamlList) {
       _error('"workspace" must be a list of strings', r.span);
     }
@@ -86,8 +91,13 @@ class Pubspec extends PubspecBase {
 
   /// The resolution mode.
   late Resolution resolution = () {
-    if (!enableWorkspaces) return Resolution.none;
     final r = fields.nodes['resolution'];
+    if (r != null && !languageVersion.supportsWorkspaces) {
+      _error(
+        '`workspace` and `resolution` requires at least language version ${LanguageVersion.firstVersionWithWorkspaces}',
+        r.span,
+      );
+    }
     return switch (r?.value) {
       null => Resolution.none,
       'local' => Resolution.local,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -21,6 +21,11 @@ import 'exceptions.dart';
 import 'io.dart';
 import 'log.dart' as log;
 
+// TODO(https://github.com/dart-lang/pub/issues/4127) remove when workspace
+// feature is done.
+bool get enableWorkspaces =>
+    Zone.current[#enableWorkspaces] == true || runningFromTest;
+
 /// A regular expression matching a Dart identifier.
 ///
 /// This also matches a package name, since they must be Dart identifiers.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -21,11 +21,6 @@ import 'exceptions.dart';
 import 'io.dart';
 import 'log.dart' as log;
 
-// TODO(https://github.com/dart-lang/pub/issues/4127) remove when workspace
-// feature is done.
-bool get enableWorkspaces =>
-    Zone.current[#enableWorkspaces] == true || runningFromTest;
-
 /// A regular expression matching a Dart identifier.
 ///
 /// This also matches a package name, since they must be Dart identifiers.

--- a/lib/src/validator/pubspec_typo.dart
+++ b/lib/src/validator/pubspec_typo.dart
@@ -72,4 +72,6 @@ const _validPubspecKeys = [
   'funding',
   'topics',
   'ignored_advisories',
+  'workspace',
+  'resolution',
 ];

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:pub/src/exceptions.dart';
@@ -309,6 +310,42 @@ dependencies:
       expectPubspecException(
         'version: not version',
         (pubspec) => pubspec.version,
+      );
+    });
+
+    test('throws if workspace is not a list', () {
+      runZoned(
+        () {
+          expectPubspecException(
+            'workspace: \'a string\'',
+            (pubspec) => pubspec.workspace,
+          );
+        },
+        zoneValues: {#enableWorkspaces: true},
+      );
+    });
+
+    test('throws if workspace is a list of not-strings', () {
+      runZoned(
+        () {
+          expectPubspecException(
+            'workspace: [\'a string\', 24]',
+            (pubspec) => pubspec.workspace,
+          );
+        },
+        zoneValues: {#enableWorkspaces: true},
+      );
+    });
+
+    test('throws if resolution is not a reasonable string', () {
+      runZoned(
+        () {
+          expectPubspecException(
+            'resolution: "sometimes"',
+            (pubspec) => pubspec.resolution,
+          );
+        },
+        zoneValues: {#enableWorkspaces: true},
       );
     });
 

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:pub/src/exceptions.dart';
@@ -313,39 +312,98 @@ dependencies:
       );
     });
 
+    test('parses workspace', () {
+      expect(
+        Pubspec.parse(
+          '''
+environment:
+  sdk: ^3.7.0
+workspace: ['a', 'b', 'c']
+''',
+          sources,
+        ).workspace,
+        ['a', 'b', 'c'],
+      );
+    });
+
+    test('parses resolution', () {
+      expect(
+        Pubspec.parse(
+          '''
+environment:
+  sdk: ^3.7.0
+resolution: workspace
+''',
+          sources,
+        ).resolution,
+        Resolution.workspace,
+      );
+    });
+
+    test('errors on workspace for earlier language versions', () {
+      expectPubspecException(
+        '''
+environment:
+  sdk: ^1.2.3
+workspace: ['a', 'b', 'c']
+''',
+        (p) => p.workspace,
+      );
+      // but no error if you don't look at it.
+      expect(
+        Pubspec.parse(
+          '''
+name: foo
+environment:
+  sdk: ^1.2.3
+resolution: workspace
+''',
+          sources,
+        ).name,
+        'foo',
+      );
+    });
+
+    test('errors on resolution for earlier language versions', () {
+      expectPubspecException(
+        '''
+environment:
+  sdk: ^1.2.3
+resolution: local
+''',
+        (p) => p.resolution,
+      );
+    });
+
     test('throws if workspace is not a list', () {
-      runZoned(
-        () {
-          expectPubspecException(
-            'workspace: \'a string\'',
-            (pubspec) => pubspec.workspace,
-          );
-        },
-        zoneValues: {#enableWorkspaces: true},
+      expectPubspecException(
+        '''
+environment:
+  sdk: ^3.7.0
+workspace: 'a string'
+''',
+        (pubspec) => pubspec.workspace,
       );
     });
 
     test('throws if workspace is a list of not-strings', () {
-      runZoned(
-        () {
-          expectPubspecException(
-            'workspace: [\'a string\', 24]',
-            (pubspec) => pubspec.workspace,
-          );
-        },
-        zoneValues: {#enableWorkspaces: true},
+      expectPubspecException(
+        '''
+environment:
+  sdk: ^3.7.0
+workspace: ['a string', 24]
+''',
+        (pubspec) => pubspec.workspace,
       );
     });
 
     test('throws if resolution is not a reasonable string', () {
-      runZoned(
-        () {
-          expectPubspecException(
-            'resolution: "sometimes"',
-            (pubspec) => pubspec.resolution,
-          );
-        },
-        zoneValues: {#enableWorkspaces: true},
+      expectPubspecException(
+        '''
+environment:
+  sdk: ^3.7.0
+resolution: "sometimes"''',
+        (pubspec) => pubspec.resolution,
       );
     });
 


### PR DESCRIPTION
Part of https://github.com/dart-lang/pub/issues/4127

Just the pubspec syntax support.

The feature is only enabled from language version 3.7 (far in the future) in that way we should not break any users

The exact language version should be adjusted when we are ready.
