### PR TITLE
Remove Entrypoint._configRoot

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -188,7 +188,9 @@ class Entrypoint {
 
   /// The path to the directory containing dependency executable snapshots.
   String get _snapshotPath => p.join(
-      isCachedGlobal ? rootDir : p.join(rootDir, '.dart_tool/pub'), 'bin');
+        isCachedGlobal ? rootDir : p.join(rootDir, '.dart_tool/pub'),
+        'bin',
+      );
 
   Entrypoint._(
     this.rootDir,

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -78,7 +78,7 @@ Future<int> runExecutable(
   if (!fileExists(executablePath)) {
     var message =
         'Could not find ${log.bold(p.normalize(executable.relativePath))}';
-    if (entrypoint.isGlobal || package != entrypoint.root.name) {
+    if (entrypoint.isCachedGlobal || package != entrypoint.root.name) {
       message += ' in package ${log.bold(package)}';
     }
     log.error('$message.');

--- a/test/global/run/fails_if_sdk_constraint_is_unmet_test.dart
+++ b/test/global/run/fails_if_sdk_constraint_is_unmet_test.dart
@@ -21,30 +21,17 @@ void main() {
       contents: [
         d.dir('bin', [d.file('script.dart', "main(args) => print('ok');")]),
       ],
+      sdk: '3.1.2+3',
     );
 
     await runPub(args: ['global', 'activate', 'foo']);
 
-    await d.hostedCache([
-      d.dir('foo-1.0.0', [d.libPubspec('foo', '1.0.0', sdk: '0.5.6')]),
-    ]).create();
-
-    // Make the snapshot out-of-date, too, so that we load the pubspec with the
-    // SDK constraint in the first place. In practice, the VM snapshot
-    // invalidation logic is based on the version anyway, so this is a safe
-    // assumption.
-    await d.dir(cachePath, [
-      d.dir('global_packages', [
-        d.dir('foo', [
-          d.dir('bin', [d.outOfDateSnapshot('script.dart.snapshot')]),
-        ]),
-      ]),
-    ]).create();
-
     await runPub(
       args: ['global', 'run', 'foo:script'],
-      error: contains("foo 1.0.0 doesn't support Dart 3.1.2+3."),
+      error:
+          contains("foo as globally activated doesn't support Dart 3.1.2+4."),
       exitCode: exit_codes.DATA,
+      environment: {'_PUB_TEST_SDK_VERSION': '3.1.2+4'},
     );
   });
 
@@ -72,7 +59,7 @@ void main() {
         '_PUB_TEST_SDK_VERSION': '3.0.0',
       },
       args: ['global', 'run', 'foo:script'],
-      error: contains("foo 1.0.0 doesn't support Dart 3.0.0."),
+      error: contains("foo as globally activated doesn't support Dart 3.0.0."),
       exitCode: exit_codes.DATA,
     );
   });


### PR DESCRIPTION
Until now `Entrypoint`s of cached global packages had a separate `rootDir` (folder in `<PUB_CACHE>/hosted/<package>`) and `globalDir` (folder in `<PUB_CACHE>/global_packages/<package>`.

Instead with this PR we treat it more like a regular package with a `rootDir` at `<PUB_CACHE>/global_packages/<package>` that has the activated package as a single dependency.

The package layout inside the package folder is still a bit different (using `bin/<snapshot>` instead of `.dart_tool/pub/bin/package/<snapshot>` to store snapshots) so we still maintain a `isCachedGlobal` state.

Globally activated packages from path are different. The `<PUB_CACHE>/global_packages/<package>` folder contains a "fake" pubspec.lock that points to the real package. And that package is used as root for the global activation. This doesn't change with this PR.