### PR TITLE
Fix _refreshBinStubs

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -618,7 +618,7 @@ try:
         log.fine('Could not parse binstub $file:\n$contents');
         continue;
       }
-      if (binStubPackage == entrypoint.workspaceRoot.name &&
+      if (binStubPackage == executable.package &&
           binStubScript ==
               p.basenameWithoutExtension(executable.relativePath)) {
         log.fine('Replacing old binstub $file');


### PR DESCRIPTION
Fixes test/global/binstubs/outdated_binstub_runs_pub_global_test.dart t

This regressed in https://github.com/dart-lang/pub/pull/4179.

We could not see it it was broken before it was rolled into the sdk, because this test tests the behavior of the binstubs and they run `dart pub...`.

Likewise this fix will only be visible after the change has rolled to the sdk, and is released in a dev build.

Maybe we should write the invocation in the binstubs differently when running tests. But that is also a bit iffy...