### PR TITLE
isUpToDate based on package_config.json

### DIFF
--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -40,13 +40,11 @@ Command<int> pubCommand({required bool Function() isVerbose}) =>
 Future<void> ensurePubspecResolved(
   String dir, {
   bool isOffline = false,
-  bool checkForSdkUpdate = false,
   bool summaryOnly = true,
   bool onlyOutputWhenTerminal = true,
 }) async {
   try {
     await Entrypoint(dir, SystemCache(isOffline: isOffline)).ensureUpToDate(
-      checkForSdkUpdate: checkForSdkUpdate,
       summaryOnly: summaryOnly,
       onlyOutputWhenTerminal: onlyOutputWhenTerminal,
     );

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -331,10 +331,10 @@ class Entrypoint {
       generatorVersion: sdk.version,
       additionalProperties: {
         if (FlutterSdk().isAvailable) ...{
-          'FLUTTER_ROOT': p.absolute(FlutterSdk().rootDirectory!),
-          'FLUTTER_VERSION': FlutterSdk().version.toString(),
+          'flutterRoot': p.absolute(FlutterSdk().rootDirectory!),
+          'flutterVersion': FlutterSdk().version.toString(),
         },
-        'PUB_CACHE': p.absolute(cache.rootDir),
+        'pubCache': p.absolute(cache.rootDir),
       },
     );
 
@@ -656,8 +656,8 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
   /// up to date with respect to pubspec.yaml and its dependencies.
   ///
   /// Always returns false if `.dart_tool/package_config.json` was generated
-  /// with a different pub cache location, a different $FLUTTER_ROOT or a
-  /// different Dart or FLUTTER SDK version.
+  /// with a different PUB_CACHE location, a different $FLUTTER_ROOT or a
+  /// different Dart or Flutter SDK version.
   ///
   /// Otherwise first the `modified` timestamps are compared, and if
   /// `.dart_tool/package_config.json` is newer than `pubspec.lock` that is
@@ -686,9 +686,6 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
   /// pubspec.lock; touch .dart_tool/package_config.json`) - that is hard to
   /// avoid, but also unlikely to happen by accident because
   /// `.dart_tool/package_config.json` is not checked into version control.
-  ///
-  /// If [checkForSdkUpdate] this will return `false` if the dart sdk version is
-  /// different than the one generating `.dart_tool/package_config.json`.
   bool _isUpToDate() {
     if (isCached) return true;
     final packageConfigStat = tryStatFile(packageConfigPath);
@@ -701,7 +698,7 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
     // sdk-packages, and therefore do a new resolution.
     //
     // This also counts if Flutter was introduced or removed.
-    if (packageConfig.additionalProperties['FLUTTER_ROOT'] !=
+    if (packageConfig.additionalProperties['flutterRoot'] !=
         (flutter.rootDirectory == null
             ? null
             : p.absolute(flutter.rootDirectory!))) {

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -694,6 +694,7 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       log.fine('No $packageConfigPath file found".\n');
       return false;
     }
+    log.fine('$packageConfigPath $packageConfigStat'); // XXX remove
     final flutter = FlutterSdk();
     // If Flutter has moved since last invocation, we want to have new
     // sdk-packages, and therefore do a new resolution.
@@ -728,6 +729,7 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       log.fine('No $lockFilePath file found.');
       return false;
     }
+    log.fine('$lockFilePath $lockFileStat'); // XXX remove
 
     final lockFileModified = lockFileStat.modified;
     var lockfileNewerThanPubspecs = true;
@@ -753,6 +755,8 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
         // A dependency is missing - do a full new resolution.
         return false;
       }
+      log.fine('$pubspecPath $pubspecStat'); // XXX remove
+
       if (pubspecStat.modified.isAfter(lockFileModified)) {
         log.fine('`$pubspecPath` is newer than `$lockFilePath`');
         lockfileNewerThanPubspecs = false;

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -705,16 +705,16 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       log.fine('Flutter has moved since last invocation.');
       return false;
     }
-    if (packageConfig.additionalProperties['FLUTTER_VERSION'] !=
+    if (packageConfig.additionalProperties['flutterVersion'] !=
         (flutter.isAvailable ? null : flutter.version)) {
       log.fine('Flutter has updated since last invocation.');
       return false;
     }
     // If the pub cache was moved we should have a new resolution.
-    if (packageConfig.additionalProperties['PUB_CACHE'] !=
+    if (packageConfig.additionalProperties['pubCache'] !=
         p.absolute(cache.rootDir)) {
       log.fine(
-        'The pub cache has moved from ${packageConfig.additionalProperties['PUB_CACHE']} to ${p.absolute(cache.rootDir)} since last invocation.',
+        'The pub cache has moved from ${packageConfig.additionalProperties['pubCache']} to ${p.absolute(cache.rootDir)} since last invocation.',
       );
       return false;
     }

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -331,10 +331,11 @@ class Entrypoint {
       generatorVersion: sdk.version,
       additionalProperties: {
         if (FlutterSdk().isAvailable) ...{
-          'flutterRoot': p.absolute(FlutterSdk().rootDirectory!),
+          'flutterRoot':
+              p.toUri(p.absolute(FlutterSdk().rootDirectory!)).toString(),
           'flutterVersion': FlutterSdk().version.toString(),
         },
-        'pubCache': p.absolute(cache.rootDir),
+        'pubCache': p.toUri(p.absolute(cache.rootDir)).toString(),
       },
     );
 
@@ -698,10 +699,10 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
     // sdk-packages, and therefore do a new resolution.
     //
     // This also counts if Flutter was introduced or removed.
-    if (packageConfig.additionalProperties['flutterRoot'] !=
-        (flutter.rootDirectory == null
-            ? null
-            : p.absolute(flutter.rootDirectory!))) {
+    final flutterRoot = flutter.rootDirectory == null
+        ? null
+        : p.toUri(p.absolute(flutter.rootDirectory!)).toString();
+    if (packageConfig.additionalProperties['flutterRoot'] != flutterRoot) {
       log.fine('Flutter has moved since last invocation.');
       return false;
     }
@@ -711,10 +712,10 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       return false;
     }
     // If the pub cache was moved we should have a new resolution.
-    if (packageConfig.additionalProperties['pubCache'] !=
-        p.absolute(cache.rootDir)) {
+    final rootCacheUrl = p.toUri(p.absolute(cache.rootDir)).toString();
+    if (packageConfig.additionalProperties['pubCache'] != rootCacheUrl) {
       log.fine(
-        'The pub cache has moved from ${packageConfig.additionalProperties['pubCache']} to ${p.absolute(cache.rootDir)} since last invocation.',
+        'The pub cache has moved from ${packageConfig.additionalProperties['pubCache']} to $rootCacheUrl since last invocation.',
       );
       return false;
     }

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -28,6 +28,7 @@ import 'package_graph.dart';
 import 'package_name.dart';
 import 'pubspec.dart';
 import 'sdk.dart';
+import 'sdk/flutter.dart';
 import 'solver.dart';
 import 'solver/report.dart';
 import 'solver/solve_suggestions.dart';
@@ -35,24 +36,6 @@ import 'source/cached.dart';
 import 'source/unknown.dart';
 import 'system_cache.dart';
 import 'utils.dart';
-
-/// A RegExp to match SDK constraints in a lockfile.
-final _sdkConstraint = () {
-  // This matches both the old-style constraint:
-  //
-  // ```yaml
-  // sdk: ">=1.2.3 <2.0.0"
-  // ```
-  //
-  // and the new-style constraint:
-  //
-  // ```yaml
-  // sdks:
-  //   dart: ">=1.2.3 <2.0.0"
-  // ```
-  var sdkNames = sdks.keys.map((name) => '  $name').join('|');
-  return RegExp(r'^(' + sdkNames + r'|sdk): "?([^"]*)"?$', multiLine: true);
-}();
 
 /// The context surrounding the root package pub is operating on.
 ///
@@ -346,6 +329,13 @@ class Entrypoint {
       generated: DateTime.now(),
       generator: 'pub',
       generatorVersion: sdk.version,
+      additionalProperties: {
+        if (FlutterSdk().isAvailable) ...{
+          'FLUTTER_ROOT': p.absolute(FlutterSdk().rootDirectory!),
+          'FLUTTER_VERSION': FlutterSdk().version.toString(),
+        },
+        'PUB_CACHE': p.absolute(cache.rootDir),
+      },
     );
 
     return '${JsonEncoder.withIndent('  ').convert(packageConfig.toJson())}\n';
@@ -637,21 +627,16 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
   /// Does a fast-pass check to see if the resolution is up-to-date
   /// ([_isUpToDate]). If not, run a resolution with `pub get` semantics.
   ///
-  /// If [checkForSdkUpdate] is `true`, the resolution is considered outdated if
-  /// the package_config.json was created by a different sdk. See
-  /// [_isPackageConfigGeneratedBySameDartSdk].
-  ///
   /// If [summaryOnly] is `true` (the default) only a short summary is shown of
   /// the solve.
   ///
   /// If [onlyOutputWhenTerminal] is `true` (the default) there will be no
   /// output if no terminal is attached.
   Future<void> ensureUpToDate({
-    bool checkForSdkUpdate = false,
     bool summaryOnly = true,
     bool onlyOutputWhenTerminal = true,
   }) async {
-    if (!_isUpToDate(checkForSdkUpdate: checkForSdkUpdate)) {
+    if (!_isUpToDate()) {
       if (onlyOutputWhenTerminal) {
         await log.errorsOnlyUnlessTerminal(() async {
           await acquireDependencies(
@@ -660,29 +645,84 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
           );
         });
       } else {
-        await acquireDependencies(
-          SolveType.get,
-          summaryOnly: summaryOnly,
-        );
+        await acquireDependencies(SolveType.get, summaryOnly: summaryOnly);
       }
     } else {
       log.fine('Package Config up to date.');
     }
   }
 
-  /// Whether `.dart_tool/package_config.json` file exists and if it's
-  /// up-to-date relative to the lockfile and the pubspec.
+  /// Whether `.dart_tool/package_config.json` and `pubspec.lock` exist and are
+  /// up to date with respect to pubspec.yaml and its dependencies.
   ///
-  /// A `.dart_tool/package_config.json` file is not required.
-  /// But if it exists it is checked for consistency with the `pubspec.lock`.
-  bool _isUpToDate({bool checkForSdkUpdate = false}) {
+  /// Always returns false if `.dart_tool/package_config.json` was generated
+  /// with a different pub cache location, a different $FLUTTER_ROOT or a
+  /// different Dart or FLUTTER SDK version.
+  ///
+  /// Otherwise first the `modified` timestamps are compared, and if
+  /// `.dart_tool/package_config.json` is newer than `pubspec.lock` that is
+  /// newer than all pubspec.yamls of all packages in
+  /// `.dart_tool/package_config.json` we short-circuit and return true.
+  ///
+  /// If any of the timestamps are out of order, the resolution in pubspec.lock
+  /// is validated against constraints of all pubspec.yamls, and the packages of
+  /// `.dart_tool/package_config.json` is validated against pubspec.lock. We do
+  /// this extra round of checking to accomodate for cases where version control
+  /// or other processes mess up the timestamp order.
+  ///
+  /// If the resolution is still valid, the timestamps are updated and this
+  /// returns `true`. Otherwise this returns `false`.
+  ///
+  /// This check is on the fast-path of `dart run` and should do as little work
+  /// as possible. Specifically we avoid parsing any yaml when the timestamps
+  /// are in the right order.
+  ///
+  /// `.dart_tool/package_config.json` is read parsed. In the case of `dart run`
+  /// this is acceptable: we speculate that it brings it to the file system
+  /// cache and the dart VM is going to read the file anyways.
+  ///
+  /// Note this procedure will give false positives if the timestamps are
+  /// artificially brought in the "right" order. (eg. by manually running `touch
+  /// pubspec.lock; touch .dart_tool/package_config.json`) - that is hard to
+  /// avoid, but also unlikely to happen by accident because
+  /// `.dart_tool/package_config.json` is not checked into version control.
+  ///
+  /// If [checkForSdkUpdate] this will return `false` if the dart sdk version is
+  /// different than the one generating `.dart_tool/package_config.json`.
+  bool _isUpToDate() {
     if (isCached) return true;
-    final pubspecStat = tryStatFile(pubspecPath);
-    if (pubspecStat == null) {
+    final packageConfigStat = tryStatFile(packageConfigPath);
+    if (packageConfigStat == null) {
+      log.fine('No $packageConfigPath file found".\n');
+      return false;
+    }
+    final flutter = FlutterSdk();
+    // If Flutter has moved since last invocation, we want to have new
+    // sdk-packages, and therefore do a new resolution.
+    //
+    // This also counts if Flutter was introduced or removed.
+    if (packageConfig.additionalProperties['FLUTTER_ROOT'] !=
+        (flutter.rootDirectory == null
+            ? null
+            : p.absolute(flutter.rootDirectory!))) {
+      log.fine('Flutter has moved since last invocation.');
+      return false;
+    }
+    if (packageConfig.additionalProperties['FLUTTER_VERSION'] !=
+        (flutter.isAvailable ? null : flutter.version)) {
+      log.fine('Flutter has updated since last invocation.');
+      return false;
+    }
+    // If the pub cache was moved we should have a new resolution.
+    if (packageConfig.additionalProperties['PUB_CACHE'] !=
+        p.absolute(cache.rootDir)) {
       log.fine(
-        'Could not find a file named "pubspec.yaml" in '
-        '"${canonicalize(rootDir)}".',
+        'The pub cache has moved from ${packageConfig.additionalProperties['PUB_CACHE']} to ${p.absolute(cache.rootDir)} since last invocation.',
       );
+      return false;
+    }
+    // If the Dart sdk was updated we want a new resolution.
+    if (!_isPackageConfigGeneratedBySameDartSdk()) {
       return false;
     }
     final lockFileStat = tryStatFile(lockFilePath);
@@ -690,101 +730,101 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       log.fine('No $lockFilePath file found.');
       return false;
     }
-    final packageConfigStat = tryStatFile(packageConfigPath);
-    if (packageConfigStat == null) {
-      log.fine('No $packageConfigPath file found".\n');
-      return false;
+
+    final lockFileModified = lockFileStat.modified;
+    var lockfileNewerThanPubspecs = true;
+
+    if (lockfileNewerThanPubspecs) {
+      // Check that all packages in packageConfig exist and their pubspecs have
+      // not been updated since the lockfile was written.
+      for (var package in packageConfig.packages) {
+        final pubspecPath = p.normalize(
+          p.join(
+            '.dart_tool',
+            package.rootUri
+                // Important to use `toFilePath()` here rather than `path`, as it handles Url-decoding.
+                .toFilePath(),
+            'pubspec.yaml',
+          ),
+        );
+        if (p.isWithin(cache.rootDir, pubspecPath)) {
+          continue;
+        }
+        final pubspecStat = tryStatFile(pubspecPath);
+        if (pubspecStat == null) {
+          log.fine('Could not find `$pubspecPath`');
+          // A dependency is missing - do a full new resolution.
+          return false;
+        }
+        if (pubspecStat.modified.isAfter(lockFileModified)) {
+          log.fine('`$pubspecPath` is newer than `$lockFilePath`');
+          lockfileNewerThanPubspecs = false;
+          break;
+        }
+        final pubspecOverridesPath =
+            p.join(package.rootUri.path, 'pubspec_overrides.yaml');
+        final pubspecOverridesStat = tryStatFile(pubspecOverridesPath);
+        if (pubspecOverridesStat != null) {
+          // This will wrongly require you to reresolve if a
+          // `pubspec_overrides.yaml` in a path-dependency is updated. That
+          // seems acceptable.
+          if (pubspecOverridesStat.modified.isAfter(lockFileModified)) {
+            log.fine('`$pubspecOverridesPath` is newer than `$lockFilePath`');
+            lockfileNewerThanPubspecs = false;
+          }
+        }
+      }
     }
-
-    // Manually parse the lockfile because a full YAML parse is relatively slow
-    // and this is on the hot path for "pub run".
-    var lockFileText = readTextFile(lockFilePath);
-    var hasPathDependencies = lockFileText.contains('\n    source: path\n');
-
-    var lockFileModified = lockFileStat.modified;
-
-    var pubspecChanged = lockFileModified.isBefore(pubspecStat.modified);
-    var pubspecOverridesChanged = false;
-
-    final pubspecOverridesStat = tryStatFile(pubspecOverridesPath);
-    if (pubspecOverridesStat != null) {
-      pubspecOverridesChanged =
-          lockFileModified.isBefore(pubspecOverridesStat.modified);
-    }
-
     var touchedLockFile = false;
-    if (pubspecChanged || pubspecOverridesChanged || hasPathDependencies) {
-      // If `pubspec.lock` is older than `pubspec.yaml` or
-      // `pubspec_overrides.yaml`, or we have path dependencies, then we check
-      // that `pubspec.lock` is a correct solution for the requirements in
-      // `pubspec.yaml` and `pubspec_overrides.yaml`. This aims to:
-      //  * Prevent missing packages when `pubspec.lock` is checked into git.
-      //  * Mitigate missing transitive dependencies when the `pubspec.yaml` in
-      //    a path dependency is changed.
-      if (!_isLockFileUpToDate()) {
-        return false;
-      }
-      if (!_arePackagesAvailable()) {
-        var filePath = pubspecChanged ? pubspecPath : pubspecOverridesPath;
-        log.fine('The $filePath file has changed since the $lockFilePath '
-            'file was generated, please run "$topLevelProgram pub get" again.');
+    if (!lockfileNewerThanPubspecs) {
+      if (_isLockFileUpToDate()) {
+        touch(lockFilePath);
+        touchedLockFile = true;
+      } else {
         return false;
       }
     }
-    if (pubspecChanged || pubspecOverridesChanged) {
-      // Ensure the timestamps are in the right order.
-      touchedLockFile = true;
-      touch(lockFilePath);
-    }
 
-    final lockFileChanged =
-        packageConfigStat.modified.isBefore(lockFileModified);
-    if (lockFileChanged || hasPathDependencies) {
-      // If `package_config.json` is older than `pubspec.lock` or we have
-      // path dependencies, then we check that `package_config.json` is a
-      // correct configuration on the local machine. This aims to:
-      //  * Mitigate issues when copying a folder from one machine to another.
-      //  * Force `pub get` if a path dependency has changed language version.
-      if (!_isPackageConfigUpToDate()) return false;
-    }
-    if (lockFileChanged || touchedLockFile) {
-      // Ensure the timestamps are in the right order.
-      touch(packageConfigPath);
-    }
-
-    for (final match in _sdkConstraint.allMatches(lockFileText)) {
-      final identifier = match[1] == 'sdk' ? 'dart' : match[1]!.trim();
-      final sdk = sdks[identifier]!;
-      // Don't complain if there's an SDK constraint for an unavailable SDK. For
-      // example, the Flutter SDK being unavailable just means that we aren't
-      // running from within the `flutter` executable, and we want users to be
-      // able to `pub run` non-Flutter tools even in a Flutter app.
-      if (!sdk.isAvailable) continue;
-
-      final parsedConstraint = VersionConstraint.parse(match[2]!);
-      if (!parsedConstraint.allows(sdk.version!)) {
-        log.fine('${sdk.name} ${sdk.version} is incompatible with your '
-            "dependencies' SDK constraints.");
+    if (touchedLockFile ||
+        lockFileModified.isAfter(packageConfigStat.modified)) {
+      log.fine('`$lockFilePath` is newer than `$packageConfigPath`');
+      if (_isPackageConfigUpToDate()) {
+        touch(packageConfigPath);
+      } else {
         return false;
       }
-    }
-    // We want to do ensure a pub get gets run when updating a minor version of
-    // the Dart SDK.
-    //
-    // Putting this check last because it leads to less specific messages than
-    // the 'incompatible sdk' check above.
-    if (checkForSdkUpdate && !_isPackageConfigGeneratedBySameDartSdk()) {
-      return false;
     }
     return true;
   }
 
-  /// Whether the lockfile is out of date with respect to the
-  /// pubspec.
+  /// Whether the lockfile is out of date with respect to the dependencies'
+  /// pubspecs.
   ///
   /// If any mutable pubspec contains dependencies that are not in the lockfile
   /// or that don't match what's in there, this will return `false`.
   bool _isLockFileUpToDate() {
+    for (final MapEntry(key: sdkName, value: constraint)
+        in lockFile.sdkConstraints.entries) {
+      final sdk = sdks[sdkName];
+      if (sdk == null) {
+        log.fine('Unknown sdk $sdkName in `$lockFilePath`');
+        return false;
+      }
+      if (!sdk.isAvailable) {
+        log.fine('sdk: ${sdk.name} not available');
+        return false;
+      }
+      final sdkVersion = sdk.version;
+      if (sdkVersion != null) {
+        if (!constraint.effectiveConstraint.allows(sdkVersion)) {
+          log.fine(
+            '`$lockFilePath` requires $sdkName $constraint. Current version is $sdkVersion',
+          );
+          return false;
+        }
+      }
+    }
+
     if (!root.immediateDependencies.values.every(_isDependencyUpToDate)) {
       log.fine('The $pubspecPath file has changed since the $lockFilePath file '
           'was generated.');
@@ -827,26 +867,7 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
     return locked != null && dep.allows(locked);
   }
 
-  /// Determines whether all of the packages in the lockfile are already
-  /// installed and available.
-  bool _arePackagesAvailable() {
-    return lockFile.packages.values.every((package) {
-      if (package.source is UnknownSource) return false;
-
-      // We only care about cached sources. Uncached sources aren't "installed".
-      // If one of those is missing, we want to show the user the file not
-      // found error later since installing won't accomplish anything.
-      var source = package.source;
-      if (source is! CachedSource) return true;
-
-      // Get the directory.
-      var dir = cache.getDirectory(package, relativeFrom: '.');
-      // See if the directory is there and looks like a package.
-      return fileExists(p.join(dir, 'pubspec.yaml'));
-    });
-  }
-
-  /// Determines [lockFile] agrees with the given [packagePathsMapping].
+  /// Determines if [lockFile] agrees with the given [packagePathsMapping].
   ///
   /// The [packagePathsMapping] is a mapping from package names to paths where
   /// the packages are located. (The library is located under
@@ -976,7 +997,7 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
     if (generatorVersion == null ||
         generatorVersion.major != sdk.version.major ||
         generatorVersion.minor != sdk.version.minor) {
-      log.fine('The sdk was updated since last package resolution.');
+      log.fine('The Dart SDK was updated since last package resolution.');
       return false;
     }
     return true;

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -694,7 +694,6 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       log.fine('No $packageConfigPath file found".\n');
       return false;
     }
-    log.fine('$packageConfigPath $packageConfigStat'); // XXX remove
     final flutter = FlutterSdk();
     // If Flutter has moved since last invocation, we want to have new
     // sdk-packages, and therefore do a new resolution.
@@ -729,7 +728,6 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       log.fine('No $lockFilePath file found.');
       return false;
     }
-    log.fine('$lockFilePath $lockFileStat'); // XXX remove
 
     final lockFileModified = lockFileStat.modified;
     var lockfileNewerThanPubspecs = true;
@@ -755,7 +753,6 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
         // A dependency is missing - do a full new resolution.
         return false;
       }
-      log.fine('$pubspecPath $pubspecStat'); // XXX remove
 
       if (pubspecStat.modified.isAfter(lockFileModified)) {
         log.fine('`$pubspecPath` is newer than `$lockFilePath`');

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -308,7 +308,7 @@ Future<DartExecutableWithPackageConfig> getExecutableForCommand(
   }
   final entrypoint = Entrypoint(root, SystemCache(rootDir: pubCacheDir));
   try {
-    await entrypoint.ensureUpToDate(checkForSdkUpdate: true);
+    await entrypoint.ensureUpToDate();
   } on ApplicationException catch (e) {
     throw CommandResolutionFailedException._(
       e.toString(),

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -977,7 +977,10 @@ T _doProcess<T>(
 }
 
 /// Updates [path]'s modification time.
-void touch(String path) => File(path).setLastModifiedSync(DateTime.now());
+void touch(String path) {
+  log.fine('Touching `$path`');
+  File(path).setLastModifiedSync(DateTime.now());
+}
 
 /// Creates a temporary directory and passes its path to [fn].
 ///

--- a/test/add/sdk/sdk_test.dart
+++ b/test/add/sdk/sdk_test.dart
@@ -47,13 +47,17 @@ void main() {
       }),
     ]).validate();
 
-    await d.appPackageConfigFile([
-      d.packageConfigEntry(
-        name: 'foo',
-        path: p.join(d.sandbox, 'flutter', 'packages', 'foo'),
-      ),
-      d.packageConfigEntry(name: 'bar', version: '1.0.0'),
-    ]).validate();
+    await d.appPackageConfigFile(
+      [
+        d.packageConfigEntry(
+          name: 'foo',
+          path: p.join(d.sandbox, 'flutter', 'packages', 'foo'),
+        ),
+        d.packageConfigEntry(name: 'bar', version: '1.0.0'),
+      ],
+      flutterRoot: p.join(d.sandbox, 'flutter'),
+      flutterVersion: '1.2.3',
+    ).validate();
   });
 
   test(
@@ -73,13 +77,17 @@ void main() {
         },
       }),
     ]).validate();
-    await d.appPackageConfigFile([
-      d.packageConfigEntry(
-        name: 'foo',
-        path: p.join(d.sandbox, 'flutter', 'packages', 'foo'),
-      ),
-      d.packageConfigEntry(name: 'bar', version: '1.0.0'),
-    ]).validate();
+    await d.appPackageConfigFile(
+      [
+        d.packageConfigEntry(
+          name: 'foo',
+          path: p.join(d.sandbox, 'flutter', 'packages', 'foo'),
+        ),
+        d.packageConfigEntry(name: 'bar', version: '1.0.0'),
+      ],
+      flutterRoot: p.join(d.sandbox, 'flutter'),
+      flutterVersion: '1.2.3',
+    ).validate();
   });
 
   test('adds an SDK dependency from bin/cache/pkg', () async {
@@ -89,12 +97,16 @@ void main() {
       environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')},
     );
 
-    await d.appPackageConfigFile([
-      d.packageConfigEntry(
-        name: 'baz',
-        path: p.join(d.sandbox, 'flutter', 'bin', 'cache', 'pkg', 'baz'),
-      ),
-    ]).validate();
+    await d.appPackageConfigFile(
+      [
+        d.packageConfigEntry(
+          name: 'baz',
+          path: p.join(d.sandbox, 'flutter', 'bin', 'cache', 'pkg', 'baz'),
+        ),
+      ],
+      flutterRoot: p.join(d.sandbox, 'flutter'),
+      flutterVersion: '1.2.3',
+    ).validate();
   });
 
   test("fails if the version constraint doesn't match", () async {

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -311,12 +311,27 @@ DirectoryDescriptor appDir({Map? dependencies, Map<String, Object>? pubspec}) =>
 Descriptor packageConfigFile(
   List<PackageConfigEntry> packages, {
   String generatorVersion = '3.1.2+3',
+  String? pubCache,
+  String? flutterVersion,
+  String? flutterRoot,
 }) =>
-    PackageConfigFileDescriptor(packages, generatorVersion);
+    PackageConfigFileDescriptor(
+      packages,
+      generatorVersion,
+      pubCache ??
+          p.join(
+            sandbox,
+            cachePath,
+          ),
+      flutterRoot,
+      flutterVersion,
+    );
 
 Descriptor appPackageConfigFile(
   List<PackageConfigEntry> packages, {
   String generatorVersion = '3.1.2+3',
+  String? flutterRoot,
+  String? flutterVersion,
 }) =>
     dir(
       appPath,
@@ -327,6 +342,8 @@ Descriptor appPackageConfigFile(
             ...packages,
           ],
           generatorVersion: generatorVersion,
+          flutterRoot: flutterRoot,
+          flutterVersion: flutterVersion,
         ),
       ],
     );

--- a/test/descriptor/package_config.dart
+++ b/test/descriptor/package_config.dart
@@ -30,9 +30,9 @@ class PackageConfigFileDescriptor extends Descriptor {
       generator: 'pub',
       generated: DateTime.now().toUtc(),
       additionalProperties: {
-        'PUB_CACHE': _pubCache,
-        if (_flutterRoot != null) 'FLUTTER_ROOT': _flutterRoot,
-        if (_flutterVersion != null) 'FLUTTER_VERSION': _flutterVersion,
+        'pubCache': _pubCache,
+        if (_flutterRoot != null) 'flutterRoot': _flutterRoot,
+        if (_flutterVersion != null) 'flutterVersion': _flutterVersion,
       },
     );
   }

--- a/test/descriptor/package_config.dart
+++ b/test/descriptor/package_config.dart
@@ -30,8 +30,9 @@ class PackageConfigFileDescriptor extends Descriptor {
       generator: 'pub',
       generated: DateTime.now().toUtc(),
       additionalProperties: {
-        'pubCache': _pubCache,
-        if (_flutterRoot != null) 'flutterRoot': _flutterRoot,
+        'pubCache': p.toUri(_pubCache).toString(),
+        if (_flutterRoot != null)
+          'flutterRoot': p.toUri(_flutterRoot).toString(),
         if (_flutterVersion != null) 'flutterVersion': _flutterVersion,
       },
     );

--- a/test/descriptor/package_config.dart
+++ b/test/descriptor/package_config.dart
@@ -15,6 +15,9 @@ import 'package:test_descriptor/test_descriptor.dart';
 /// Describes a `.dart_tools/package_config.json` file and its contents.
 class PackageConfigFileDescriptor extends Descriptor {
   final String _generatorVersion;
+  final String _pubCache;
+  final String? _flutterRoot;
+  final String? _flutterVersion;
 
   /// A map describing the packages in this `package_config.json` file.
   final List<PackageConfigEntry> _packages;
@@ -26,14 +29,24 @@ class PackageConfigFileDescriptor extends Descriptor {
       generatorVersion: Version.parse(_generatorVersion),
       generator: 'pub',
       generated: DateTime.now().toUtc(),
+      additionalProperties: {
+        'PUB_CACHE': _pubCache,
+        if (_flutterRoot != null) 'FLUTTER_ROOT': _flutterRoot,
+        if (_flutterVersion != null) 'FLUTTER_VERSION': _flutterVersion,
+      },
     );
   }
 
   /// Describes a `.dart_tools/package_config.json` file
   /// with the given list of package configurations and
   /// generated with specified version.
-  PackageConfigFileDescriptor(this._packages, this._generatorVersion)
-      : super('.dart_tool/package_config.json');
+  PackageConfigFileDescriptor(
+    this._packages,
+    this._generatorVersion,
+    this._pubCache,
+    this._flutterRoot,
+    this._flutterVersion,
+  ) : super('.dart_tool/package_config.json');
 
   @override
   Future<void> create([String? parent]) async {

--- a/test/embedding/ensure_pubspec_resolved.dart
+++ b/test/embedding/ensure_pubspec_resolved.dart
@@ -202,8 +202,7 @@ void testEnsurePubspecResolved() {
         // Ensure that the pubspec looks newer than the lockfile.
         await _touch('pubspec.yaml');
 
-        await _implicitPubGet('The pubspec.yaml file has changed since the '
-            'pubspec.lock file was generated');
+        await _implicitPubGet('`pubspec.yaml` is newer than `pubspec.lock`');
       });
 
       test('the package_config.json file points to the wrong place', () async {
@@ -235,8 +234,7 @@ void testEnsurePubspecResolved() {
         // Ensure that the pubspec looks newer than the lockfile.
         await _touch('pubspec.lock');
 
-        await _implicitPubGet('The pubspec.lock file has changed since the '
-            '.dart_tool/package_config.json file was generated');
+        await _implicitPubGet('Could not find `../foo/pubspec.yaml`');
       });
 
       test("the lock file's SDK constraint doesn't match the current SDK",
@@ -270,8 +268,8 @@ void testEnsurePubspecResolved() {
         );
 
         await _implicitPubGet(
-            "Dart 3.1.2+3 is incompatible with your dependencies' "
-            'SDK constraints');
+          'The Dart SDK was updated since last package resolution.',
+        );
       });
 
       test(
@@ -314,7 +312,7 @@ void testEnsurePubspecResolved() {
         );
 
         await _implicitPubGet(
-          'Flutter 0.9.0 is incompatible with your dependencies\' SDK constraints',
+          'Flutter has updated since last invocation.',
           environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')},
         );
       });
@@ -496,38 +494,6 @@ void testEnsurePubspecResolved() {
         await _touch('pubspec.lock');
 
         await _noImplicitPubGet();
-      });
-
-      test('the lock file has a Flutter SDK but Flutter is unavailable',
-          () async {
-        // Avoid using a path dependency because it triggers the full validation
-        // logic. We want to be sure SDK-validation works without that logic.
-        server.serve(
-          'foo',
-          '3.0.0',
-          pubspec: {
-            'environment': {
-              'flutter': '>=1.0.0 <2.0.0',
-              'sdk': defaultSdkConstraint,
-            },
-          },
-        );
-
-        await d.dir('flutter', [d.flutterVersion('1.2.3')]).create();
-
-        await d.dir(appPath, [
-          d.appPubspec(dependencies: {'foo': '3.0.0'}),
-        ]).create();
-
-        await pubGet(
-          environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')},
-        );
-
-        await d.dir('flutter', [d.flutterVersion('2.4.6')]).create();
-
-        // Run pub manually here because otherwise we don't have access to
-        // d.sandbox.
-        await runPub(args: ['run', 'bin/script.dart']);
       });
     });
   });

--- a/test/embedding/ensure_pubspec_resolved.dart
+++ b/test/embedding/ensure_pubspec_resolved.dart
@@ -339,7 +339,7 @@ void testEnsurePubspecResolved() {
         ]).create();
 
         // To ensure the timestamp is strictly later we need to touch again here.
-        _touch(p.join(d.sandbox, 'bar', 'pubspec.yaml'));
+        await _touch(p.join(d.sandbox, 'bar', 'pubspec.yaml'));
 
         await _implicitPubGet(
             '${p.join('..', 'bar', 'pubspec.yaml')} has changed '
@@ -380,7 +380,7 @@ void testEnsurePubspecResolved() {
           ),
         ]).create();
         // To ensure the timestamp is strictly later we need to touch again here.
-        _touch(p.join(d.sandbox, 'bar', 'pubspec.yaml'));
+        await _touch(p.join(d.sandbox, 'bar', 'pubspec.yaml'));
 
         await _implicitPubGet(
             '${p.join('..', 'bar', 'pubspec.yaml')} has changed '

--- a/test/embedding/ensure_pubspec_resolved.dart
+++ b/test/embedding/ensure_pubspec_resolved.dart
@@ -338,6 +338,9 @@ void testEnsurePubspecResolved() {
           d.libPubspec('bar', '1.0.0', deps: {'foo': '2.0.0'}),
         ]).create();
 
+        // To ensure the timestamp is strictly later we need to touch again here.
+        _touch(p.join(d.sandbox, 'bar', 'pubspec.yaml'));
+
         await _implicitPubGet(
             '${p.join('..', 'bar', 'pubspec.yaml')} has changed '
             'since the pubspec.lock file was generated.');
@@ -376,6 +379,8 @@ void testEnsurePubspecResolved() {
             sdk: '>= 2.100.0 <=4.0.0', // tests runs with '3.1.2+3'
           ),
         ]).create();
+        // To ensure the timestamp is strictly later we need to touch again here.
+        _touch(p.join(d.sandbox, 'bar', 'pubspec.yaml'));
 
         await _implicitPubGet(
             '${p.join('..', 'bar', 'pubspec.yaml')} has changed '

--- a/test/embedding/ensure_pubspec_resolved.dart
+++ b/test/embedding/ensure_pubspec_resolved.dart
@@ -341,8 +341,7 @@ void testEnsurePubspecResolved() {
         // To ensure the timestamp is strictly later we need to touch again here.
         await _touch(p.join(d.sandbox, 'bar', 'pubspec.yaml'));
 
-        await _implicitPubGet(
-            '${p.join('..', 'bar', 'pubspec.yaml')} has changed '
+        await _implicitPubGet('../bar/pubspec.yaml has changed '
             'since the pubspec.lock file was generated.');
       });
 
@@ -382,8 +381,7 @@ void testEnsurePubspecResolved() {
         // To ensure the timestamp is strictly later we need to touch again here.
         await _touch(p.join(d.sandbox, 'bar', 'pubspec.yaml'));
 
-        await _implicitPubGet(
-            '${p.join('..', 'bar', 'pubspec.yaml')} has changed '
+        await _implicitPubGet('../bar/pubspec.yaml has changed '
             'since the pubspec.lock file was generated.');
       });
     });

--- a/test/embedding/ensure_pubspec_resolved.dart
+++ b/test/embedding/ensure_pubspec_resolved.dart
@@ -338,7 +338,8 @@ void testEnsurePubspecResolved() {
           d.libPubspec('bar', '1.0.0', deps: {'foo': '2.0.0'}),
         ]).create();
 
-        await _implicitPubGet('../bar/pubspec.yaml has changed '
+        await _implicitPubGet(
+            '${p.join('..', 'bar', 'pubspec.yaml')} has changed '
             'since the pubspec.lock file was generated.');
       });
 

--- a/test/embedding/ensure_pubspec_resolved.dart
+++ b/test/embedding/ensure_pubspec_resolved.dart
@@ -377,7 +377,8 @@ void testEnsurePubspecResolved() {
           ),
         ]).create();
 
-        await _implicitPubGet('../bar/pubspec.yaml has changed '
+        await _implicitPubGet(
+            '${p.join('..', 'bar', 'pubspec.yaml')} has changed '
             'since the pubspec.lock file was generated.');
       });
     });

--- a/test/sdk_test.dart
+++ b/test/sdk_test.dart
@@ -43,13 +43,17 @@ void main() {
         command,
         environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')},
       );
-      await d.appPackageConfigFile([
-        d.packageConfigEntry(
-          name: 'foo',
-          path: p.join(d.sandbox, 'flutter', 'packages', 'foo'),
-        ),
-        d.packageConfigEntry(name: 'bar', version: '1.0.0'),
-      ]).validate();
+      await d.appPackageConfigFile(
+        [
+          d.packageConfigEntry(
+            name: 'foo',
+            path: p.join(d.sandbox, 'flutter', 'packages', 'foo'),
+          ),
+          d.packageConfigEntry(name: 'bar', version: '1.0.0'),
+        ],
+        flutterRoot: p.join(d.sandbox, 'flutter'),
+        flutterVersion: '1.2.3',
+      ).validate();
     });
 
     test('gets an SDK dependency from bin/cache/pkg', () async {
@@ -63,12 +67,16 @@ void main() {
         environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')},
       );
 
-      await d.appPackageConfigFile([
-        d.packageConfigEntry(
-          name: 'baz',
-          path: p.join(d.sandbox, 'flutter', 'bin', 'cache', 'pkg', 'baz'),
-        ),
-      ]).validate();
+      await d.appPackageConfigFile(
+        [
+          d.packageConfigEntry(
+            name: 'baz',
+            path: p.join(d.sandbox, 'flutter', 'bin', 'cache', 'pkg', 'baz'),
+          ),
+        ],
+        flutterRoot: p.join(d.sandbox, 'flutter'),
+        flutterVersion: '1.2.3',
+      ).validate();
     });
 
     test('unlocks an SDK dependency when the version changes', () async {
@@ -116,7 +124,11 @@ void main() {
         command,
         environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')},
       );
-      await d.appPackageConfigFile([]).validate();
+      await d.appPackageConfigFile(
+        [],
+        flutterRoot: p.join(d.sandbox, 'flutter'),
+        flutterVersion: '1.2.3',
+      ).validate();
     });
 
     group('fails if', () {

--- a/test/testdata/goldens/directory_option_test/commands taking a --directory~-C parameter work.txt
+++ b/test/testdata/goldens/directory_option_test/commands taking a --directory~-C parameter work.txt
@@ -95,6 +95,10 @@ Got dependencies in myapp/example.
 
 ## Section 10
 $ pub run -C myapp 'bin/app.dart'
+Resolving dependencies in myapp...
+Got dependencies in myapp.
+Resolving dependencies in myapp...
+Got dependencies in myapp.
 Building package executable...
 Built test_pkg:app.
 Hi
@@ -139,6 +143,8 @@ $ pub uploader -C myapp add sigurdm@google.com
 
 ## Section 13
 $ pub deps -C myapp
+Resolving dependencies in myapp...
+Got dependencies in myapp.
 Dart SDK 3.1.2+3
 test_pkg 1.0.0
 └── foo 1.0.0

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -122,7 +122,8 @@ MSG : Logs written to $SANDBOX/cache/log/pub_log.txt.
 [E]    |   ],
 [E]    |   "generated": "$TIME",
 [E]    |   "generator": "pub",
-[E]    |   "generatorVersion": "3.1.2+3"
+[E]    |   "generatorVersion": "3.1.2+3",
+[E]    |   "PUB_CACHE": "$SANDBOX/cache"
 [E]    | }
 [E] IO  : Writing $N characters to text file $SANDBOX/cache/log/pub_log.txt.
 
@@ -283,7 +284,8 @@ FINE: Contents:
    |   ],
    |   "generated": "$TIME",
    |   "generator": "pub",
-   |   "generatorVersion": "3.1.2+3"
+   |   "generatorVersion": "3.1.2+3",
+   |   "PUB_CACHE": "$SANDBOX/cache"
    | }
 ---- End log transcript ----
 -------------------------------- END OF OUTPUT ---------------------------------

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -123,7 +123,7 @@ MSG : Logs written to $SANDBOX/cache/log/pub_log.txt.
 [E]    |   "generated": "$TIME",
 [E]    |   "generator": "pub",
 [E]    |   "generatorVersion": "3.1.2+3",
-[E]    |   "pubCache": "$SANDBOX/cache"
+[E]    |   "pubCache": "file://$SANDBOX/cache"
 [E]    | }
 [E] IO  : Writing $N characters to text file $SANDBOX/cache/log/pub_log.txt.
 
@@ -285,7 +285,7 @@ FINE: Contents:
    |   "generated": "$TIME",
    |   "generator": "pub",
    |   "generatorVersion": "3.1.2+3",
-   |   "pubCache": "$SANDBOX/cache"
+   |   "pubCache": "file://$SANDBOX/cache"
    | }
 ---- End log transcript ----
 -------------------------------- END OF OUTPUT ---------------------------------

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -123,7 +123,7 @@ MSG : Logs written to $SANDBOX/cache/log/pub_log.txt.
 [E]    |   "generated": "$TIME",
 [E]    |   "generator": "pub",
 [E]    |   "generatorVersion": "3.1.2+3",
-[E]    |   "PUB_CACHE": "$SANDBOX/cache"
+[E]    |   "pubCache": "$SANDBOX/cache"
 [E]    | }
 [E] IO  : Writing $N characters to text file $SANDBOX/cache/log/pub_log.txt.
 
@@ -285,7 +285,7 @@ FINE: Contents:
    |   "generated": "$TIME",
    |   "generator": "pub",
    |   "generatorVersion": "3.1.2+3",
-   |   "PUB_CACHE": "$SANDBOX/cache"
+   |   "pubCache": "$SANDBOX/cache"
    | }
 ---- End log transcript ----
 -------------------------------- END OF OUTPUT ---------------------------------


### PR DESCRIPTION
Updates the logic we use in `_isUptoDate`.

Fixes https://github.com/dart-lang/pub/issues/4153

Instead of grepping the lockfile for presence of path-dependencies we compare timestamps against the `pubspec.yaml`s of all packages mentioned in `.dart_tool/package_config.json`. In the "fast" case we avoid reading any other file than `package_config.json`, and avoid dealing with yaml.

This will make `_isUpToDate` possible when we introduce workspace support. We don't need to parse pubspec.yamls to find all packages in the workspace, but can rather just look at all the entries in `package_config.json`.

This PR also adds new entries in package_config.json: pub_cache, flutter_root and flutter_version. If any of these changes, we require a new resolution.

We remove the "checkForSdkUpdate" option. And now always redo resolution when the flutter or dart sdk gets updated. 