### PR TITLE
Refactor test setup for security advisories

### DIFF
--- a/test/get/hosted/advisory_test.dart
+++ b/test/get/hosted/advisory_test.dart
@@ -4,6 +4,7 @@
 
 import '../../descriptor.dart' as d;
 import '../../golden_file.dart';
+import '../../package_server.dart';
 import '../../test_pub.dart';
 
 Future<void> main() async {
@@ -23,10 +24,13 @@ Future<void> main() async {
         },
       }),
     ]).create();
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+
+    server.addAdvisory(
       advisoryId: '123',
-      affectedVersions: ['1.0.0'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.0.0']),
+        AffectedPackage(name: 'foo', ecosystem: 'NotPub', versions: ['1.2.3']),
+      ],
     );
     await ctx.run(['get']);
   });
@@ -46,10 +50,12 @@ Future<void> main() async {
         },
       }),
     ]).create();
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+
+    server.addAdvisory(
       advisoryId: '123',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
     await ctx.run(['get']);
   });
@@ -70,15 +76,18 @@ Future<void> main() async {
       }),
     ]).create();
 
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+    server.addAdvisory(
       advisoryId: '123',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+
+    server.addAdvisory(
       advisoryId: '456',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
     await ctx.run(['get']);
   });
@@ -98,40 +107,48 @@ Future<void> main() async {
         },
       }),
     ]).create();
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+
+    server.addAdvisory(
       advisoryId: '000',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+    server.addAdvisory(
       advisoryId: '111',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+    server.addAdvisory(
       advisoryId: '222',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+    server.addAdvisory(
       advisoryId: '333',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+    server.addAdvisory(
       advisoryId: '444',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+    server.addAdvisory(
       advisoryId: '555',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+    server.addAdvisory(
       advisoryId: '666',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
     await ctx.run(['get']);
   });
@@ -152,10 +169,11 @@ Future<void> main() async {
         },
       }),
     ]).create();
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+    server.addAdvisory(
       advisoryId: '123',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
     await ctx.run(['get']);
   });
@@ -179,15 +197,17 @@ Future<void> main() async {
         },
       ),
     ]).create();
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+    server.addAdvisory(
       advisoryId: '123',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+    server.addAdvisory(
       advisoryId: '456',
-      affectedVersions: ['1.2.3'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
     await ctx.run(['get']);
   });
@@ -211,18 +231,22 @@ Future<void> main() async {
         },
       ),
     ]).create();
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+
+    server.addAdvisory(
       advisoryId: '123',
-      affectedVersions: ['1.2.3'],
       aliases: ['abc', 'def'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
-    server.affectVersionsByAdvisory(
-      packageName: 'foo',
+    server.addAdvisory(
       advisoryId: '456',
-      affectedVersions: ['1.2.3'],
       aliases: ['cde'],
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.2.3']),
+      ],
     );
+
     await ctx.run(['get']);
   });
 }

--- a/test/outdated/outdated_test.dart
+++ b/test/outdated/outdated_test.dart
@@ -4,6 +4,7 @@
 
 import '../descriptor.dart' as d;
 import '../golden_file.dart';
+import '../package_server.dart';
 import '../test_pub.dart';
 
 extension on GoldenTestContext {
@@ -397,17 +398,25 @@ Future<void> main() async {
     ]).create();
     await pubGet();
 
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+    builder.addAdvisory(
       advisoryId: 'ABCD-1234-5678-9101',
-      affectedVersions: ['1.0.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['1.0.0'],
+        ),
+      ],
     );
 
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+    builder.addAdvisory(
       advisoryId: 'EFGH-0000-1111-2222',
       aliases: ['1234-ABCD-EFGH-IJKL'],
-      affectedVersions: ['1.0.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['1.0.0'],
+        ),
+      ],
     );
 
     builder.serve('foo', '1.2.0');
@@ -431,24 +440,37 @@ Future<void> main() async {
     ]).create();
     await pubGet();
 
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+    builder.addAdvisory(
       advisoryId: 'ABCD-1234-5678-9101',
-      affectedVersions: ['1.0.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['1.0.0'],
+        ),
+      ],
     );
 
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+    builder.addAdvisory(
       advisoryId: 'EFGH-0000-1111-2222',
       aliases: ['1234-ABCD-EFGH-IJKL'],
-      affectedVersions: ['1.0.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['1.0.0'],
+        ),
+      ],
     );
 
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+    builder.addAdvisory(
       advisoryId: 'VXYZ-1234-5678-9101',
-      affectedVersions: ['1.0.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['1.0.0'],
+        ),
+      ],
     );
+
     builder.serve('foo', '1.2.0');
     await ctx.runOutdatedTests();
   });
@@ -470,11 +492,16 @@ Future<void> main() async {
     ]).create();
     await pubGet();
 
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+    builder.addAdvisory(
       advisoryId: 'ABCD-1234-5678-9101',
-      affectedVersions: ['0.1.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['0.1.0'],
+        ),
+      ],
     );
+
     builder.serve('foo', '1.2.0');
     await ctx.runOutdatedTests();
   });
@@ -495,11 +522,16 @@ Future<void> main() async {
     ]).create();
     await pubGet();
 
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+    builder.addAdvisory(
       advisoryId: 'ABCD-1234-5678-9101',
-      affectedVersions: ['1.0.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['1.0.0'],
+        ),
+      ],
     );
+
     builder.serve('foo', '1.2.0');
     await ctx.runOutdatedTests();
   });
@@ -521,11 +553,17 @@ Future<void> main() async {
     await pubGet();
 
     builder.retractPackageVersion('foo', '1.0.0');
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+
+    builder.addAdvisory(
       advisoryId: 'ABCD-1234-5678-9101',
-      affectedVersions: ['1.0.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['1.0.0'],
+        ),
+      ],
     );
+
     builder.serve('foo', '1.2.0');
     await ctx.runOutdatedTests();
   });
@@ -546,11 +584,16 @@ Future<void> main() async {
     ]).create();
     await pubGet();
 
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+    builder.addAdvisory(
       advisoryId: 'ABCD-1234-5678-9101',
-      affectedVersions: ['1.2.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['1.2.0'],
+        ),
+      ],
     );
+
     builder.serve('foo', '1.2.0');
     await ctx.runOutdatedTests();
   });
@@ -572,11 +615,16 @@ Future<void> main() async {
     await pubGet();
 
     builder.discontinue('foo');
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+    builder.addAdvisory(
       advisoryId: 'ABCD-1234-5678-9101',
-      affectedVersions: ['1.2.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['1.2.0'],
+        ),
+      ],
     );
+
     builder.serve('foo', '1.2.0');
     await ctx.runOutdatedTests();
   });
@@ -597,11 +645,16 @@ Future<void> main() async {
     ]).create();
     await pubGet();
 
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+    builder.addAdvisory(
       advisoryId: 'ABCD-1234-5678-9101',
-      affectedVersions: ['1.0.0', '1.2.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['1.0.0', '1.2.0'],
+        ),
+      ],
     );
+
     builder.serve('foo', '1.2.0');
     await ctx.runOutdatedTests();
   });
@@ -622,17 +675,26 @@ Future<void> main() async {
     ]).create();
     await pubGet();
 
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+    builder.addAdvisory(
       advisoryId: 'ABCD-1234-5678-9101',
-      affectedVersions: ['1.0.0', '1.2.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['1.0.0', '1.2.0'],
+        ),
+      ],
     );
 
-    builder.affectVersionsByAdvisory(
-      packageName: 'foo',
+    builder.addAdvisory(
       advisoryId: 'VXYZ-1234-5678-9101',
-      affectedVersions: ['1.0.0'],
+      affectedPackages: [
+        AffectedPackage(
+          name: 'foo',
+          versions: ['1.0.0'],
+        ),
+      ],
     );
+
     builder.serve('foo', '1.2.0');
     await ctx.runOutdatedTests();
   });

--- a/test/package_server.dart
+++ b/test/package_server.dart
@@ -156,7 +156,7 @@ class PackageServer {
                       {
                         'package': {
                           'name': package.name,
-                          'ecosystem': package.ecosystem
+                          'ecosystem': package.ecosystem,
                         },
                         'versions': [...package.versions],
                       },


### PR DESCRIPTION
This enables testing security advisories with affected package fields that have other ecosystems specified.