### PR TITLE
Import package:path `as p` everywhere

### DIFF
--- a/lib/src/ascii_tree.dart
+++ b/lib/src/ascii_tree.dart
@@ -8,7 +8,7 @@ library;
 
 import 'dart:io';
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 
 import 'log.dart' as log;
 import 'utils.dart';
@@ -69,10 +69,10 @@ String fromFiles(
   var root = <String, Map>{};
   for (var file in files) {
     final relativeFile =
-        baseDir == null ? file : path.relative(file, from: baseDir);
-    final parts = path.split(relativeFile);
+        baseDir == null ? file : p.relative(file, from: baseDir);
+    final parts = p.split(relativeFile);
     if (showFileSizes) {
-      final size = File(path.normalize(file)).statSync().size;
+      final size = File(p.normalize(file)).statSync().size;
       final sizeString = _readableFileSize(size);
       parts.last = '${parts.last} $sizeString';
     }

--- a/lib/src/authentication/token_store.dart
+++ b/lib/src/authentication/token_store.dart
@@ -5,7 +5,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 
 import '../exceptions.dart';
 import '../io.dart';
@@ -101,7 +101,7 @@ class TokenStore {
     if (tokensFile == null) {
       missingConfigDir();
     }
-    ensureDir(path.dirname(tokensFile));
+    ensureDir(p.dirname(tokensFile));
     writeTextFile(
       tokensFile,
       jsonEncode(<String, dynamic>{
@@ -187,6 +187,6 @@ class TokenStore {
   /// `null` if no config directory could be found.
   String? get tokensFile {
     var dir = configDir;
-    return dir == null ? null : path.join(dir, 'pub-tokens.json');
+    return dir == null ? null : p.join(dir, 'pub-tokens.json');
   }
 }

--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:collection/collection.dart' show IterableExtension;
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 
 import '../command.dart';
 import '../command_runner.dart';
@@ -379,7 +379,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
         showTransitiveDependencies: showTransitiveDependencies,
         hasUpgradableResolution: hasUpgradableResolution,
         hasResolvableResolution: hasResolvableResolution,
-        directory: path.normalize(directory),
+        directory: p.normalize(directory),
       );
     }
   }

--- a/lib/src/oauth2.dart
+++ b/lib/src/oauth2.dart
@@ -12,7 +12,7 @@ import 'package:crypto/crypto.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/retry.dart';
 import 'package:http_parser/http_parser.dart';
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf_io;
 
@@ -202,7 +202,7 @@ void _saveCredentials(Credentials credentials) {
   _credentials = credentials;
   var credentialsPath = _credentialsFile();
   if (credentialsPath != null) {
-    ensureDir(path.dirname(credentialsPath));
+    ensureDir(p.dirname(credentialsPath));
     writeTextFile(credentialsPath, credentials.toJson(), dontLogContents: true);
   }
 }
@@ -212,9 +212,7 @@ void _saveCredentials(Credentials credentials) {
 /// Returns `null` if there is no good place for the file.
 String? _credentialsFile() {
   final configDir = dartConfigDir;
-  return configDir == null
-      ? null
-      : path.join(configDir, 'pub-credentials.json');
+  return configDir == null ? null : p.join(configDir, 'pub-credentials.json');
 }
 
 /// Gets the user to authorize pub as a client of pub.dev via oauth2.

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -3,7 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:collection/collection.dart' hide mapMap;
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
@@ -265,8 +265,8 @@ class Pubspec extends PubspecBase {
     bool allowOverridesFile = false,
     required Description containingDescription,
   }) {
-    var pubspecPath = path.join(packageDir, pubspecYamlFilename);
-    var overridesPath = path.join(packageDir, pubspecOverridesFilename);
+    var pubspecPath = p.join(packageDir, pubspecYamlFilename);
+    var overridesPath = p.join(packageDir, pubspecOverridesFilename);
     if (!fileExists(pubspecPath)) {
       throw FileException(
         // Make the package dir absolute because for the entrypoint it'll just
@@ -285,9 +285,9 @@ class Pubspec extends PubspecBase {
       readTextFile(pubspecPath),
       sources,
       expectedName: expectedName,
-      location: path.toUri(pubspecPath),
+      location: p.toUri(pubspecPath),
       overridesFileContents: overridesFileContents,
-      overridesLocation: path.toUri(overridesPath),
+      overridesLocation: p.toUri(overridesPath),
       containingDescription: containingDescription,
     );
   }

--- a/lib/src/source/cached.dart
+++ b/lib/src/source/cached.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 
 import '../io.dart';
@@ -28,7 +28,7 @@ abstract class CachedSource extends Source {
   @override
   Future<Pubspec> doDescribe(PackageId id, SystemCache cache) async {
     var packageDir = getDirectoryInCache(id, cache);
-    if (fileExists(path.join(packageDir, 'pubspec.yaml'))) {
+    if (fileExists(p.join(packageDir, 'pubspec.yaml'))) {
       return Pubspec.load(
         packageDir,
         cache.sources,

--- a/lib/src/validator/compiled_dartdoc.dart
+++ b/lib/src/validator/compiled_dartdoc.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 
 import '../io.dart';
 import '../validator.dart';
@@ -15,21 +15,21 @@ class CompiledDartdocValidator extends Validator {
   Future validate() {
     return Future.sync(() {
       for (var entry in files) {
-        if (path.basename(entry) != 'nav.json') continue;
-        var dir = path.dirname(entry);
+        if (p.basename(entry) != 'nav.json') continue;
+        var dir = p.dirname(entry);
 
         // Look for tell-tale Dartdoc output files all in the same directory.
         var files = [
           entry,
-          path.join(dir, 'index.html'),
-          path.join(dir, 'styles.css'),
-          path.join(dir, 'dart-logo-small.png'),
-          path.join(dir, 'client-live-nav.js'),
+          p.join(dir, 'index.html'),
+          p.join(dir, 'styles.css'),
+          p.join(dir, 'dart-logo-small.png'),
+          p.join(dir, 'client-live-nav.js'),
         ];
 
         if (files.every(fileExists)) {
           warnings.add('Avoid putting generated documentation in '
-              '${path.relative(dir)}.\n'
+              '${p.relative(dir)}.\n'
               'Generated documentation bloats the package with redundant '
               'data.');
         }

--- a/lib/src/validator/directory.dart
+++ b/lib/src/validator/directory.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 
 import '../io.dart';
 import '../validator.dart';
@@ -26,14 +26,14 @@ class DirectoryValidator extends Validator {
     final visited = <String>{};
     for (final file in files) {
       // Find the topmost directory name of [file].
-      final dir = path.join(
+      final dir = p.join(
         package.dir,
-        path.split(path.relative(file, from: package.dir)).first,
+        p.split(p.relative(file, from: package.dir)).first,
       );
       if (!visited.add(dir)) continue;
       if (!dirExists(dir)) continue;
 
-      final dirName = path.basename(dir);
+      final dirName = p.basename(dir);
       if (_pluralNames.contains(dirName)) {
         // Cut off the "s"
         var singularName = dirName.substring(0, dirName.length - 1);

--- a/lib/src/validator/name.dart
+++ b/lib/src/validator/name.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 
 import '../utils.dart';
 import '../validator.dart';
@@ -20,7 +20,7 @@ class NameValidator extends Validator {
       var libraries = _libraries(files);
 
       if (libraries.length == 1) {
-        var libName = path.basenameWithoutExtension(libraries[0]);
+        var libName = p.basenameWithoutExtension(libraries[0]);
         if (libName == package.name) return;
         warnings.add('The name of "${libraries[0]}", "$libName", should match '
             'the name of the package, "${package.name}".\n'
@@ -34,11 +34,10 @@ class NameValidator extends Validator {
   List<String> _libraries(List<String> files) {
     var libDir = package.path('lib');
     return filesBeneath('lib', recursive: true)
-        .map((file) => path.relative(file, from: path.dirname(libDir)))
+        .map((file) => p.relative(file, from: p.dirname(libDir)))
         .where(
           (file) =>
-              !path.split(file).contains('src') &&
-              path.extension(file) == '.dart',
+              !p.split(file).contains('src') && p.extension(file) == '.dart',
         )
         .toList();
   }

--- a/test/add/path/absolute_path_test.dart
+++ b/test/add/path/absolute_path_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:test/test.dart';
 
@@ -16,7 +16,7 @@ void main() {
 
     await d.appDir(dependencies: {}).create();
 
-    final absolutePath = path.join(d.sandbox, 'foo');
+    final absolutePath = p.join(d.sandbox, 'foo');
 
     await pubAdd(args: ['foo', '--path', absolutePath]);
 
@@ -36,7 +36,7 @@ void main() {
         .dir('foo', [d.libDir('foo'), d.libPubspec('foo', '0.0.1')]).create();
 
     await d.appDir(dependencies: {}).create();
-    final absolutePath = path.join(d.sandbox, 'foo');
+    final absolutePath = p.join(d.sandbox, 'foo');
 
     await pubAdd(args: ['foo:0.0.1', '--path', absolutePath]);
 
@@ -56,7 +56,7 @@ void main() {
     ).create();
 
     await d.appDir(dependencies: {}).create();
-    final absolutePath = path.join(d.sandbox, 'foo');
+    final absolutePath = p.join(d.sandbox, 'foo');
 
     await pubAdd(
       args: ['foo:2.0.0', 'bar:0.1.3', 'baz:1.3.1', '--path', absolutePath],
@@ -80,7 +80,7 @@ void main() {
     ).create();
 
     await d.appDir(dependencies: {}).create();
-    final absolutePath = path.join(d.sandbox, 'foo');
+    final absolutePath = p.join(d.sandbox, 'foo');
 
     await pubAdd(
       args: ['foo:2.0.0', '--path', absolutePath],
@@ -101,7 +101,7 @@ void main() {
   test('fails if path does not exist', () async {
     await d.appDir(dependencies: {}).create();
 
-    final absolutePath = path.join(d.sandbox, 'foo');
+    final absolutePath = p.join(d.sandbox, 'foo');
 
     await pubAdd(
       args: ['foo', '--path', absolutePath],
@@ -133,7 +133,7 @@ void main() {
       }),
     ]).create();
 
-    final absolutePath = path.join(d.sandbox, 'foo');
+    final absolutePath = p.join(d.sandbox, 'foo');
     await pubAdd(args: ['foo', '--path', absolutePath]);
 
     await d.cacheDir({'foo': '1.2.2'}).validate();

--- a/test/cache/clean_test.dart
+++ b/test/cache/clean_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/io.dart';
 import 'package:test/test.dart';
 
@@ -11,7 +11,7 @@ import '../test_pub.dart';
 
 void main() {
   test('running pub cache clean when there is no cache', () async {
-    final cache = path.join(d.sandbox, cachePath);
+    final cache = p.join(d.sandbox, cachePath);
 
     await runPub(args: ['cache', 'clean'], output: 'No pub cache at $cache.');
   });
@@ -22,7 +22,7 @@ void main() {
       ..serve('bar', '1.2.3');
     await d.appDir(dependencies: {'foo': 'any', 'bar': 'any'}).create();
     await pubGet();
-    final cache = path.join(d.sandbox, cachePath);
+    final cache = p.join(d.sandbox, cachePath);
     expect(listDir(cache, includeHidden: true), contains(endsWith('hosted')));
     await runPub(
       args: ['cache', 'clean', '--force'],
@@ -43,7 +43,7 @@ void main() {
       ..serve('bar', '1.2.3');
     await d.appDir(dependencies: {'foo': 'any', 'bar': 'any'}).create();
     await pubGet();
-    final cache = path.join(d.sandbox, cachePath);
+    final cache = p.join(d.sandbox, cachePath);
     expect(
       listDir(cache, includeHidden: true),
       contains(pathInCache('hosted')),

--- a/test/cache/list_test.dart
+++ b/test/cache/list_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
@@ -10,7 +10,7 @@ import '../test_pub.dart';
 
 void main() {
   String hostedDir(String package) {
-    return path.join(d.sandbox, cachePath, 'hosted', 'pub.dev', package);
+    return p.join(d.sandbox, cachePath, 'hosted', 'pub.dev', package);
   }
 
   test('running pub cache list when there is no cache', () async {

--- a/test/cache/repair/git_test.dart
+++ b/test/cache/repair/git_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/io.dart';
 import 'package:test/test.dart';
@@ -36,14 +36,14 @@ void main() {
 
     test('reinstalls previously cached git packages', () async {
       // Find the cached foo packages for each revision.
-      var gitCacheDir = path.join(d.sandbox, cachePath, 'git');
+      var gitCacheDir = p.join(d.sandbox, cachePath, 'git');
       var fooDirs = listDir(gitCacheDir)
-          .where((dir) => path.basename(dir).startsWith('foo-'))
+          .where((dir) => p.basename(dir).startsWith('foo-'))
           .toList();
 
       // Delete "foo.dart" from them.
       for (var dir in fooDirs) {
-        deleteEntry(path.join(dir, 'lib', 'foo.dart'));
+        deleteEntry(p.join(dir, 'lib', 'foo.dart'));
       }
 
       // Repair them.
@@ -57,7 +57,7 @@ void main() {
 
       // The missing libraries should have been replaced.
       var fooLibs = fooDirs.map((dir) {
-        var fooDirName = path.basename(dir);
+        var fooDirName = p.basename(dir);
         return d.dir(fooDirName, [
           d.dir('lib', [d.file('foo.dart', 'main() => "foo";')]),
         ]);
@@ -67,13 +67,13 @@ void main() {
     });
 
     test('deletes packages without pubspecs', () async {
-      var gitCacheDir = path.join(d.sandbox, cachePath, 'git');
+      var gitCacheDir = p.join(d.sandbox, cachePath, 'git');
       var fooDirs = listDir(gitCacheDir)
-          .where((dir) => path.basename(dir).startsWith('foo-'))
+          .where((dir) => p.basename(dir).startsWith('foo-'))
           .toList();
 
       for (var dir in fooDirs) {
-        deleteEntry(path.join(dir, 'pubspec.yaml'));
+        deleteEntry(p.join(dir, 'pubspec.yaml'));
       }
 
       await runPub(
@@ -92,18 +92,18 @@ void main() {
       );
 
       await d.dir(cachePath, [
-        d.dir('git', fooDirs.map((dir) => d.nothing(path.basename(dir)))),
+        d.dir('git', fooDirs.map((dir) => d.nothing(p.basename(dir)))),
       ]).validate();
     });
 
     test('deletes packages with invalid pubspecs', () async {
-      var gitCacheDir = path.join(d.sandbox, cachePath, 'git');
+      var gitCacheDir = p.join(d.sandbox, cachePath, 'git');
       var fooDirs = listDir(gitCacheDir)
-          .where((dir) => path.basename(dir).startsWith('foo-'))
+          .where((dir) => p.basename(dir).startsWith('foo-'))
           .toList();
 
       for (var dir in fooDirs) {
-        writeTextFile(path.join(dir, 'pubspec.yaml'), '{');
+        writeTextFile(p.join(dir, 'pubspec.yaml'), '{');
       }
 
       await runPub(
@@ -122,7 +122,7 @@ void main() {
       );
 
       await d.dir(cachePath, [
-        d.dir('git', fooDirs.map((dir) => d.nothing(path.basename(dir)))),
+        d.dir('git', fooDirs.map((dir) => d.nothing(p.basename(dir)))),
       ]).validate();
     });
   });
@@ -152,14 +152,14 @@ void main() {
 
     test('reinstalls previously cached git packages', () async {
       // Find the cached foo packages for each revision.
-      var gitCacheDir = path.join(d.sandbox, cachePath, 'git');
+      var gitCacheDir = p.join(d.sandbox, cachePath, 'git');
       var fooDirs = listDir(gitCacheDir)
-          .where((dir) => path.basename(dir).startsWith('foo-'))
+          .where((dir) => p.basename(dir).startsWith('foo-'))
           .toList();
 
       // Delete "sub.dart" from them.
       for (var dir in fooDirs) {
-        deleteEntry(path.join(dir, 'subdir/lib/sub.dart'));
+        deleteEntry(p.join(dir, 'subdir/lib/sub.dart'));
       }
 
       // Repair them.
@@ -173,7 +173,7 @@ void main() {
 
       // The missing libraries should have been replaced.
       var fooLibs = fooDirs.map((dir) {
-        var fooDirName = path.basename(dir);
+        var fooDirName = p.basename(dir);
         return d.dir(fooDirName, [
           d.dir('subdir', [
             d.dir('lib', [d.file('sub.dart', 'main() => "sub";')]),
@@ -185,13 +185,13 @@ void main() {
     });
 
     test('deletes packages without pubspecs', () async {
-      var gitCacheDir = path.join(d.sandbox, cachePath, 'git');
+      var gitCacheDir = p.join(d.sandbox, cachePath, 'git');
       var fooDirs = listDir(gitCacheDir)
-          .where((dir) => path.basename(dir).startsWith('foo-'))
+          .where((dir) => p.basename(dir).startsWith('foo-'))
           .toList();
 
       for (var dir in fooDirs) {
-        deleteEntry(path.join(dir, 'subdir', 'pubspec.yaml'));
+        deleteEntry(p.join(dir, 'subdir', 'pubspec.yaml'));
       }
 
       await runPub(
@@ -200,7 +200,7 @@ void main() {
           contains('Failed to load package:'),
           contains('Could not find a file named "pubspec.yaml" in '),
           contains('foo-'),
-          contains('${path.separator}subdir'),
+          contains('${p.separator}subdir'),
         ]),
         output: allOf([
           startsWith('Failed to reinstall 2 packages:'),
@@ -211,7 +211,7 @@ void main() {
       );
 
       await d.dir(cachePath, [
-        d.dir('git', fooDirs.map((dir) => d.nothing(path.basename(dir)))),
+        d.dir('git', fooDirs.map((dir) => d.nothing(p.basename(dir)))),
       ]).validate();
     });
   });

--- a/test/dependency_override_test.dart
+++ b/test/dependency_override_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 
 import 'package:test/test.dart';
 
@@ -121,7 +121,7 @@ void main() {
         }),
       ]).create();
 
-      var bazPath = path.join('..', 'baz');
+      var bazPath = p.join('..', 'baz');
 
       await runPub(
         args: [command.name],

--- a/test/descriptor/git.dart
+++ b/test/descriptor/git.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/git.dart' as git;
 import 'package:test_descriptor/test_descriptor.dart';
 
@@ -69,7 +69,7 @@ class GitRepoDescriptor extends DirectoryDescriptor {
 
     return git.run(
       args,
-      workingDir: path.join(parent ?? sandbox, name),
+      workingDir: p.join(parent ?? sandbox, name),
       environment: environment,
     );
   }

--- a/test/descriptor/tar.dart
+++ b/test/descriptor/tar.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/io.dart';
 import 'package:pub/src/log.dart' as log;
 import 'package:test_descriptor/test_descriptor.dart';
@@ -34,7 +34,7 @@ class TarFileDescriptor extends FileDescriptor {
       var bytes =
           await createTarGz(createdContents, baseDir: tempDir).toBytes();
 
-      var file = path.join(parent ?? sandbox, name);
+      var file = p.join(parent ?? sandbox, name);
       _writeBinaryFile(file, bytes);
       return file;
     });
@@ -56,7 +56,7 @@ class TarFileDescriptor extends FileDescriptor {
     return Stream<List<int>>.fromFuture(
       withTempDir((tempDir) async {
         await create(tempDir);
-        return readBinaryFile(path.join(tempDir, name));
+        return readBinaryFile(p.join(tempDir, name));
       }),
     );
   }

--- a/test/downgrade/dry_run_does_not_apply_changes_test.dart
+++ b/test/downgrade/dry_run_does_not_apply_changes_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/io.dart';
 import 'package:test/test.dart';
 
@@ -24,7 +24,7 @@ void main() {
     await d.appDir(dependencies: {'foo': 'any'}).create();
 
     // Also delete the "packages" directory.
-    deleteEntry(path.join(d.sandbox, appPath, 'packages'));
+    deleteEntry(p.join(d.sandbox, appPath, 'packages'));
 
     // Do the dry run.
     await pubDowngrade(

--- a/test/get/git/clean_invalid_git_repo_cache_test.dart
+++ b/test/get/git/clean_invalid_git_repo_cache_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
@@ -12,8 +12,7 @@ import '../../test_pub.dart';
 
 /// Invalidates a git clone in the pub-cache, by recreating it as empty-directory.
 void _invalidateGitCache(String repo) {
-  final cacheDir =
-      path.join(d.sandbox, path.joinAll([cachePath, 'git', 'cache']));
+  final cacheDir = p.join(d.sandbox, p.joinAll([cachePath, 'git', 'cache']));
   final fooCacheDir = Directory(cacheDir).listSync().firstWhere((entity) {
     return entity is Directory &&
         entity.path.split(Platform.pathSeparator).last.startsWith(repo);

--- a/test/get/git/lock_version_test.dart
+++ b/test/get/git/lock_version_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/io.dart';
 import 'package:test/test.dart';
 
@@ -39,7 +39,7 @@ void main() {
     var originalFooSpec = packageSpec('foo');
 
     // Delete the package spec to simulate a new checkout of the application.
-    deleteEntry(path.join(d.sandbox, packageConfigFilePath));
+    deleteEntry(p.join(d.sandbox, packageConfigFilePath));
 
     await d.git(
       'foo.git',

--- a/test/get/git/locked_revision_without_repo_test.dart
+++ b/test/get/git/locked_revision_without_repo_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/io.dart';
 import 'package:test/test.dart';
 
@@ -42,8 +42,8 @@ void main() {
 
     // Delete the package spec and the cache to simulate a brand new checkout
     // of the application.
-    deleteEntry(path.join(d.sandbox, packageConfigFilePath));
-    deleteEntry(path.join(d.sandbox, cachePath));
+    deleteEntry(p.join(d.sandbox, packageConfigFilePath));
+    deleteEntry(p.join(d.sandbox, cachePath));
 
     await d.git(
       'foo.git',

--- a/test/get/hosted/stay_locked_test.dart
+++ b/test/get/hosted/stay_locked_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/io.dart';
 import 'package:test/test.dart';
 
@@ -25,7 +25,7 @@ void main() {
     ]).validate();
 
     // Delete the .dart_tool/package_config.json file to simulate a new checkout of the application.
-    deleteEntry(path.join(d.sandbox, packageConfigFilePath));
+    deleteEntry(p.join(d.sandbox, packageConfigFilePath));
 
     // Start serving a newer package as well.
     server.serve('foo', '1.0.1');

--- a/test/get/path/absolute_path_test.dart
+++ b/test/get/path/absolute_path_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
@@ -16,7 +16,7 @@ void main() {
     await d.dir(appPath, [
       d.appPubspec(
         dependencies: {
-          'foo': {'path': path.join(d.sandbox, 'foo')},
+          'foo': {'path': p.join(d.sandbox, 'foo')},
         },
       ),
     ]).create();
@@ -24,7 +24,7 @@ void main() {
     await pubGet();
 
     await d.appPackageConfigFile([
-      d.packageConfigEntry(name: 'foo', path: path.join(d.sandbox, 'foo')),
+      d.packageConfigEntry(name: 'foo', path: p.join(d.sandbox, 'foo')),
     ]).validate();
   });
 }

--- a/test/get/path/absolute_symlink_test.dart
+++ b/test/get/path/absolute_symlink_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
@@ -34,7 +34,7 @@ void main() {
 
     // Move the app but not the package. Since the symlink is absolute, it
     // should still be able to find it.
-    renameInSandbox(appPath, path.join('moved', appPath));
+    renameInSandbox(appPath, p.join('moved', appPath));
 
     await d.dir('moved', [
       d.appPackageConfigFile([

--- a/test/get/path/no_pubspec_test.dart
+++ b/test/get/path/no_pubspec_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:test/test.dart';
 
@@ -13,7 +13,7 @@ void main() {
   test('path dependency to non-package directory', () async {
     // Make an empty directory.
     await d.dir('foo').create();
-    var fooPath = path.join(d.sandbox, 'foo');
+    var fooPath = p.join(d.sandbox, 'foo');
 
     await d.dir(appPath, [
       d.appPubspec(

--- a/test/get/path/nonexistent_dir_test.dart
+++ b/test/get/path/nonexistent_dir_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:test/test.dart';
 
@@ -11,7 +11,7 @@ import '../../test_pub.dart';
 
 void main() {
   test('path dependency to non-existent directory', () async {
-    var badPath = path.join(d.sandbox, 'bad_path');
+    var badPath = p.join(d.sandbox, 'bad_path');
 
     await d.dir(appPath, [
       d.appPubspec(

--- a/test/get/path/path_is_file_test.dart
+++ b/test/get/path/path_is_file_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:test/test.dart';
 
@@ -15,7 +15,7 @@ void main() {
         .dir('foo', [d.libDir('foo'), d.libPubspec('foo', '0.0.1')]).create();
 
     await d.file('dummy.txt', '').create();
-    var dummyPath = path.join(d.sandbox, 'dummy.txt');
+    var dummyPath = p.join(d.sandbox, 'dummy.txt');
 
     await d.dir(appPath, [
       d.appPubspec(

--- a/test/get/path/relative_path_test.dart
+++ b/test/get/path/relative_path_test.dart
@@ -4,7 +4,7 @@
 
 import 'dart:io';
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/lock_file.dart';
 import 'package:pub/src/source/path.dart';
 import 'package:pub/src/system_cache.dart';
@@ -115,7 +115,7 @@ void main() {
 
     await pubGet();
 
-    var lockfilePath = path.join(d.sandbox, appPath, 'pubspec.lock');
+    var lockfilePath = p.join(d.sandbox, appPath, 'pubspec.lock');
     final lockfileJson = loadYaml(File(lockfilePath).readAsStringSync());
     expect(
       lockfileJson['packages']['foo']['description']['path'],
@@ -127,6 +127,6 @@ void main() {
         lockfile.packages['foo']!.description.description as PathDescription;
 
     expect(description.relative, isTrue);
-    expect(description.path, path.join(d.sandbox, 'foo'));
+    expect(description.path, p.join(d.sandbox, 'foo'));
   });
 }

--- a/test/get/path/relative_symlink_test.dart
+++ b/test/get/path/relative_symlink_test.dart
@@ -9,7 +9,7 @@
 @TestOn('!windows')
 library;
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
@@ -41,8 +41,8 @@ void main() {
     // Move the app and package. Since they are still next to each other, it
     // should still be found and have the same relative path in the package
     // spec.
-    renameInSandbox('foo', path.join('moved', 'foo'));
-    renameInSandbox(appPath, path.join('moved', appPath));
+    renameInSandbox('foo', p.join('moved', 'foo'));
+    renameInSandbox(appPath, p.join('moved', appPath));
 
     await d.dir('moved', [
       d.appPackageConfigFile([

--- a/test/get/path/shared_dependency_symlink_test.dart
+++ b/test/get/path/shared_dependency_symlink_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 
 import 'package:test/test.dart';
 
@@ -48,7 +48,7 @@ void main() {
     ]).create();
 
     await d.dir('link').create();
-    symlinkInSandbox('shared', path.join('link', 'shared'));
+    symlinkInSandbox('shared', p.join('link', 'shared'));
 
     await pubGet();
 

--- a/test/get/preserve_lock_file_line_endings_test.dart
+++ b/test/get/preserve_lock_file_line_endings_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/lock_file.dart';
 import 'package:test/test.dart';
 
@@ -18,7 +18,7 @@ Future<void> main() async {
 
     await d
         .file(
-          path.join(appPath, 'pubspec.lock'),
+          p.join(appPath, 'pubspec.lock'),
           allOf(contains('\n'), isNot(contains('\r\n'))),
         )
         .validate();
@@ -29,7 +29,7 @@ Future<void> main() async {
 
     await pubGet();
 
-    final lockFile = d.file(path.join(appPath, 'pubspec.lock')).io;
+    final lockFile = d.file(p.join(appPath, 'pubspec.lock')).io;
     lockFile.writeAsStringSync(
       lockFile.readAsStringSync().replaceAll('\n', '\r\n'),
     );

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/exceptions.dart';
 import 'package:pub/src/io.dart';
 import 'package:tar/tar.dart';
@@ -17,8 +17,7 @@ import 'test_pub.dart';
 
 void main() {
   group('process', () {
-    final nonExisting =
-        path.join(path.dirname(Platform.resolvedExecutable), 'gone');
+    final nonExisting = p.join(p.dirname(Platform.resolvedExecutable), 'gone');
     test('Nice error message when failing to start process.', () {
       final throwsNiceErrorMessage = throwsA(
         predicate(
@@ -48,16 +47,16 @@ void main() {
     test('ignores hidden files by default', () {
       expect(
         withTempDir((temp) {
-          writeTextFile(path.join(temp, 'file1.txt'), '');
-          writeTextFile(path.join(temp, 'file2.txt'), '');
-          writeTextFile(path.join(temp, '.file3.txt'), '');
-          _createDir(path.join(temp, '.subdir'));
-          writeTextFile(path.join(temp, '.subdir', 'file3.txt'), '');
+          writeTextFile(p.join(temp, 'file1.txt'), '');
+          writeTextFile(p.join(temp, 'file2.txt'), '');
+          writeTextFile(p.join(temp, '.file3.txt'), '');
+          _createDir(p.join(temp, '.subdir'));
+          writeTextFile(p.join(temp, '.subdir', 'file3.txt'), '');
 
           expect(
             listDir(temp, recursive: true),
             unorderedEquals(
-              [path.join(temp, 'file1.txt'), path.join(temp, 'file2.txt')],
+              [p.join(temp, 'file1.txt'), p.join(temp, 'file2.txt')],
             ),
           );
         }),
@@ -68,20 +67,20 @@ void main() {
     test('includes hidden files when told to', () {
       expect(
         withTempDir((temp) {
-          writeTextFile(path.join(temp, 'file1.txt'), '');
-          writeTextFile(path.join(temp, 'file2.txt'), '');
-          writeTextFile(path.join(temp, '.file3.txt'), '');
-          _createDir(path.join(temp, '.subdir'));
-          writeTextFile(path.join(temp, '.subdir', 'file3.txt'), '');
+          writeTextFile(p.join(temp, 'file1.txt'), '');
+          writeTextFile(p.join(temp, 'file2.txt'), '');
+          writeTextFile(p.join(temp, '.file3.txt'), '');
+          _createDir(p.join(temp, '.subdir'));
+          writeTextFile(p.join(temp, '.subdir', 'file3.txt'), '');
 
           expect(
             listDir(temp, recursive: true, includeHidden: true),
             unorderedEquals([
-              path.join(temp, 'file1.txt'),
-              path.join(temp, 'file2.txt'),
-              path.join(temp, '.file3.txt'),
-              path.join(temp, '.subdir'),
-              path.join(temp, '.subdir', 'file3.txt'),
+              p.join(temp, 'file1.txt'),
+              p.join(temp, 'file2.txt'),
+              p.join(temp, '.file3.txt'),
+              p.join(temp, '.subdir'),
+              p.join(temp, '.subdir', 'file3.txt'),
             ]),
           );
         }),
@@ -92,18 +91,18 @@ void main() {
     test("doesn't ignore hidden files above the directory being listed", () {
       expect(
         withTempDir((temp) {
-          var dir = path.join(temp, '.foo', 'bar');
+          var dir = p.join(temp, '.foo', 'bar');
           ensureDir(dir);
-          writeTextFile(path.join(dir, 'file1.txt'), '');
-          writeTextFile(path.join(dir, 'file2.txt'), '');
-          writeTextFile(path.join(dir, 'file3.txt'), '');
+          writeTextFile(p.join(dir, 'file1.txt'), '');
+          writeTextFile(p.join(dir, 'file2.txt'), '');
+          writeTextFile(p.join(dir, 'file3.txt'), '');
 
           expect(
             listDir(dir, recursive: true),
             unorderedEquals([
-              path.join(dir, 'file1.txt'),
-              path.join(dir, 'file2.txt'),
-              path.join(dir, 'file3.txt'),
+              p.join(dir, 'file1.txt'),
+              p.join(dir, 'file2.txt'),
+              p.join(dir, 'file3.txt'),
             ]),
           );
         }),
@@ -116,7 +115,7 @@ void main() {
     test('resolves a non-link', () {
       expect(
         _withCanonicalTempDir((temp) {
-          var filePath = path.join(temp, 'file');
+          var filePath = p.join(temp, 'file');
           writeTextFile(filePath, '');
           expect(canonicalize(filePath), equals(filePath));
         }),
@@ -128,8 +127,8 @@ void main() {
       expect(
         _withCanonicalTempDir((temp) {
           expect(
-            canonicalize(path.join(temp, 'nothing')),
-            equals(path.join(temp, 'nothing')),
+            canonicalize(p.join(temp, 'nothing')),
+            equals(p.join(temp, 'nothing')),
           );
         }),
         completes,
@@ -139,11 +138,11 @@ void main() {
     test('resolves a symlink', () {
       expect(
         _withCanonicalTempDir((temp) {
-          _createDir(path.join(temp, 'linked-dir'));
-          createSymlink(path.join(temp, 'linked-dir'), path.join(temp, 'dir'));
+          _createDir(p.join(temp, 'linked-dir'));
+          createSymlink(p.join(temp, 'linked-dir'), p.join(temp, 'dir'));
           expect(
-            canonicalize(path.join(temp, 'dir')),
-            equals(path.join(temp, 'linked-dir')),
+            canonicalize(p.join(temp, 'dir')),
+            equals(p.join(temp, 'linked-dir')),
           );
         }),
         completes,
@@ -153,16 +152,16 @@ void main() {
     test('resolves a symlink to parent', () {
       expect(
         _withCanonicalTempDir((temp) {
-          _createDir(path.join(temp, 'linked-dir'));
-          _createDir(path.join(temp, 'linked-dir', 'a'));
-          _createDir(path.join(temp, 'linked-dir', 'b'));
+          _createDir(p.join(temp, 'linked-dir'));
+          _createDir(p.join(temp, 'linked-dir', 'a'));
+          _createDir(p.join(temp, 'linked-dir', 'b'));
           createSymlink(
-            path.join(temp, 'linked-dir'),
-            path.join(temp, 'linked-dir', 'a', 'symlink'),
+            p.join(temp, 'linked-dir'),
+            p.join(temp, 'linked-dir', 'a', 'symlink'),
           );
           expect(
-            canonicalize(path.join(temp, 'linked-dir', 'a', 'symlink', 'b')),
-            equals(path.join(temp, 'linked-dir', 'b')),
+            canonicalize(p.join(temp, 'linked-dir', 'a', 'symlink', 'b')),
+            equals(p.join(temp, 'linked-dir', 'b')),
           );
         }),
         completes,
@@ -172,15 +171,15 @@ void main() {
     test('resolves a relative symlink', () {
       expect(
         _withCanonicalTempDir((temp) {
-          _createDir(path.join(temp, 'linked-dir'));
+          _createDir(p.join(temp, 'linked-dir'));
           createSymlink(
-            path.join(temp, 'linked-dir'),
-            path.join(temp, 'dir'),
+            p.join(temp, 'linked-dir'),
+            p.join(temp, 'dir'),
             relative: true,
           );
           expect(
-            canonicalize(path.join(temp, 'dir')),
-            equals(path.join(temp, 'linked-dir')),
+            canonicalize(p.join(temp, 'dir')),
+            equals(p.join(temp, 'linked-dir')),
           );
         }),
         completes,
@@ -190,7 +189,7 @@ void main() {
     test('resolves a single-level horizontally recursive symlink', () {
       expect(
         _withCanonicalTempDir((temp) {
-          var linkPath = path.join(temp, 'foo');
+          var linkPath = p.join(temp, 'foo');
           createSymlink(linkPath, linkPath);
           expect(canonicalize(linkPath), equals(linkPath));
         }),
@@ -201,9 +200,9 @@ void main() {
     test('resolves a multi-level horizontally recursive symlink', () {
       expect(
         _withCanonicalTempDir((temp) {
-          var fooPath = path.join(temp, 'foo');
-          var barPath = path.join(temp, 'bar');
-          var bazPath = path.join(temp, 'baz');
+          var fooPath = p.join(temp, 'foo');
+          var barPath = p.join(temp, 'bar');
+          var bazPath = p.join(temp, 'baz');
           createSymlink(barPath, fooPath);
           createSymlink(bazPath, barPath);
           createSymlink(fooPath, bazPath);
@@ -211,8 +210,8 @@ void main() {
           expect(canonicalize(barPath), equals(barPath));
           expect(canonicalize(bazPath), equals(bazPath));
 
-          createSymlink(fooPath, path.join(temp, 'outer'));
-          expect(canonicalize(path.join(temp, 'outer')), equals(fooPath));
+          createSymlink(fooPath, p.join(temp, 'outer'));
+          expect(canonicalize(p.join(temp, 'outer')), equals(fooPath));
         }),
         completes,
       );
@@ -221,10 +220,10 @@ void main() {
     test('resolves a broken symlink', () {
       expect(
         _withCanonicalTempDir((temp) {
-          createSymlink(path.join(temp, 'nonexistent'), path.join(temp, 'foo'));
+          createSymlink(p.join(temp, 'nonexistent'), p.join(temp, 'foo'));
           expect(
-            canonicalize(path.join(temp, 'foo')),
-            equals(path.join(temp, 'nonexistent')),
+            canonicalize(p.join(temp, 'foo')),
+            equals(p.join(temp, 'nonexistent')),
           );
         }),
         completes,
@@ -234,17 +233,17 @@ void main() {
     test('resolves multiple nested symlinks', () {
       expect(
         _withCanonicalTempDir((temp) {
-          var dir1 = path.join(temp, 'dir1');
-          var dir2 = path.join(temp, 'dir2');
-          var subdir1 = path.join(dir1, 'subdir1');
-          var subdir2 = path.join(dir2, 'subdir2');
+          var dir1 = p.join(temp, 'dir1');
+          var dir2 = p.join(temp, 'dir2');
+          var subdir1 = p.join(dir1, 'subdir1');
+          var subdir2 = p.join(dir2, 'subdir2');
           _createDir(dir2);
           _createDir(subdir2);
           createSymlink(dir2, dir1);
           createSymlink(subdir2, subdir1);
           expect(
-            canonicalize(path.join(subdir1, 'file')),
-            equals(path.join(subdir2, 'file')),
+            canonicalize(p.join(subdir1, 'file')),
+            equals(p.join(subdir2, 'file')),
           );
         }),
         completes,
@@ -254,15 +253,15 @@ void main() {
     test('resolves a nested vertical symlink', () {
       expect(
         _withCanonicalTempDir((temp) {
-          var dir1 = path.join(temp, 'dir1');
-          var dir2 = path.join(temp, 'dir2');
-          var subdir = path.join(dir1, 'subdir');
+          var dir1 = p.join(temp, 'dir1');
+          var dir2 = p.join(temp, 'dir2');
+          var subdir = p.join(dir1, 'subdir');
           _createDir(dir1);
           _createDir(dir2);
           createSymlink(dir2, subdir);
           expect(
-            canonicalize(path.join(subdir, 'file')),
-            equals(path.join(dir2, 'file')),
+            canonicalize(p.join(subdir, 'file')),
+            equals(p.join(dir2, 'file')),
           );
         }),
         completes,
@@ -272,13 +271,13 @@ void main() {
     test('resolves a vertically recursive symlink', () {
       expect(
         _withCanonicalTempDir((temp) {
-          var dir = path.join(temp, 'dir');
-          var subdir = path.join(dir, 'subdir');
+          var dir = p.join(temp, 'dir');
+          var subdir = p.join(dir, 'subdir');
           _createDir(dir);
           createSymlink(dir, subdir);
           expect(
             canonicalize(
-              path.join(
+              p.join(
                 temp,
                 'dir',
                 'subdir',
@@ -288,7 +287,7 @@ void main() {
                 'file',
               ),
             ),
-            equals(path.join(dir, 'file')),
+            equals(p.join(dir, 'file')),
           );
         }),
         completes,
@@ -299,13 +298,13 @@ void main() {
         () {
       expect(
         _withCanonicalTempDir((temp) {
-          var dir = path.join(temp, 'dir');
-          var linkdir = path.join(temp, 'linkdir');
-          var linkfile = path.join(dir, 'link');
+          var dir = p.join(temp, 'dir');
+          var linkdir = p.join(temp, 'linkdir');
+          var linkfile = p.join(dir, 'link');
           _createDir(dir);
           createSymlink(dir, linkdir);
-          createSymlink(path.join(linkdir, 'file'), linkfile);
-          expect(canonicalize(linkfile), equals(path.join(dir, 'file')));
+          createSymlink(p.join(linkdir, 'file'), linkfile);
+          expect(canonicalize(linkfile), equals(p.join(dir, 'file')));
         }),
         completes,
       );
@@ -314,15 +313,15 @@ void main() {
     test('resolves a pair of pathologically-recursive symlinks', () {
       expect(
         _withCanonicalTempDir((temp) {
-          var foo = path.join(temp, 'foo');
-          var subfoo = path.join(foo, 'subfoo');
-          var bar = path.join(temp, 'bar');
-          var subbar = path.join(bar, 'subbar');
+          var foo = p.join(temp, 'foo');
+          var subfoo = p.join(foo, 'subfoo');
+          var bar = p.join(temp, 'bar');
+          var subbar = p.join(bar, 'subbar');
           createSymlink(subbar, foo);
           createSymlink(subfoo, bar);
           expect(
             canonicalize(subfoo),
-            equals(path.join(subfoo, 'subbar', 'subfoo')),
+            equals(p.join(subfoo, 'subbar', 'subfoo')),
           );
         }),
         completes,
@@ -484,7 +483,7 @@ void main() {
           Directory(tempDir).list(),
           emits(
             isA<Directory>()
-                .having((e) => path.basename(e.path), 'basename', 'bin'),
+                .having((e) => p.basename(e.path), 'basename', 'bin'),
           ),
         );
       });
@@ -628,7 +627,7 @@ void testExistencePredicate(
     test('returns $forFile for a file', () {
       expect(
         withTempDir((temp) {
-          var file = path.join(temp, 'test.txt');
+          var file = p.join(temp, 'test.txt');
           writeTextFile(file, 'contents');
           expect(predicate(file), equals(forFile));
         }),
@@ -639,7 +638,7 @@ void testExistencePredicate(
     test('returns $forDirectory for a directory', () {
       expect(
         withTempDir((temp) {
-          var file = path.join(temp, 'dir');
+          var file = p.join(temp, 'dir');
           _createDir(file);
           expect(predicate(file), equals(forDirectory));
         }),
@@ -650,8 +649,8 @@ void testExistencePredicate(
     test('returns $forDirectorySymlink for a symlink to a directory', () {
       expect(
         withTempDir((temp) {
-          var targetPath = path.join(temp, 'dir');
-          var symlinkPath = path.join(temp, 'linkdir');
+          var targetPath = p.join(temp, 'dir');
+          var symlinkPath = p.join(temp, 'linkdir');
           _createDir(targetPath);
           createSymlink(targetPath, symlinkPath);
           expect(predicate(symlinkPath), equals(forDirectorySymlink));
@@ -665,9 +664,9 @@ void testExistencePredicate(
         'a directory', () {
       expect(
         withTempDir((temp) {
-          var targetPath = path.join(temp, 'dir');
-          var symlink1Path = path.join(temp, 'link1dir');
-          var symlink2Path = path.join(temp, 'link2dir');
+          var targetPath = p.join(temp, 'dir');
+          var symlink1Path = p.join(temp, 'link1dir');
+          var symlink2Path = p.join(temp, 'link2dir');
           _createDir(targetPath);
           createSymlink(targetPath, symlink1Path);
           createSymlink(symlink1Path, symlink2Path);
@@ -683,8 +682,8 @@ void testExistencePredicate(
     test('returns $forBrokenSymlink for a broken symlink', () {
       expect(
         withTempDir((temp) {
-          var targetPath = path.join(temp, 'dir');
-          var symlinkPath = path.join(temp, 'linkdir');
+          var targetPath = p.join(temp, 'dir');
+          var symlinkPath = p.join(temp, 'linkdir');
           _createDir(targetPath);
           createSymlink(targetPath, symlinkPath);
           deleteEntry(targetPath);
@@ -698,9 +697,9 @@ void testExistencePredicate(
         () {
       expect(
         withTempDir((temp) {
-          var targetPath = path.join(temp, 'dir');
-          var symlink1Path = path.join(temp, 'link1dir');
-          var symlink2Path = path.join(temp, 'link2dir');
+          var targetPath = p.join(temp, 'dir');
+          var symlink1Path = p.join(temp, 'link1dir');
+          var symlink2Path = p.join(temp, 'link2dir');
           _createDir(targetPath);
           createSymlink(targetPath, symlink1Path);
           createSymlink(symlink1Path, symlink2Path);
@@ -716,8 +715,8 @@ void testExistencePredicate(
       test('returns $forFileSymlink for a symlink to a file', () {
         expect(
           withTempDir((temp) {
-            var targetPath = path.join(temp, 'test.txt');
-            var symlinkPath = path.join(temp, 'link.txt');
+            var targetPath = p.join(temp, 'test.txt');
+            var symlinkPath = p.join(temp, 'link.txt');
             writeTextFile(targetPath, 'contents');
             createSymlink(targetPath, symlinkPath);
             expect(predicate(symlinkPath), equals(forFileSymlink));
@@ -731,9 +730,9 @@ void testExistencePredicate(
           'file', () {
         expect(
           withTempDir((temp) {
-            var targetPath = path.join(temp, 'test.txt');
-            var symlink1Path = path.join(temp, 'link1.txt');
-            var symlink2Path = path.join(temp, 'link2.txt');
+            var targetPath = p.join(temp, 'test.txt');
+            var symlink1Path = p.join(temp, 'link1.txt');
+            var symlink2Path = p.join(temp, 'link2.txt');
             writeTextFile(targetPath, 'contents');
             createSymlink(targetPath, symlink1Path);
             createSymlink(symlink1Path, symlink2Path);

--- a/test/run/includes_parent_directories_of_entrypoint_test.dart
+++ b/test/run/includes_parent_directories_of_entrypoint_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
@@ -32,7 +32,7 @@ void main() {
     ]).create();
 
     await pubGet();
-    var pub = await pubRun(args: [path.join('tool', 'a', 'b', 'app')]);
+    var pub = await pubRun(args: [p.join('tool', 'a', 'b', 'app')]);
     expect(pub.stdout, emitsThrough('a b'));
     await pub.shouldExit();
   });

--- a/test/run/runs_app_in_directory_in_entrypoint_test.dart
+++ b/test/run/runs_app_in_directory_in_entrypoint_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
@@ -19,11 +19,11 @@ void main() {
     ]).create();
 
     await pubGet();
-    var pub = await pubRun(args: [path.join('tool', 'app')]);
+    var pub = await pubRun(args: [p.join('tool', 'app')]);
     expect(pub.stdout, emitsThrough('tool'));
     await pub.shouldExit();
 
-    pub = await pubRun(args: [path.join('tool', 'sub', 'app')]);
+    pub = await pubRun(args: [p.join('tool', 'sub', 'app')]);
     expect(pub.stdout, emitsThrough('sub'));
     await pub.shouldExit();
   });

--- a/test/upgrade/dry_run_does_not_apply_changes_test.dart
+++ b/test/upgrade/dry_run_does_not_apply_changes_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/io.dart';
 import 'package:test/test.dart';
 
@@ -29,7 +29,7 @@ void main() {
     await d.appDir(dependencies: {'foo': 'any'}).create();
 
     // Also delete the ".dart_tool" directory.
-    deleteEntry(path.join(d.sandbox, appPath, '.dart_tool'));
+    deleteEntry(p.join(d.sandbox, appPath, '.dart_tool'));
 
     // Do the dry run.
     await pubUpgrade(
@@ -63,7 +63,7 @@ void main() {
     ]).validate();
 
     // Also delete the ".dart_tool" directory.
-    deleteEntry(path.join(d.sandbox, appPath, '.dart_tool'));
+    deleteEntry(p.join(d.sandbox, appPath, '.dart_tool'));
 
     // Do the dry run.
     await pubUpgrade(

--- a/test/validator/dependency_test.dart
+++ b/test/validator/dependency_test.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 
 import 'package:pub/src/exit_codes.dart';
 import 'package:test/test.dart';
@@ -133,7 +133,7 @@ void main() {
       ).create();
 
       await expectValidation(
-        environment: {'FLUTTER_ROOT': path.join(d.sandbox, 'flutter')},
+        environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')},
       );
     });
 
@@ -150,7 +150,7 @@ void main() {
 
         await expectValidation(
           environment: {
-            'FLUTTER_ROOT': path.join(d.sandbox, 'flutter'),
+            'FLUTTER_ROOT': p.join(d.sandbox, 'flutter'),
           },
         );
       },
@@ -168,7 +168,7 @@ void main() {
 
         await expectValidation(
           environment: {
-            'FUCHSIA_DART_SDK_ROOT': path.join(d.sandbox, 'fuchsia'),
+            'FUCHSIA_DART_SDK_ROOT': p.join(d.sandbox, 'fuchsia'),
           },
         );
       },
@@ -185,7 +185,7 @@ void main() {
             d.libPubspec('foo', '1.2.3'),
           ]).create();
           await setUpDependency(
-            {'path': path.join(d.sandbox, 'foo')},
+            {'path': p.join(d.sandbox, 'foo')},
             hostedVersions: ['3.0.0-pre', '2.0.0', '1.0.0'],
           );
           await expectValidationError(
@@ -200,7 +200,7 @@ void main() {
             d.libPubspec('foo', '1.2.3'),
           ]).create();
           await setUpDependency(
-            {'path': path.join(d.sandbox, 'foo')},
+            {'path': p.join(d.sandbox, 'foo')},
             hostedVersions: ['3.0.0-pre', '2.0.0-pre'],
           );
           await expectValidationError(
@@ -214,7 +214,7 @@ void main() {
             d.libPubspec('foo', '1.2.3'),
           ]).create();
           await setUpDependency(
-            {'path': path.join(d.sandbox, 'foo')},
+            {'path': p.join(d.sandbox, 'foo')},
             hostedVersions: ['0.0.1', '0.0.2'],
           );
           await expectValidationError(
@@ -229,7 +229,7 @@ void main() {
             d.libPubspec('foo', '1.2.3'),
           ]).create();
           await setUpDependency({
-            'path': path.join(d.sandbox, 'foo'),
+            'path': p.join(d.sandbox, 'foo'),
             'version': '>=1.0.0 <2.0.0',
           });
           await expectValidationError(
@@ -244,7 +244,7 @@ void main() {
             d.libPubspec('foo', '0.2.3'),
           ]).create();
           await setUpDependency(
-            {'path': path.join(d.sandbox, 'foo'), 'version': '0.2.3'},
+            {'path': p.join(d.sandbox, 'foo'), 'version': '0.2.3'},
           );
           await expectValidationError(
             '  foo: 0.2.3',

--- a/test/validator/license_test.dart
+++ b/test/validator/license_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/io.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/license.dart';
@@ -23,7 +23,7 @@ void main() {
 
     test('has both LICENSE and UNLICENSE file', () async {
       await d.validPackage().create();
-      await d.file(path.join(appPath, 'UNLICENSE'), '').create();
+      await d.file(p.join(appPath, 'UNLICENSE'), '').create();
       await expectValidationDeprecated(license);
     });
   });
@@ -31,29 +31,29 @@ void main() {
   group('should warn if it', () {
     test('has only a COPYING file', () async {
       await d.validPackage().create();
-      deleteEntry(path.join(d.sandbox, appPath, 'LICENSE'));
-      await d.file(path.join(appPath, 'COPYING'), '').create();
+      deleteEntry(p.join(d.sandbox, appPath, 'LICENSE'));
+      await d.file(p.join(appPath, 'COPYING'), '').create();
       await expectValidationDeprecated(license, warnings: isNotEmpty);
     });
 
     test('has only an UNLICENSE file', () async {
       await d.validPackage().create();
-      deleteEntry(path.join(d.sandbox, appPath, 'LICENSE'));
-      await d.file(path.join(appPath, 'UNLICENSE'), '').create();
+      deleteEntry(p.join(d.sandbox, appPath, 'LICENSE'));
+      await d.file(p.join(appPath, 'UNLICENSE'), '').create();
       await expectValidationDeprecated(license, warnings: isNotEmpty);
     });
 
     test('has only a prefixed LICENSE file', () async {
       await d.validPackage().create();
-      deleteEntry(path.join(d.sandbox, appPath, 'LICENSE'));
-      await d.file(path.join(appPath, 'MIT_LICENSE'), '').create();
+      deleteEntry(p.join(d.sandbox, appPath, 'LICENSE'));
+      await d.file(p.join(appPath, 'MIT_LICENSE'), '').create();
       await expectValidationDeprecated(license, warnings: isNotEmpty);
     });
 
     test('has only a suffixed LICENSE file', () async {
       await d.validPackage().create();
-      deleteEntry(path.join(d.sandbox, appPath, 'LICENSE'));
-      await d.file(path.join(appPath, 'LICENSE.md'), '').create();
+      deleteEntry(p.join(d.sandbox, appPath, 'LICENSE'));
+      await d.file(p.join(appPath, 'LICENSE.md'), '').create();
       await expectValidationDeprecated(license, warnings: isNotEmpty);
     });
   });
@@ -61,14 +61,14 @@ void main() {
   group('should consider a package invalid if it', () {
     test('has no LICENSE file', () async {
       await d.validPackage().create();
-      deleteEntry(path.join(d.sandbox, appPath, 'LICENSE'));
+      deleteEntry(p.join(d.sandbox, appPath, 'LICENSE'));
       await expectValidationDeprecated(license, errors: isNotEmpty);
     });
 
     test('has a prefixed UNLICENSE file', () async {
       await d.validPackage().create();
-      deleteEntry(path.join(d.sandbox, appPath, 'LICENSE'));
-      await d.file(path.join(appPath, 'MIT_UNLICENSE'), '').create();
+      deleteEntry(p.join(d.sandbox, appPath, 'LICENSE'));
+      await d.file(p.join(appPath, 'MIT_UNLICENSE'), '').create();
       await expectValidationDeprecated(license, errors: isNotEmpty);
     });
 

--- a/test/validator/name_test.dart
+++ b/test/validator/name_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/io.dart';
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/name.dart';
@@ -49,7 +49,7 @@ void main() {
     });
 
     test('has a single library named differently than the package', () async {
-      deleteEntry(path.join(d.sandbox, appPath, 'lib', 'test_pkg.dart'));
+      deleteEntry(p.join(d.sandbox, appPath, 'lib', 'test_pkg.dart'));
       await d.dir(appPath, [
         d.dir('lib', [d.file('best_pkg.dart', 'int i = 0;')]),
       ]).create();

--- a/test/validator/strict_dependencies_test.dart
+++ b/test/validator/strict_dependencies_test.dart
@@ -2,7 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 import 'package:pub/src/validator.dart';
 import 'package:pub/src/validator/strict_dependencies.dart';
 import 'package:test/test.dart';
@@ -128,7 +128,7 @@ void main() {
     }
 
     test('only uses dart: dependencies (not pub packages)', () async {
-      await d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+      await d.file(p.join(appPath, 'lib', 'library.dart'), r'''
         import 'dart:async';
         import 'dart:collection';
         import 'dart:typed_data';
@@ -138,7 +138,7 @@ void main() {
     });
 
     test('imports itself', () async {
-      await d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+      await d.file(p.join(appPath, 'lib', 'library.dart'), r'''
         import 'package:test_pkg/test_pkg.dart';
       ''').create();
 
@@ -146,7 +146,7 @@ void main() {
     });
 
     test('has a relative import', () async {
-      await d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+      await d.file(p.join(appPath, 'lib', 'library.dart'), r'''
         import 'some/relative/path.dart';
       ''').create();
 
@@ -154,7 +154,7 @@ void main() {
     });
 
     test('has an absolute import', () async {
-      await d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+      await d.file(p.join(appPath, 'lib', 'library.dart'), r'''
         import 'file://shared/some/library.dart';
       ''').create();
 
@@ -162,7 +162,7 @@ void main() {
     });
 
     test('has a parse error preventing reading directives', () async {
-      await d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+      await d.file(p.join(appPath, 'lib', 'library.dart'), r'''
         import not_supported_keyword 'dart:async';
       ''').create();
 
@@ -170,7 +170,7 @@ void main() {
     });
 
     test('has a top-level Dart file with an invalid dependency', () async {
-      await d.file(path.join(appPath, 'top_level.dart'), r'''
+      await d.file(p.join(appPath, 'top_level.dart'), r'''
         import 'package:';
       ''').create();
 
@@ -178,7 +178,7 @@ void main() {
     });
 
     test('has a Dart-like file with an invalid dependency', () async {
-      await d.file(path.join(appPath, 'lib', 'generator.dart.template'), r'''
+      await d.file(p.join(appPath, 'lib', 'generator.dart.template'), r'''
         import 'package:';
       ''').create();
 
@@ -259,7 +259,7 @@ linter:
     setUp(d.validPackage().create);
 
     test('has an invalid String value', () async {
-      await d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+      await d.file(p.join(appPath, 'lib', 'library.dart'), r'''
         import 'package:$bad';
       ''').create();
 
@@ -270,7 +270,7 @@ linter:
     });
 
     test('does not declare an "import" as a dependency', () async {
-      await d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+      await d.file(p.join(appPath, 'lib', 'library.dart'), r'''
         import 'package:silly_monkey/silly_monkey.dart';
       ''').create();
 
@@ -283,7 +283,7 @@ linter:
     });
 
     test('does not declare an "export" as a dependency', () async {
-      await d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+      await d.file(p.join(appPath, 'lib', 'library.dart'), r'''
         export 'package:silly_monkey/silly_monkey.dart';
       ''').create();
 
@@ -296,7 +296,7 @@ linter:
     });
 
     test('has an invalid URI', () async {
-      await d.file(path.join(appPath, 'lib', 'library.dart'), r'''
+      await d.file(p.join(appPath, 'lib', 'library.dart'), r'''
         import 'package:/';
       ''').create();
 

--- a/tool/test.dart
+++ b/tool/test.dart
@@ -13,7 +13,7 @@
 library;
 
 import 'dart:io';
-import 'package:path/path.dart' as path;
+import 'package:path/path.dart' as p;
 
 import 'package:pub/src/dart.dart';
 import 'package:pub/src/exceptions.dart';
@@ -29,15 +29,15 @@ Future<void> main(List<String> args) async {
     testProcess?.kill(signal);
   });
   final pubSnapshotFilename =
-      path.absolute(path.join('.dart_tool', '_pub', 'pub.dart.snapshot.dart2'));
+      p.absolute(p.join('.dart_tool', '_pub', 'pub.dart.snapshot.dart2'));
   try {
     final stopwatch = Stopwatch()..start();
     stderr.write('Building snapshot...');
     await precompile(
-      executablePath: path.join('bin', 'pub.dart'),
+      executablePath: p.join('bin', 'pub.dart'),
       outputPath: pubSnapshotFilename,
       name: 'bin/pub.dart',
-      packageConfigPath: path.join('.dart_tool', 'package_config.json'),
+      packageConfigPath: p.join('.dart_tool', 'package_config.json'),
     );
     stderr.writeln(' (${stopwatch.elapsed.inMilliseconds}ms)');
     testProcess = await Process.start(


### PR DESCRIPTION
For consistency...

The name `path` is often useful for other things.