### PR TITLE
Use resident compiler to start test runner

### DIFF
--- a/tool/test.dart
+++ b/tool/test.dart
@@ -1,4 +1,4 @@
-#!/usr/bin/env dart
+#!/usr/bin/env -S dart run -r
 // Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.


### PR DESCRIPTION
Makes running a single test a few seconds faster (after first run)