### PR TITLE
Tests of workspace error handling

### DIFF
--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -111,7 +111,6 @@ FileDescriptor libPubspec(
   String version, {
   Map<String, Object?>? deps,
   Map<String, Object?>? devDeps,
-  String? resolution,
   String? sdk,
   Map<String, Object?>? extras,
   bool resolutionWorkspace = false,

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -232,10 +232,11 @@ void main() {
         ]),
       ]),
     ]).create();
+    final s = p.separator;
     await pubGet(
       environment: {'_PUB_TEST_SDK_VERSION': '3.7.0'},
       error: contains(
-        'Error on line 1, column 118 of pkgs/a/pubspec.yaml: A dependency specification must be a string or a mapping.',
+        'Error on line 1, column 118 of pkgs${s}a${s}pubspec.yaml: A dependency specification must be a string or a mapping.',
       ),
       exitCode: DATA,
     );
@@ -291,10 +292,11 @@ void main() {
         ]),
       ]),
     ]).create();
+    final s = p.separator;
     await pubGet(
       environment: {'_PUB_TEST_SDK_VERSION': '3.7.0'},
       error: contains(
-        'pkgs/a/pubspec.yaml is inluded in the workspace from ./pubspec.yaml, but does not have `resolution: workspace`.',
+        'pkgs${s}a${s}pubspec.yaml is inluded in the workspace from .${s}pubspec.yaml, but does not have `resolution: workspace`.',
       ),
     );
   });

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -272,6 +272,33 @@ void main() {
     );
   });
 
+  test('Rejects workspace pubspecs without "resolution: workspace"', () async {
+    await dir(appPath, [
+      libPubspec(
+        'myapp',
+        '1.2.3',
+        extras: {
+          'workspace': ['pkgs/a'],
+        },
+        sdk: '^3.7.0',
+      ),
+      dir('pkgs', [
+        dir('a', [
+          libPubspec(
+            'a',
+            '1.1.1',
+          ),
+        ]),
+      ]),
+    ]).create();
+    await pubGet(
+      environment: {'_PUB_TEST_SDK_VERSION': '3.7.0'},
+      error: contains(
+        'pkgs/a/pubspec.yaml is inluded in the workspace from ./pubspec.yaml, but does not have `resolution: workspace`.',
+      ),
+    );
+  });
+
   test('Can resolve from any directory inside the workspace', () async {
     await dir(appPath, [
       libPubspec(


### PR DESCRIPTION
The existing test 'reports errors in workspace pubspec.yamls correctly' was actually testing that 'ignores the source of dependencies on root packages. (Uses the local version instead)'. Fixed

Contains tests for

* Syntax errors  in workspace pubspecs.
* Solve errors in dependencies of a workspace pubspec
* Rejecting a pubspec without "resolution: workspace" in a workspace.
