### PR TITLE
rename RetrieveFlags.option to RetrieveFlags.optionWithDefault

### DIFF
--- a/bin/dependency_services.dart
+++ b/bin/dependency_services.dart
@@ -21,7 +21,7 @@ import 'package:pub/src/utils.dart';
 class _DependencyServicesCommandRunner extends CommandRunner<int>
     implements PubTopLevel {
   @override
-  String get directory => argResults.option('directory');
+  String get directory => argResults.optionWithDefault('directory');
 
   @override
   bool get captureStackChains => argResults.flag('verbose');

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -45,7 +45,9 @@ class LishCommand extends PubCommand {
     // An explicit argument takes precedence.
     if (argResults.wasParsed('server')) {
       try {
-        return validateAndNormalizeHostedUrl(argResults.option('server'));
+        return validateAndNormalizeHostedUrl(
+          argResults.optionWithDefault('server'),
+        );
       } on FormatException catch (e) {
         usageException('Invalid server: $e');
       }

--- a/lib/src/command/uploader.dart
+++ b/lib/src/command/uploader.dart
@@ -23,7 +23,7 @@ class UploaderCommand extends PubCommand {
   bool get hidden => true;
 
   /// The URL of the package hosting server.
-  Uri get server => Uri.parse(argResults.option('server'));
+  Uri get server => Uri.parse(argResults.optionWithDefault('server'));
 
   UploaderCommand() {
     argParser.addOption(

--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -44,7 +44,7 @@ bool _isRunningInsideFlutter =
 
 class PubCommandRunner extends CommandRunner<int> implements PubTopLevel {
   @override
-  String get directory => argResults.option('directory');
+  String get directory => argResults.optionWithDefault('directory');
 
   @override
   bool get captureStackChains {

--- a/lib/src/pub_embeddable_command.dart
+++ b/lib/src/pub_embeddable_command.dart
@@ -39,7 +39,7 @@ class PubEmbeddableCommand extends PubCommand implements PubTopLevel {
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-global';
 
   @override
-  String get directory => argResults.option('directory');
+  String get directory => argResults.optionWithDefault('directory');
 
   final bool Function() isVerbose;
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -764,7 +764,7 @@ Future<T> retry<T>(
 extension RetrieveFlags on ArgResults {
   bool flag(String name) => this[name] as bool;
 
-  String option(String name) => this[name] as String;
+  String optionWithDefault(String name) => this[name] as String;
   String? optionWithoutDefault(String name) => this[name] as String?;
 }
 


### PR DESCRIPTION
- rename `RetrieveFlags.option` to `RetrieveFlags.optionWithDefault`

This rename will let us land https://github.com/dart-lang/args/pull/248 in the sdk repo; without this, the new `option()` method is used instead of the RetrieveFlags.option extension method, and the two have different return types (`String?` vs `String`).

```
output: ../../third_party/pkg/pub/lib/src/command/lish.dart:48:57: Error: The argument type 'String?' can't be assigned to the parameter type 'String' because 'String?' is nullable and 'String' isn't.
        return validateAndNormalizeHostedUrl(argResults.option('server'));
                                                        ^
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
