### PR TITLE
Always pass --git-dir when handling repoCache

### DIFF
--- a/test/get/git/get_test.dart
+++ b/test/get/git/get_test.dart
@@ -32,4 +32,55 @@ void main() {
       exitCode: UNAVAILABLE,
     );
   });
+
+  test('works with safe.bareRepository=explicit', () async {
+    // https://git-scm.com/docs/git-config#Documentation/git-config.txt-safebareRepository
+    await d.git(
+      'foo.git',
+      [d.libDir('foo'), d.libPubspec('foo', '1.0.0')],
+    ).create();
+    await d.appDir(
+      dependencies: {
+        'foo': {
+          'git': {'url': '../foo.git'},
+        },
+      },
+    ).create();
+    final gitConfigDir = d.dir('gitconfig');
+    await gitConfigDir.create();
+    await pubGet(
+      environment: {
+        // See https://git-scm.com/docs/git-config#ENVIRONMENT
+        'GIT_CONFIG_COUNT': '1',
+        'GIT_CONFIG_KEY_0': 'safe.bareRepository',
+        'GIT_CONFIG_VALUE_0': 'explicit',
+      },
+    );
+    await d.git(
+      'foo.git',
+      [d.libDir('foo'), d.libPubspec('foo', '2.0.0')],
+    ).commit();
+
+    await d.git(
+      'foo.git',
+      [d.libDir('foo'), d.libPubspec('foo', '2.0.0')],
+    ).runGit(['tag', '2.0.0']);
+    await d.appDir(
+      dependencies: {
+        'foo': {
+          'git': {'url': '../foo.git', 'ref': '2.0.0'},
+        },
+      },
+    ).create();
+
+    await pubGet(
+      environment: {
+        // See https://git-scm.com/docs/git-config#ENVIRONMENT
+        'GIT_CONFIG_COUNT': '1',
+        'GIT_CONFIG_KEY_0': 'safe.bareRepository',
+        'GIT_CONFIG_VALUE_0': 'explicit',
+      },
+      output: contains('2.0.0'),
+    );
+  });
 }


### PR DESCRIPTION
This will allow commands to work even when `safe.bareRepository=explicit` is configured.

Fixes https://github.com/dart-lang/pub/issues/4141 