### PR TITLE
Prefer IPV4 on localhost, serve testserver on IPV4

### DIFF
--- a/test/package_server.dart
+++ b/test/package_server.dart
@@ -77,8 +77,9 @@ class PackageServer {
       RegExp(r'/packages/([^/]*)/versions/([^/]*).tar.gz');
 
   static Future<PackageServer> start() async {
-    final server =
-        PackageServer._(await shelf_io.IOServer.bind('localhost', 0));
+    final server = PackageServer._(
+      await shelf_io.IOServer.bind(InternetAddress.loopbackIPv4, 0),
+    );
     server.handle(
       _versionInfoPattern,
       (shelf.Request request) async {


### PR DESCRIPTION
This should resolve some flakynes observed in tests.

Because binding to port 0 `localhost` will bind to a random free port on one of `127.0.0.1` (ipv4) and `::1` (ipv6) it risks colliding with a different service with the same port, but the other ipvx.

When pub then connects to `localhost` it will race ipv4 against ipv6, causing flakiness.

Note that pub always will canonicalize loopbacks 127.0.0.1 and ::1 to `localhost` for cache directory names and for lockfile purposes.