### PR TITLE
More robust snapshot deletion

### DIFF
--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -359,7 +359,11 @@ Future<DartExecutableWithPackageConfig> getExecutableForCommand(
     );
   } else {
     final snapshotPath = entrypoint.pathOfExecutable(executable);
-    if (!fileExists(snapshotPath) ||
+    final snapshotStat = tryStatFile(snapshotPath);
+    final packageConfigStat = tryStatFile(packageConfigPath);
+    if (snapshotStat == null ||
+        packageConfigStat == null ||
+        packageConfigStat.modified.isAfter(snapshotStat.modified) ||
         (await entrypoint.packageGraph).isPackageMutable(package)) {
       try {
         await errorsOnlyUnlessTerminal(


### PR DESCRIPTION
Change snapshot deletion to only delete snapshots made by different sdk's.

This is such that the `.dart_tool` folder will not grow without bounds.

This requires that we rebuild even snapshots from mutable packages after pub get. So this pr also adds a timestamp check comparing the snapshot modified time to the `.dart_tool/package_config.json` modified time. And will recompile if the snapshot is older, even for immutable packages.

This is not as bad as it sounds, because we are doing incremental recompilation.

Fixes https://github.com/dart-lang/pub/issues/4161

`pub get` and `dart run` will still race if they are run concurrently from **different** sdks. But that seems acceptable.
