### PR TITLE
Use existing server for test

### DIFF
--- a/test/lish/uses_publish_to_url_test.dart
+++ b/test/lish/uses_publish_to_url_test.dart
@@ -11,12 +11,13 @@ import '../test_pub.dart';
 
 void main() {
   test('uses the publish_to URL', () async {
+    final server = await servePackages();
     var pkg = packageMap('test_pkg', '1.0.0');
-    pkg['publish_to'] = 'http://example.com';
+    pkg['publish_to'] = server.url;
     await d.dir(appPath, [d.pubspec(pkg)]).create();
     await runPub(
       args: ['lish', '--dry-run'],
-      output: contains('Publishing test_pkg 1.0.0 to http://example.com'),
+      output: contains('Publishing test_pkg 1.0.0 to ${server.url}'),
       exitCode: exit_codes.DATA,
     );
   });


### PR DESCRIPTION
Seems like requesting from example.com is flaky in the CI. So set up a fake server and use that for validations.

Should fix https://github.com/dart-lang/pub/issues/4177