### PR TITLE
Delay error reporting for dependencies

### DIFF
--- a/lib/src/source/error.dart
+++ b/lib/src/source/error.dart
@@ -1,0 +1,40 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../language_version.dart';
+import '../source.dart';
+import 'unknown.dart';
+
+/// Represents a bad dependency description.
+///
+/// Allows for postponing the error until the dependency is actually read.
+class ErrorDescription extends Description {
+  final Exception exception;
+
+  ErrorDescription(this.exception);
+
+  @override
+  String format() {
+    throw UnimplementedError();
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(other, this);
+  }
+
+  @override
+  int get hashCode => identityHashCode(this);
+
+  @override
+  Object? serializeForPubspec({
+    required String? containingDir,
+    required LanguageVersion languageVersion,
+  }) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Source get source => UnknownSource('Error');
+}

--- a/lib/src/system_cache.dart
+++ b/lib/src/system_cache.dart
@@ -17,6 +17,7 @@ import 'package_name.dart';
 import 'pubspec.dart';
 import 'source.dart';
 import 'source/cached.dart';
+import 'source/error.dart';
 import 'source/git.dart';
 import 'source/hosted.dart';
 import 'source/path.dart';
@@ -185,6 +186,10 @@ Consider setting the `PUB_CACHE` variable manually.
     Duration? maxAge,
     Version? allowedRetractedVersion,
   }) async {
+    final description = ref.description;
+    if (description is ErrorDescription) {
+      throw description.exception;
+    }
     if (ref.isRoot) {
       throw ArgumentError('Cannot get versions for the root package.');
     }

--- a/test/dependency_override_test.dart
+++ b/test/dependency_override_test.dart
@@ -133,4 +133,23 @@ void main() {
       );
     });
   });
+
+  test('can override package with faulty description', () async {
+    final server = await servePackages();
+    server.serve(
+      'foo',
+      '1.0.0',
+      deps: {
+        'bar': {'path': '../abc'},
+      },
+    );
+    server.serve('bar', '1.0.0');
+    await d.appDir(
+      dependencies: {'foo': '^1.0.0'},
+      pubspec: {
+        'dependency_overrides': {'bar': '1.0.0'},
+      },
+    ).create();
+    await pubGet();
+  });
 }


### PR DESCRIPTION
Allows for overriding "bad" dependencies


We could consider taking this even further, such that the solver can look at different versions even if one has a bad dependency. But I think this step makes sense on its own.

Fixes https://github.com/dart-lang/pub/issues/4139