### PR TITLE
Make a RootDescription not depend on the root Package

### DIFF
--- a/lib/src/command/add.dart
+++ b/lib/src/command/add.dart
@@ -208,7 +208,7 @@ Specify multiple sdk packages with descriptors.''');
       solveResult = await resolveVersions(
         SolveType.upgrade,
         cache,
-        Package.inMemory(resolutionPubspec),
+        Package(resolutionPubspec, entrypoint.rootDir),
       );
     } on GitException {
       final name = updates.first.ref.name;

--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -145,7 +145,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
       'Resolving',
       () async {
         final upgradablePackagesResult = await _tryResolve(
-          upgradablePubspec,
+          Package(upgradablePubspec, entrypoint.rootDir),
           cache,
           lockFile: entrypoint.lockFile,
         );
@@ -153,7 +153,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
         upgradablePackages = upgradablePackagesResult ?? [];
 
         final resolvablePackagesResult = await _tryResolve(
-          resolvablePubspec,
+          Package(resolvablePubspec, entrypoint.rootDir),
           cache,
           lockFile: entrypoint.lockFile,
         );
@@ -407,14 +407,14 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
 /// Try to solve [pubspec] return [PackageId]s in the resolution or `null` if no
 /// resolution was found.
 Future<List<PackageId>?> _tryResolve(
-  Pubspec pubspec,
+  Package package,
   SystemCache cache, {
   LockFile? lockFile,
 }) async {
   final solveResult = await tryResolveVersions(
     SolveType.upgrade,
     cache,
-    Package.inMemory(pubspec),
+    package,
     lockFile: lockFile,
   );
 

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -278,7 +278,7 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
         return await resolveVersions(
           SolveType.upgrade,
           cache,
-          Package.inMemory(resolvablePubspec),
+          Package(resolvablePubspec, entrypoint.rootDir),
         );
       },
       condition: _shouldShowSpinner,
@@ -328,7 +328,10 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
       final solveResult = await resolveVersions(
         SolveType.upgrade,
         cache,
-        Package.inMemory(_updatedPubspec(newPubspecText, entrypoint)),
+        Package(
+          _updatedPubspec(newPubspecText, entrypoint),
+          entrypoint.rootDir,
+        ),
       );
       changes = tighten(
         entrypoint.root.pubspec,

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -235,7 +235,7 @@ class Entrypoint {
     this.rootDir,
     this.cache, {
     Pubspec? pubspec,
-  })  : _root = pubspec == null ? null : Package.inMemory(pubspec),
+  })  : _root = pubspec == null ? null : Package(pubspec, rootDir),
         globalDir = null {
     if (p.isWithin(cache.rootDir, rootDir)) {
       fail('Cannot operate on packages inside the cache.');
@@ -251,7 +251,7 @@ class Entrypoint {
       _example,
       _packageGraph,
       cache,
-      Package.inMemory(pubspec),
+      Package(pubspec, rootDir),
       globalDir,
     );
   }

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -212,12 +212,13 @@ class GlobalPackages {
     final originalLockFile = _describeActive(name, cache);
 
     // Create a dummy package with just [dep] so we can do resolution on it.
-    var root = Package.inMemory(
+    var root = Package(
       Pubspec(
         'pub global activate',
         dependencies: [dep],
         sources: cache.sources,
       ),
+      _packageDir(name),
     );
 
     // Resolve it and download its dependencies.

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -124,7 +124,7 @@ class Package {
 
   /// Creates a package with [pubspec] associated with [dir].
   ///
-  /// For temporary resolution attempts `pubspec` does not have to correspond
+  /// For temporary resolution attempts [pubspec] does not have to correspond
   /// to the one at disk.
   Package(this.pubspec, this.dir);
 

--- a/lib/src/package_name.dart
+++ b/lib/src/package_name.dart
@@ -27,7 +27,7 @@ class PackageRef {
 
   /// Creates a reference to the given root package.
   static PackageRef root(Package package) =>
-      PackageRef(package.name, RootDescription(package));
+      PackageRef(package.name, RootDescription(package.dir));
 
   @override
   String toString([PackageDetail? detail]) {
@@ -88,7 +88,7 @@ class PackageId {
   static PackageId root(Package package) => PackageId(
         package.name,
         package.version,
-        ResolvedRootDescription(RootDescription(package)),
+        ResolvedRootDescription(RootDescription(package.dir)),
       );
 
   @override

--- a/lib/src/solver/solve_suggestions.dart
+++ b/lib/src/solver/solve_suggestions.dart
@@ -9,7 +9,6 @@ import '../flutter_releases.dart';
 import '../io.dart';
 import '../package.dart';
 import '../package_name.dart';
-import '../pubspec.dart';
 import '../pubspec_utils.dart';
 import '../solver.dart';
 import '../source/hosted.dart';
@@ -149,7 +148,7 @@ class _ResolutionContext {
         await inferBestFlutterRelease({cause.sdk.identifier: constraint});
     if (bestRelease == null) return null;
     final result = await _tryResolve(
-      entrypoint.root.pubspec,
+      entrypoint.root,
       sdkOverrides: {
         'dart': bestRelease.dartVersion,
         'flutter': bestRelease.flutterVersion,
@@ -185,7 +184,8 @@ class _ResolutionContext {
       stripLowerBound: true,
     );
 
-    final result = await _tryResolve(relaxedPubspec);
+    final result =
+        await _tryResolve(Package(relaxedPubspec, entrypoint.rootDir));
     if (result == null) {
       return null;
     }
@@ -223,7 +223,8 @@ class _ResolutionContext {
     final relaxedPubspec =
         stripVersionBounds(originalPubspec, stripLowerBound: stripLowerBound);
 
-    final result = await _tryResolve(relaxedPubspec);
+    final result =
+        await _tryResolve(Package(relaxedPubspec, entrypoint.rootDir));
     if (result == null) {
       return null;
     }
@@ -259,14 +260,14 @@ class _ResolutionContext {
 
   /// Attempt resolving
   Future<SolveResult?> _tryResolve(
-    Pubspec pubspec, {
+    Package package, {
     Map<String, Version> sdkOverrides = const {},
   }) async {
     try {
       return await resolveVersions(
         type,
         cache,
-        Package.inMemory(pubspec),
+        package,
         sdkOverrides: sdkOverrides,
         lockFile: entrypoint.lockFile,
         unlock: unlock,

--- a/lib/src/source/root.dart
+++ b/lib/src/source/root.dart
@@ -5,12 +5,21 @@
 import 'package:pub_semver/pub_semver.dart';
 
 import '../language_version.dart';
-import '../package.dart';
 import '../package_name.dart';
 import '../pubspec.dart';
 import '../source.dart';
 import '../system_cache.dart';
 
+/// A root package is the root of a package dependency graph that seeds a
+/// version resolution.
+///
+/// There is no explicit way to depend on a root package.
+///
+/// A root package is the only package for whom dev_dependencies are taken into
+/// account.
+///
+/// A root package is the only package for whom dependency_overrides are taken
+/// into account.
 class RootSource extends Source {
   static final RootSource instance = RootSource._();
 
@@ -24,11 +33,7 @@ class RootSource extends Source {
     PackageId id,
     SystemCache cache,
   ) async {
-    final description = id.description.description;
-    if (description is! RootDescription) {
-      throw ArgumentError('Wrong source');
-    }
-    return description.package.pubspec;
+    throw UnsupportedError('Cannot describe the root');
   }
 
   @override
@@ -37,11 +42,7 @@ class RootSource extends Source {
     Duration? maxAge,
     SystemCache cache,
   ) async {
-    final description = ref.description;
-    if (description is! RootDescription) {
-      throw ArgumentError('Wrong source');
-    }
-    return [PackageId.root(description.package)];
+    throw UnsupportedError('Trying to get versions of the root package');
   }
 
   @override
@@ -76,6 +77,9 @@ class RootSource extends Source {
 }
 
 class ResolvedRootDescription extends ResolvedDescription {
+  @override
+  RootDescription get description => super.description as RootDescription;
+
   ResolvedRootDescription(RootDescription super.description);
 
   @override
@@ -92,9 +96,9 @@ class ResolvedRootDescription extends ResolvedDescription {
 }
 
 class RootDescription extends Description {
-  final Package package;
+  final String path;
 
-  RootDescription(this.package);
+  RootDescription(this.path);
   @override
   String format() {
     throw UnsupportedError('Trying to format a root package description.');
@@ -113,7 +117,7 @@ class RootDescription extends Description {
 
   @override
   bool operator ==(Object other) =>
-      other is RootDescription && other.package == package;
+      other is RootDescription && other.path == path;
 
   @override
   int get hashCode => 'root'.hashCode;

--- a/lib/src/source/root.dart
+++ b/lib/src/source/root.dart
@@ -15,10 +15,10 @@ import '../system_cache.dart';
 ///
 /// There is no explicit way to depend on a root package.
 ///
-/// A root package is the only package for whom dev_dependencies are taken into
+/// A root package is the only package for which dev_dependencies are taken into
 /// account.
 ///
-/// A root package is the only package for whom dependency_overrides are taken
+/// A root package is the only package for which dependency_overrides are taken
 /// into account.
 class RootSource extends Source {
   static final RootSource instance = RootSource._();


### PR DESCRIPTION
This is refactor that is extracted from https://github.com/dart-lang/pub/pull/4060 . It will allow a RootDescription to be created before the pubspec is loaded.

This removes the concept of an "in-memory package". These packages were always a modified version of a pubspec, being used for trying out a resolution, and they might as well be associated with the directory of the original pubspec.