### PR TITLE
Refactor `Entrypoint.rootDir` preparing for workspaces

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -295,19 +295,19 @@ the \$PUB_HOSTED_URL environment variable.''',
       await entrypoint.acquireDependencies(SolveType.get);
     }
 
-    var files = entrypoint.root.listFiles();
-    log.fine('Archiving and publishing ${entrypoint.root.name}.');
+    var files = entrypoint.workPackage.listFiles();
+    log.fine('Archiving and publishing ${entrypoint.workPackage.name}.');
 
     // Show the package contents so the user can verify they look OK.
-    var package = entrypoint.root;
+    var package = entrypoint.workPackage;
     final host = computeHost(package.pubspec);
     log.message(
       'Publishing ${package.name} ${package.version} to $host:\n'
-      '${tree.fromFiles(files, baseDir: entrypoint.rootDir, showFileSizes: true)}',
+      '${tree.fromFiles(files, baseDir: entrypoint.workPackage.dir, showFileSizes: true)}',
     );
 
     final packageBytes =
-        await createTarGz(files, baseDir: entrypoint.rootDir).toBytes();
+        await createTarGz(files, baseDir: entrypoint.workPackage.dir).toBytes();
 
     log.message(
       '\nTotal compressed archive size: ${_readableFileSize(packageBytes.length)}.\n',

--- a/lib/src/command/remove.dart
+++ b/lib/src/command/remove.dart
@@ -88,7 +88,9 @@ To remove a dependency override of a package prefix the package name with
       /// Update the pubspec.
       _writeRemovalToPubspec(targets);
     }
-    final rootPubspec = entrypoint.root.pubspec;
+    // TODO(https://github.com/dart-lang/pub/issues/4127): This should
+    // operate on entrypoint.workPackage.
+    final rootPubspec = entrypoint.workspaceRoot.pubspec;
     final newPubspec = _removePackagesFromPubspec(rootPubspec, targets);
 
     await entrypoint.withPubspec(newPubspec).acquireDependencies(
@@ -138,7 +140,8 @@ To remove a dependency override of a package prefix the package name with
   void _writeRemovalToPubspec(Iterable<_PackageRemoval> packages) {
     ArgumentError.checkNotNull(packages, 'packages');
 
-    final yamlEditor = YamlEditor(readTextFile(entrypoint.pubspecPath));
+    final yamlEditor =
+        YamlEditor(readTextFile(entrypoint.workspaceRoot.pubspecPath));
 
     for (final package in packages) {
       final dependencyKeys = package.removeFromOverride
@@ -165,13 +168,13 @@ To remove a dependency override of a package prefix the package name with
       }
       if (!found) {
         log.warning(
-          'Package "$name" was not found in ${entrypoint.pubspecPath}!',
+          'Package "$name" was not found in ${entrypoint.workspaceRoot.pubspecPath}!',
         );
       }
     }
 
     /// Windows line endings are already handled by [yamlEditor]
-    writeTextFile(entrypoint.pubspecPath, yamlEditor.toString());
+    writeTextFile(entrypoint.workspaceRoot.pubspecPath, yamlEditor.toString());
   }
 }
 

--- a/lib/src/command/run.dart
+++ b/lib/src/command/run.dart
@@ -69,7 +69,7 @@ class RunCommand extends PubCommand {
       dataError('The --(no-)sound-null-safety flag is no longer supported.');
     }
 
-    var package = entrypoint.root.name;
+    var package = entrypoint.workspaceRoot.name;
     var executable = argResults.rest[0];
     var args = argResults.rest.skip(1).toList();
 

--- a/lib/src/command/unpack.dart
+++ b/lib/src/command/unpack.dart
@@ -144,7 +144,9 @@ in a directory `foo-<version>`.
       } finally {
         log.message('To explore type: cd $destinationDir');
         if (e.example != null) {
-          log.message('To explore the example type: cd ${e.example!.rootDir}');
+          log.message(
+            'To explore the example type: cd ${e.example!.workspaceRoot.dir}',
+          );
         }
       }
     }

--- a/lib/src/command/uploader.dart
+++ b/lib/src/command/uploader.dart
@@ -49,7 +49,7 @@ class UploaderCommand extends PubCommand {
   Future<void> runProtected() async {
     var packageName = '<packageName>';
     try {
-      packageName = entrypoint.root.name;
+      packageName = entrypoint.workspaceRoot.name;
     } on Exception catch (_) {
       // Probably run without a pubspec.
       // Just print error below without a specific package name.

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -56,8 +56,8 @@ Future<int> runExecutable(
 
   // Make sure the package is an immediate dependency of the entrypoint or the
   // entrypoint itself.
-  if (entrypoint.root.name != executable.package &&
-      !entrypoint.root.immediateDependencies.containsKey(package)) {
+  if (entrypoint.workspaceRoot.name != executable.package &&
+      !entrypoint.workspaceRoot.immediateDependencies.containsKey(package)) {
     if ((await entrypoint.packageGraph).packages.containsKey(package)) {
       dataError('Package "$package" is not an immediate dependency.\n'
           'Cannot run executables in transitive dependencies.');
@@ -84,7 +84,7 @@ Future<int> runExecutable(
   if (!fileExists(executablePath)) {
     var message =
         'Could not find ${log.bold(p.normalize(executable.relativePath))}';
-    if (entrypoint.isCachedGlobal || package != entrypoint.root.name) {
+    if (entrypoint.isCachedGlobal || package != entrypoint.workspaceRoot.name) {
       message += ' in package ${log.bold(package)}';
     }
     log.error('$message.');
@@ -95,7 +95,7 @@ Future<int> runExecutable(
     // Since we don't access the package graph, this doesn't happen
     // automatically.
     await Entrypoint.ensureUpToDate(
-      entrypoint.rootDir,
+      entrypoint.workspaceRoot.dir,
       cache: entrypoint.cache,
     );
 

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -182,14 +182,14 @@ class GlobalPackages {
 
     // Get the package's dependencies.
     await entrypoint.acquireDependencies(SolveType.get);
-    var name = entrypoint.root.name;
+    var name = entrypoint.workspaceRoot.name;
     _describeActive(name, cache);
 
     // Write a lockfile that points to the local package.
-    var fullPath = canonicalize(entrypoint.rootDir);
+    var fullPath = canonicalize(entrypoint.workspaceRoot.dir);
     var id = cache.path.idFor(
       name,
-      entrypoint.root.version,
+      entrypoint.workspaceRoot.version,
       fullPath,
       p.current,
     );
@@ -205,7 +205,7 @@ class GlobalPackages {
 
     _updateBinStubs(
       entrypoint,
-      entrypoint.root,
+      entrypoint.workspaceRoot,
       executables,
       overwriteBinStubs: overwriteBinStubs,
     );
@@ -565,7 +565,7 @@ try:
             );
           } else {
             await activatePath(
-              entrypoint.rootDir,
+              entrypoint.workspaceRoot.dir,
               packageExecutables,
               overwriteBinStubs: true,
             );
@@ -618,17 +618,18 @@ try:
         log.fine('Could not parse binstub $file:\n$contents');
         continue;
       }
-      if (binStubPackage == entrypoint.root.name &&
+      if (binStubPackage == entrypoint.workspaceRoot.name &&
           binStubScript ==
               p.basenameWithoutExtension(executable.relativePath)) {
         log.fine('Replacing old binstub $file');
         deleteEntry(file);
         _createBinStub(
-          entrypoint.root,
+          entrypoint.workspaceRoot,
           p.basenameWithoutExtension(file),
           binStubScript,
           overwrite: true,
-          snapshot: executable.pathOfGlobalSnapshot(entrypoint.rootDir),
+          snapshot:
+              executable.pathOfGlobalSnapshot(entrypoint.workspaceRoot.dir),
         );
       }
     }

--- a/lib/src/log.dart
+++ b/lib/src/log.dart
@@ -376,20 +376,31 @@ Platform: ${Platform.operatingSystem}
 ''');
 
   if (entrypoint != null) {
-    buffer.writeln('---- ${p.absolute(entrypoint.pubspecPath)} ----');
-    if (fileExists(entrypoint.pubspecPath)) {
-      buffer.writeln(limitLength(readTextFile(entrypoint.pubspecPath), 5000));
+    // TODO(https://github.com/dart-lang/pub/issues/4127): We probably want to
+    // log all pubspecs in workspace?
+
+    if (entrypoint.canFindWorkspaceRoot) {
+      buffer.writeln(
+        '---- ${p.absolute(entrypoint.workspaceRoot.pubspecPath)} ----',
+      );
+      buffer.writeln(
+        limitLength(
+          readTextFile(entrypoint.workspaceRoot.pubspecPath),
+          5000,
+        ),
+      );
+      buffer.writeln('---- End pubspec.yaml ----');
     } else {
       buffer.writeln('<No pubspec.yaml>');
     }
-    buffer.writeln('---- End pubspec.yaml ----');
-    buffer.writeln('---- ${p.absolute(entrypoint.lockFilePath)} ----');
-    if (fileExists(entrypoint.lockFilePath)) {
+    if (entrypoint.canFindWorkspaceRoot &&
+        fileExists(entrypoint.lockFilePath)) {
+      buffer.writeln('---- ${p.absolute(entrypoint.lockFilePath)} ----');
       buffer.writeln(limitLength(readTextFile(entrypoint.lockFilePath), 5000));
+      buffer.writeln('---- End pubspec.lock ----');
     } else {
       buffer.writeln('<No pubspec.lock>');
     }
-    buffer.writeln('---- End pubspec.lock ----');
   }
 
   buffer.writeln('---- Log transcript ----');

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -45,6 +45,13 @@ class Package {
   /// The parsed pubspec associated with this package.
   final Pubspec pubspec;
 
+  /// The path to the entrypoint package's pubspec.
+  String get pubspecPath => p.normalize(p.join(dir, 'pubspec.yaml'));
+
+  /// The path to the entrypoint package's pubspec overrides file.
+  String get pubspecOverridesPath =>
+      p.normalize(p.join(dir, 'pubspec_overrides.yaml'));
+
   /// The (non-transitive) workspace packages.
   final List<Package> workspaceChildren;
 

--- a/lib/src/package_graph.dart
+++ b/lib/src/package_graph.dart
@@ -38,7 +38,7 @@ class PackageGraph {
     final packages = {
       for (final id in result.packages)
         id.name: id.isRoot
-            ? entrypoint.root
+            ? entrypoint.workspaceRoot
             : Package(
                 result.pubspecs[id.name]!,
                 entrypoint.cache.getDirectory(id),
@@ -55,7 +55,9 @@ class PackageGraph {
   /// dev and override. For any other package, it ignores dev and override
   /// dependencies.
   Set<Package> transitiveDependencies(String package) {
-    if (package == entrypoint.root.name) return packages.values.toSet();
+    if (package == entrypoint.workspaceRoot.name) {
+      return packages.values.toSet();
+    }
 
     if (_transitiveDependencies == null) {
       var closure = transitiveClosure(

--- a/lib/src/pubspec_utils.dart
+++ b/lib/src/pubspec_utils.dart
@@ -5,7 +5,7 @@
 import 'package:collection/collection.dart';
 import 'package:pub_semver/pub_semver.dart';
 
-import 'entrypoint.dart';
+import 'package.dart';
 import 'package_name.dart';
 import 'pubspec.dart';
 import 'source/hosted.dart';
@@ -166,7 +166,7 @@ VersionConstraint stripUpperBound(VersionConstraint constraint) {
 Object pubspecDescription(
   PackageRange range,
   SystemCache cache,
-  Entrypoint relativeEntrypoint,
+  Package receivingPackage,
 ) {
   final description = range.description;
 
@@ -177,8 +177,8 @@ Object pubspecDescription(
   } else {
     return {
       range.source.name: description.serializeForPubspec(
-        containingDir: relativeEntrypoint.rootDir,
-        languageVersion: relativeEntrypoint.root.pubspec.languageVersion,
+        containingDir: receivingPackage.dir,
+        languageVersion: receivingPackage.pubspec.languageVersion,
       ),
       if (!constraint.isAny) 'version': constraint.toString(),
     };

--- a/lib/src/validator/analyze.dart
+++ b/lib/src/validator/analyze.dart
@@ -25,11 +25,11 @@ class AnalyzeValidator extends Validator {
   @override
   Future<void> validate() async {
     final entries = _entriesToAnalyze
-        .map((dir) => p.join(entrypoint.rootDir, dir))
+        .map((dir) => p.join(package.dir, dir))
         .where(entryExists);
     final result = await runProcess(
       Platform.resolvedExecutable,
-      ['analyze', ...entries, p.join(entrypoint.rootDir, 'pubspec.yaml')],
+      ['analyze', ...entries, p.join(package.dir, 'pubspec.yaml')],
     );
     if (result.exitCode != 0) {
       final limitedOutput = limitLength(result.stdout.join('\n'), 1000);

--- a/lib/src/validator/changelog.dart
+++ b/lib/src/validator/changelog.dart
@@ -46,7 +46,7 @@ class ChangelogValidator extends Validator {
       return;
     }
 
-    final version = entrypoint.root.pubspec.version.toString();
+    final version = package.pubspec.version.toString();
 
     if (!contents.contains(version)) {
       warnings.add("$changelog doesn't mention current version ($version).\n"

--- a/lib/src/validator/dependency.dart
+++ b/lib/src/validator/dependency.dart
@@ -37,8 +37,7 @@ class DependencyValidator extends Validator {
     Future warnAboutSource(PackageRange dep) async {
       List<Version> versions;
       try {
-        var ids = await entrypoint.cache
-            .getVersions(entrypoint.cache.hosted.refFor(dep.name));
+        var ids = await cache.getVersions(cache.hosted.refFor(dep.name));
         versions = ids.map((id) => id.version).toList();
       } on ApplicationException catch (_) {
         versions = [];
@@ -88,7 +87,7 @@ class DependencyValidator extends Validator {
     void warnAboutNoConstraint(PackageRange dep) {
       var message = 'Your dependency on "${dep.name}" should have a version '
           'constraint.';
-      var locked = entrypoint.lockFile.packages[dep.name];
+      var locked = context.entrypoint.lockFile.packages[dep.name];
       if (locked != null) {
         message = '$message For example:\n'
             '\n'
@@ -118,7 +117,7 @@ class DependencyValidator extends Validator {
     void warnAboutNoConstraintLowerBound(PackageRange dep) {
       var message =
           'Your dependency on "${dep.name}" should have a lower bound.';
-      var locked = entrypoint.lockFile.packages[dep.name];
+      var locked = context.entrypoint.lockFile.packages[dep.name];
       if (locked != null) {
         String constraint;
         if (locked.version == (dep.constraint as VersionRange).max) {
@@ -160,7 +159,7 @@ class DependencyValidator extends Validator {
     }
 
     void warnAboutPrerelease(String dependencyName, VersionRange constraint) {
-      final packageVersion = entrypoint.root.version;
+      final packageVersion = package.version;
       if (constraint.min != null &&
           constraint.min!.isPreRelease &&
           !packageVersion.isPreRelease) {
@@ -203,6 +202,6 @@ class DependencyValidator extends Validator {
       }
     }
 
-    await validateDependencies(entrypoint.root.pubspec.dependencies.values);
+    await validateDependencies(package.pubspec.dependencies.values);
   }
 }

--- a/lib/src/validator/dependency_override.dart
+++ b/lib/src/validator/dependency_override.dart
@@ -13,13 +13,12 @@ import '../validator.dart';
 class DependencyOverrideValidator extends Validator {
   @override
   Future validate() {
-    var overridden = MapKeySet(entrypoint.root.dependencyOverrides);
-    var dev = MapKeySet(entrypoint.root.devDependencies);
+    var overridden = MapKeySet(package.dependencyOverrides);
+    var dev = MapKeySet(package.devDependencies);
     if (overridden.difference(dev).isNotEmpty) {
-      final overridesFile =
-          entrypoint.root.pubspec.dependencyOverridesFromOverridesFile
-              ? entrypoint.pubspecOverridesPath
-              : entrypoint.pubspecPath;
+      final overridesFile = package.pubspec.dependencyOverridesFromOverridesFile
+          ? package.pubspecOverridesPath
+          : package.pubspecPath;
 
       hints.add('''
 Non-dev dependencies are overridden in $overridesFile.

--- a/lib/src/validator/deprecated_fields.dart
+++ b/lib/src/validator/deprecated_fields.dart
@@ -11,19 +11,19 @@ import '../validator.dart';
 class DeprecatedFieldsValidator extends Validator {
   @override
   Future validate() async {
-    if (entrypoint.root.pubspec.fields.containsKey('transformers')) {
+    if (package.pubspec.fields.containsKey('transformers')) {
       warnings.add('Your pubspec.yaml includes a "transformers" section which'
           ' is no longer used and may be removed.');
     }
-    if (entrypoint.root.pubspec.fields.containsKey('web')) {
+    if (package.pubspec.fields.containsKey('web')) {
       warnings.add('Your pubspec.yaml includes a "web" section which'
           ' is no longer used and may be removed.');
     }
-    if (entrypoint.root.pubspec.fields.containsKey('author')) {
+    if (package.pubspec.fields.containsKey('author')) {
       warnings.add('Your pubspec.yaml includes an "author" section which'
           ' is no longer used and may be removed.');
     }
-    if (entrypoint.root.pubspec.fields.containsKey('authors')) {
+    if (package.pubspec.fields.containsKey('authors')) {
       warnings.add('Your pubspec.yaml includes an "authors" section which'
           ' is no longer used and may be removed.');
     }

--- a/lib/src/validator/devtools_extension.dart
+++ b/lib/src/validator/devtools_extension.dart
@@ -15,12 +15,12 @@ class DevtoolsExtensionValidator extends Validator {
 
   @override
   Future<void> validate() async {
-    if (dirExists(p.join(entrypoint.rootDir, 'extension', 'devtools'))) {
+    if (dirExists(p.join(package.dir, 'extension', 'devtools'))) {
       if (!files.any(
             (f) => p.equals(
               f,
               p.join(
-                entrypoint.rootDir,
+                package.dir,
                 'extension',
                 'devtools',
                 'config.yaml',
@@ -29,7 +29,7 @@ class DevtoolsExtensionValidator extends Validator {
           ) ||
           !files.any(
             (f) => p.isWithin(
-              p.join(entrypoint.rootDir, 'extension', 'devtools', 'build'),
+              p.join(package.dir, 'extension', 'devtools', 'build'),
               f,
             ),
           )) {

--- a/lib/src/validator/directory.dart
+++ b/lib/src/validator/directory.dart
@@ -27,8 +27,8 @@ class DirectoryValidator extends Validator {
     for (final file in files) {
       // Find the topmost directory name of [file].
       final dir = path.join(
-        entrypoint.rootDir,
-        path.split(path.relative(file, from: entrypoint.rootDir)).first,
+        package.dir,
+        path.split(path.relative(file, from: package.dir)).first,
       );
       if (!visited.add(dir)) continue;
       if (!dirExists(dir)) continue;

--- a/lib/src/validator/executable.dart
+++ b/lib/src/validator/executable.dart
@@ -13,10 +13,10 @@ import '../validator.dart';
 class ExecutableValidator extends Validator {
   @override
   Future validate() async {
-    final binFiles =
-        filesBeneath('bin', recursive: false).map(entrypoint.root.relative);
+    final binFiles = filesBeneath('bin', recursive: false)
+        .map(package.relative);
 
-    entrypoint.root.pubspec.executables.forEach((executable, script) {
+    package.pubspec.executables.forEach((executable, script) {
       var scriptPath = p.join('bin', '$script.dart');
       if (binFiles.contains(scriptPath)) return;
 

--- a/lib/src/validator/executable.dart
+++ b/lib/src/validator/executable.dart
@@ -13,8 +13,8 @@ import '../validator.dart';
 class ExecutableValidator extends Validator {
   @override
   Future validate() async {
-    final binFiles = filesBeneath('bin', recursive: false)
-        .map(package.relative);
+    final binFiles =
+        filesBeneath('bin', recursive: false).map(package.relative);
 
     package.pubspec.executables.forEach((executable, script) {
       var scriptPath = p.join('bin', '$script.dart');

--- a/lib/src/validator/flutter_constraint.dart
+++ b/lib/src/validator/flutter_constraint.dart
@@ -15,7 +15,7 @@ class FlutterConstraintValidator extends Validator {
 
   @override
   Future validate() async {
-    final environment = entrypoint.root.pubspec.fields['environment'];
+    final environment = package.pubspec.fields['environment'];
     if (environment is Map) {
       final flutterConstraint = environment['flutter'];
       if (flutterConstraint is String) {

--- a/lib/src/validator/flutter_plugin_format.dart
+++ b/lib/src/validator/flutter_plugin_format.dart
@@ -20,7 +20,7 @@ const _pluginDocsUrl =
 class FlutterPluginFormatValidator extends Validator {
   @override
   Future validate() async {
-    final pubspec = entrypoint.root.pubspec;
+    final pubspec = package.pubspec;
 
     // Ignore all packages that do not have the `flutter.plugin` property.
     if (pubspec.fields['flutter'] is! Map ||

--- a/lib/src/validator/gitignore.dart
+++ b/lib/src/validator/gitignore.dart
@@ -21,7 +21,7 @@ import '../validator.dart';
 class GitignoreValidator extends Validator {
   @override
   Future<void> validate() async {
-    if (entrypoint.root.inGitRepo) {
+    if (package.inGitRepo) {
       late final List<String> checkedIntoGit;
       try {
         checkedIntoGit = git.runSync(
@@ -33,7 +33,7 @@ class GitignoreValidator extends Validator {
             '--exclude-standard',
             '--recurse-submodules',
           ],
-          workingDir: entrypoint.rootDir,
+          workingDir: package.dir,
           stdoutEncoding: Utf8Codec(),
         );
       } on git.GitException catch (e) {
@@ -43,9 +43,9 @@ class GitignoreValidator extends Validator {
         // --recurse-submodules we just continue silently.
         return;
       }
-      final root = git.repoRoot(entrypoint.rootDir) ?? entrypoint.rootDir;
+      final root = git.repoRoot(package.dir) ?? package.dir;
       var beneath = p.posix.joinAll(
-        p.split(p.normalize(p.relative(entrypoint.rootDir, from: root))),
+        p.split(p.normalize(p.relative(package.dir, from: root))),
       );
       if (beneath == './') {
         beneath = '';
@@ -77,7 +77,7 @@ class GitignoreValidator extends Validator {
         },
         isDir: (dir) => dirExists(resolve(dir)),
       ).map((file) {
-        final relative = p.relative(resolve(file), from: entrypoint.rootDir);
+        final relative = p.relative(resolve(file), from: package.dir);
         return Platform.isWindows
             ? p.posix.joinAll(p.split(relative))
             : relative;

--- a/lib/src/validator/leak_detection.dart
+++ b/lib/src/validator/leak_detection.dart
@@ -29,14 +29,14 @@ final class LeakDetectionValidator extends Validator {
   Future<void> validate() async {
     // Load `false_secrets` from `pubspec.yaml`.
     final falseSecrets = Ignore(
-      entrypoint.root.pubspec.falseSecrets,
+      package.pubspec.falseSecrets,
       ignoreCase: Platform.isWindows || Platform.isMacOS,
     );
 
     final pool = Pool(20); // don't read more than 20 files concurrently!
     final leaks = await Future.wait(
       files.map((f) async {
-        final relPath = entrypoint.root.relative(f);
+        final relPath = package.relative(f);
 
         // Skip files matching patterns in `false_secrets`
         final nixPath = p.posix.joinAll(p.split(relPath));

--- a/lib/src/validator/name.dart
+++ b/lib/src/validator/name.dart
@@ -15,15 +15,15 @@ class NameValidator extends Validator {
   @override
   Future validate() {
     return Future.sync(() {
-      _checkName(entrypoint.root.name);
+      _checkName(package.name);
 
       var libraries = _libraries(files);
 
       if (libraries.length == 1) {
         var libName = path.basenameWithoutExtension(libraries[0]);
-        if (libName == entrypoint.root.name) return;
+        if (libName == package.name) return;
         warnings.add('The name of "${libraries[0]}", "$libName", should match '
-            'the name of the package, "${entrypoint.root.name}".\n'
+            'the name of the package, "${package.name}".\n'
             'This helps users know what library to import.');
       }
     });
@@ -32,7 +32,7 @@ class NameValidator extends Validator {
   /// Returns a list of all libraries in the current package as paths relative
   /// to the package's root directory.
   List<String> _libraries(List<String> files) {
-    var libDir = entrypoint.root.path('lib');
+    var libDir = package.path('lib');
     return filesBeneath('lib', recursive: true)
         .map((file) => path.relative(file, from: path.dirname(libDir)))
         .where(

--- a/lib/src/validator/pubspec_field.dart
+++ b/lib/src/validator/pubspec_field.dart
@@ -29,18 +29,18 @@ class PubspecFieldValidator extends Validator {
 
     // Pubspec errors are detected lazily, so we make sure there aren't any
     // here.
-    for (var error in entrypoint.root.pubspec.allErrors) {
+    for (var error in package.pubspec.allErrors) {
       errors.add('In your pubspec.yaml, ${error.message}');
     }
 
     return Future.value();
   }
 
-  bool _hasField(String field) => entrypoint.root.pubspec.fields[field] != null;
+  bool _hasField(String field) => package.pubspec.fields[field] != null;
 
   /// Adds an error if [field] doesn't exist or isn't a string.
   void _validateFieldIsString(String field) {
-    var value = entrypoint.root.pubspec.fields[field];
+    var value = package.pubspec.fields[field];
     if (value == null) {
       errors.add('Your pubspec.yaml is missing a "$field" field.');
     } else if (value is! String) {
@@ -51,7 +51,7 @@ class PubspecFieldValidator extends Validator {
 
   /// Adds an error if the URL for [field] is invalid.
   void _validateFieldUrl(String field) {
-    var url = entrypoint.root.pubspec.fields[field];
+    var url = package.pubspec.fields[field];
     if (url == null) return;
 
     if (url is! String) {

--- a/lib/src/validator/pubspec_typo.dart
+++ b/lib/src/validator/pubspec_typo.dart
@@ -9,7 +9,7 @@ import '../validator.dart';
 class PubspecTypoValidator extends Validator {
   @override
   Future validate() async {
-    final fields = entrypoint.root.pubspec.fields;
+    final fields = package.pubspec.fields;
 
     /// Limit the number of typo warnings so as not to drown out the other
     /// warnings

--- a/lib/src/validator/relative_version_numbering.dart
+++ b/lib/src/validator/relative_version_numbering.dart
@@ -49,8 +49,8 @@ The latest published version is $latestVersion.
 Your version $currentVersion is earlier than that.''');
     }
 
-    final previousRelease = existingVersions
-        .lastWhereOrNull((id) => id.version < package.version);
+    final previousRelease =
+        existingVersions.lastWhereOrNull((id) => id.version < package.version);
 
     if (previousRelease == null) return;
 
@@ -90,8 +90,7 @@ Consider one of:
 
     final previousPubspec = await cache.describe(previousRelease);
 
-    final currentOptedIn =
-        package.pubspec.languageVersion.supportsNullSafety;
+    final currentOptedIn = package.pubspec.languageVersion.supportsNullSafety;
     final previousOptedIn = previousPubspec.languageVersion.supportsNullSafety;
 
     if (currentOptedIn && !previousOptedIn) {

--- a/lib/src/validator/relative_version_numbering.dart
+++ b/lib/src/validator/relative_version_numbering.dart
@@ -25,18 +25,21 @@ class RelativeVersionNumberingValidator extends Validator {
 
   @override
   Future<void> validate() async {
-    final hostedSource = entrypoint.cache.hosted;
+    final hostedSource = cache.hosted;
     List<PackageId> existingVersions;
     try {
-      existingVersions = await entrypoint.cache.getVersions(
-        hostedSource.refFor(entrypoint.root.name, url: serverUrl.toString()),
+      existingVersions = await cache.getVersions(
+        hostedSource.refFor(
+          package.name,
+          url: serverUrl.toString(),
+        ),
       );
     } on PackageNotFoundException {
       existingVersions = [];
     }
     existingVersions.sort((a, b) => a.version.compareTo(b.version));
 
-    final currentVersion = entrypoint.root.pubspec.version;
+    final currentVersion = package.pubspec.version;
 
     final latestVersion =
         existingVersions.isEmpty ? null : existingVersions.last.version;
@@ -47,7 +50,7 @@ Your version $currentVersion is earlier than that.''');
     }
 
     final previousRelease = existingVersions
-        .lastWhereOrNull((id) => id.version < entrypoint.root.version);
+        .lastWhereOrNull((id) => id.version < package.version);
 
     if (previousRelease == null) return;
 
@@ -85,10 +88,10 @@ Consider one of:
       hints.add(hint + suggestion);
     }
 
-    final previousPubspec = await entrypoint.cache.describe(previousRelease);
+    final previousPubspec = await cache.describe(previousRelease);
 
     final currentOptedIn =
-        entrypoint.root.pubspec.languageVersion.supportsNullSafety;
+        package.pubspec.languageVersion.supportsNullSafety;
     final previousOptedIn = previousPubspec.languageVersion.supportsNullSafety;
 
     if (currentOptedIn && !previousOptedIn) {

--- a/lib/src/validator/sdk_constraint.dart
+++ b/lib/src/validator/sdk_constraint.dart
@@ -18,7 +18,7 @@ import '../validator.dart';
 class SdkConstraintValidator extends Validator {
   @override
   Future validate() async {
-    final dartConstraint = entrypoint.root.pubspec.dartSdkConstraint;
+    final dartConstraint = package.pubspec.dartSdkConstraint;
     final originalConstraint = dartConstraint.originalConstraint;
     final effectiveConstraint = dartConstraint.effectiveConstraint;
     if (originalConstraint is VersionRange) {
@@ -32,7 +32,7 @@ class SdkConstraintValidator extends Validator {
       }
 
       final constraintMin = originalConstraint.min;
-      final packageVersion = entrypoint.root.version;
+      final packageVersion = package.version;
 
       if (constraintMin != null &&
           constraintMin.isPreRelease &&

--- a/lib/src/validator/size.dart
+++ b/lib/src/validator/size.dart
@@ -17,17 +17,17 @@ class SizeValidator extends Validator {
     if (packageSize <= _maxSize) return;
     var sizeInMb = (packageSize / (1 << 20)).toStringAsPrecision(4);
     // Current implementation of Package.listFiles skips hidden files
-    var ignoreExists = fileExists(entrypoint.root.path('.gitignore'));
+    var ignoreExists = fileExists(package.path('.gitignore'));
 
     var hint = StringBuffer('''
 Your package is $sizeInMb MB.
 
 Consider the impact large downloads can have on the package consumer.''');
 
-    if (ignoreExists && !entrypoint.root.inGitRepo) {
+    if (ignoreExists && !package.inGitRepo) {
       hint.write('\nYour .gitignore has no effect since your project '
           'does not appear to be in version control.');
-    } else if (!ignoreExists && entrypoint.root.inGitRepo) {
+    } else if (!ignoreExists && package.inGitRepo) {
       hint.write('\nConsider adding a .gitignore to avoid including '
           'temporary files.');
     }

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -23,7 +23,7 @@ class StrictDependenciesValidator extends Validator {
   /// Files that do not parse and directives that don't import or export
   /// `package:` URLs are ignored.
   Iterable<_Usage> _findPackages(Iterable<String> files) sync* {
-    final packagePath = p.normalize(p.absolute(entrypoint.rootDir));
+    final packagePath = p.normalize(p.absolute(package.dir));
     final analysisContextManager = AnalysisContextManager(packagePath);
 
     for (var file in files) {
@@ -63,9 +63,8 @@ class StrictDependenciesValidator extends Validator {
 
   @override
   Future validate() async {
-    var dependencies = entrypoint.root.dependencies.keys.toSet()
-      ..add(entrypoint.root.name);
-    var devDependencies = MapKeySet(entrypoint.root.devDependencies);
+    var dependencies = package.dependencies.keys.toSet()..add(package.name);
+    var devDependencies = MapKeySet(package.devDependencies);
     _validateLibBin(dependencies, devDependencies);
     _validateBenchmarkTestTool(dependencies, devDependencies);
   }

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -33,7 +33,7 @@ void main() {
     createEntrypoint();
 
     expect(
-      entrypoint!.root.listFiles(),
+      entrypoint!.workspaceRoot.listFiles(),
       unorderedEquals([
         p.join(root, 'pubspec.yaml'),
         p.join(root, 'file1.txt'),
@@ -75,7 +75,7 @@ void main() {
     createEntrypoint();
 
     expect(
-      () => entrypoint!.root.listFiles(),
+      () => entrypoint!.workspaceRoot.listFiles(),
       throwsA(
         isA<DataException>().having(
           (e) => e.message,
@@ -106,7 +106,7 @@ void main() {
       SystemCache(rootDir: p.join(d.sandbox, cachePath)),
     );
 
-    expect(entrypoint.root.listFiles(), {
+    expect(entrypoint.workspaceRoot.listFiles(), {
       p.join(root, 'pubspec.yaml'),
       p.join(root, 'file1.txt'),
       p.join(root, 'file2.txt'),
@@ -129,7 +129,7 @@ void main() {
     createEntrypoint();
 
     expect(
-      () => entrypoint!.root.listFiles(),
+      () => entrypoint!.workspaceRoot.listFiles(),
       throwsA(
         isA<DataException>().having(
           (e) => e.message,
@@ -158,7 +158,7 @@ void main() {
     createEntrypoint();
 
     expect(
-      () => entrypoint!.root.listFiles(),
+      () => entrypoint!.workspaceRoot.listFiles(),
       throwsA(
         isA<DataException>().having(
           (e) => e.message,
@@ -177,7 +177,7 @@ void main() {
       d.file('.foo', ''),
     ]).create();
     createEntrypoint();
-    expect(entrypoint!.root.listFiles(), {
+    expect(entrypoint!.workspaceRoot.listFiles(), {
       p.join(root, '.foo'),
       p.join(root, 'pubspec.yaml'),
     });
@@ -201,7 +201,7 @@ void main() {
         ]),
       ]).create();
 
-      expect(entrypoint!.root.listFiles(), {
+      expect(entrypoint!.workspaceRoot.listFiles(), {
         p.join(root, 'pubspec.yaml'),
         p.join(root, 'file1.txt'),
         p.join(root, 'file2.txt'),
@@ -221,7 +221,7 @@ void main() {
         ]),
       ]).create();
 
-      expect(entrypoint!.root.listFiles(), {
+      expect(entrypoint!.workspaceRoot.listFiles(), {
         p.join(root, 'pubspec.yaml'),
         p.join(root, 'file2.text'),
         p.join(root, 'subdir', 'subfile2.text'),
@@ -254,7 +254,7 @@ void main() {
 
       createEntrypoint(p.join(appPath, 'rep', 'sub'));
 
-      expect(entrypoint!.root.listFiles(), {
+      expect(entrypoint!.workspaceRoot.listFiles(), {
         p.join(root, 'pubspec.yaml'),
         p.join(root, 'file2.text'),
         p.join(root, 'file4.gak'),
@@ -284,7 +284,7 @@ void main() {
       });
 
       test('respects its .gitignore with useGitIgnore', () {
-        expect(entrypoint!.root.listFiles(), {
+        expect(entrypoint!.workspaceRoot.listFiles(), {
           p.join(root, 'pubspec.yaml'),
           p.join(root, 'submodule', 'file2.text'),
         });
@@ -297,7 +297,10 @@ void main() {
         d.dir('subdir', [d.file('pubspec.lock')]),
       ]).create();
 
-      expect(entrypoint!.root.listFiles(), {p.join(root, 'pubspec.yaml')});
+      expect(
+        entrypoint!.workspaceRoot.listFiles(),
+        {p.join(root, 'pubspec.yaml')},
+      );
     });
 
     test('allows pubspec.lock directories', () async {
@@ -307,7 +310,7 @@ void main() {
         ]),
       ]).create();
 
-      expect(entrypoint!.root.listFiles(), {
+      expect(entrypoint!.workspaceRoot.listFiles(), {
         p.join(root, 'pubspec.yaml'),
         p.join(root, 'pubspec.lock', 'file.txt'),
       });
@@ -328,7 +331,7 @@ void main() {
           ]),
         ]).create();
 
-        expect(entrypoint!.root.listFiles(beneath: 'subdir'), {
+        expect(entrypoint!.workspaceRoot.listFiles(beneath: 'subdir'), {
           p.join(root, 'subdir', 'subfile1.txt'),
           p.join(root, 'subdir', 'subfile2.txt'),
           p.join(root, 'subdir', 'subsubdir', 'subsubfile1.txt'),
@@ -347,7 +350,7 @@ void main() {
         d.dir('lib', [d.file('not_ignored.dart', 'content')]),
       ]).create();
       createEntrypoint();
-      expect(entrypoint!.root.listFiles(), {
+      expect(entrypoint!.workspaceRoot.listFiles(), {
         p.join(root, 'LICENSE'),
         p.join(root, 'CHANGELOG.md'),
         p.join(root, 'README.md'),
@@ -399,7 +402,7 @@ void main() {
     ]).create();
 
     createEntrypoint();
-    expect(entrypoint!.root.listFiles(), {
+    expect(entrypoint!.workspaceRoot.listFiles(), {
       p.join(root, 'pubspec.yaml'),
       p.join(root, 'not_ignored_by_gitignore.txt'),
       p.join(root, 'ignored_by_gitignore.txt'),
@@ -431,7 +434,7 @@ void main() {
         await repo.create();
         createEntrypoint(p.join(appPath, 'packages', 'nested'));
 
-        expect(entrypoint!.root.listFiles(), {
+        expect(entrypoint!.workspaceRoot.listFiles(), {
           p.join(root, 'pubspec.yaml'),
         });
       });
@@ -449,7 +452,7 @@ void main() {
         await repo.create();
         createEntrypoint(p.join(appPath, 'packages', 'nested'));
 
-        expect(entrypoint!.root.listFiles(), {
+        expect(entrypoint!.workspaceRoot.listFiles(), {
           p.join(root, 'pubspec.yaml'),
           p.join(root, 'bin'),
         });
@@ -470,7 +473,7 @@ void main() {
         await repo.create();
         createEntrypoint(p.join(appPath, 'packages', 'nested'));
 
-        expect(entrypoint!.root.listFiles(), {
+        expect(entrypoint!.workspaceRoot.listFiles(), {
           p.join(root, 'pubspec.yaml'),
         });
       });
@@ -493,7 +496,7 @@ void main() {
         await repo.create();
         createEntrypoint(p.join(appPath, 'packages', 'nested'));
 
-        expect(entrypoint!.root.listFiles(), {
+        expect(entrypoint!.workspaceRoot.listFiles(), {
           p.join(root, 'pubspec.yaml'),
           p.join(root, 'bin', 'nested_again', 'run.dart'),
         });
@@ -518,7 +521,7 @@ void main() {
         await repo.create();
         createEntrypoint(p.join(appPath, 'packages', 'nested'));
 
-        expect(entrypoint!.root.listFiles(), {
+        expect(entrypoint!.workspaceRoot.listFiles(), {
           p.join(root, 'pubspec.yaml'),
           p.join(root, 'bin', 'run.dart'),
         });
@@ -545,7 +548,7 @@ void main() {
       await repo.create();
       createEntrypoint(p.join(appPath, 'packages', 'nested'));
 
-      expect(entrypoint!.root.listFiles(), {
+      expect(entrypoint!.workspaceRoot.listFiles(), {
         p.join(root, 'pubspec.yaml'),
         p.join(root, 'bin', 'nested_again', 'run.dart'),
       });
@@ -569,7 +572,7 @@ void main() {
       await repo.create();
       createEntrypoint(p.join(appPath, 'packages', 'nested'));
 
-      expect(entrypoint!.root.listFiles(), {
+      expect(entrypoint!.workspaceRoot.listFiles(), {
         p.join(root, 'pubspec.yaml'),
         p.join(root, 'bin', 'run.dart'),
         p.join(root, 'bin', 'nested_again', 'run.dart'),

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -911,7 +911,7 @@ Future<Validator> validatePackage(ValidatorCreator fn, int? size) async {
     _globalServer == null
         ? Uri.parse('https://pub.dev')
         : Uri.parse(globalServer.url),
-    entrypoint.root.listFiles(),
+    entrypoint.workspaceRoot.listFiles(),
   );
   await validator.validate();
   return validator;

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -331,12 +331,8 @@ PUB_CACHE: "$SANDBOX/cache"
 Command: dart pub fail
 Platform: $OS
 
----- $SANDBOX/empty/pubspec.yaml ----
 <No pubspec.yaml>
----- End pubspec.yaml ----
----- $SANDBOX/empty/pubspec.lock ----
 <No pubspec.lock>
----- End pubspec.lock ----
 ---- Log transcript ----
 FINE: Pub 3.1.2+3
 ERR : Bad state: Pub has crashed


### PR DESCRIPTION
An entrypoint now no longer knows a single `rootDir`. Instead it knows:

`workingDir`: the directory that the entrypoint is created around. Typically this is the current working dir.
`workspaceRoot` The root package of the workspace
`workPackage` The package closest to the workingDir.

This PR still just has `workPackage = workspaceRoot = Package(workingDir)` but should be easy to review.
A follow-up will do the actual search in the file system.
