### PR TITLE
Report failure if package is included twice in same workspace

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -123,6 +123,7 @@ class Entrypoint {
         );
         for (final package in root.transitiveWorkspace) {
           if (identical(pubspecsMet.entries.first.value, package.pubspec)) {
+            validateWorkspaceGraph(root);
             return (root: root, work: package);
           }
         }

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -347,3 +347,27 @@ See $workspacesDocUrl for more information.
     ).map(resolve).toList();
   }
 }
+
+/// Reports an error if the graph of the workspace rooted at [root] is not a
+/// tree.
+void validateWorkspaceGraph(Package root) {
+  final includedFrom = <String, String>{};
+  final stack = [root];
+
+  while (stack.isNotEmpty) {
+    final current = stack.removeLast();
+    for (final child in current.workspaceChildren) {
+      final previous = includedFrom[child.dir];
+      if (previous != null) {
+        fail('''
+Packages can only be included in the workspace once.
+
+`${p.join(child.dir, 'pubspec.yaml')}` is included in the workspace, both from:
+* `${p.join(current.dir, 'pubspec.yaml')}` and
+* ${p.join(previous, 'pubspec.yaml')}.''');
+      }
+      includedFrom[child.dir] = current.dir;
+    }
+    stack.addAll(current.workspaceChildren);
+  }
+}

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -366,7 +366,7 @@ void validateWorkspaceGraph(Package root) {
   while (stack.isNotEmpty) {
     final current = stack.removeLast();
     for (final child in current.workspaceChildren) {
-      final previous = includedFrom[child.dir];
+      final previous = includedFrom[p.canonicalize(child.dir)];
       if (previous != null) {
         fail('''
 Packages can only be included in the workspace once.
@@ -375,7 +375,7 @@ Packages can only be included in the workspace once.
 * `${p.join(current.dir, 'pubspec.yaml')}` and
 * ${p.join(previous, 'pubspec.yaml')}.''');
       }
-      includedFrom[child.dir] = current.dir;
+      includedFrom[p.canonicalize(child.dir)] = current.dir;
     }
     stack.addAll(current.workspaceChildren);
   }

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -751,7 +751,7 @@ foo:foomain''',
       error: '''
 Packages can only be included in the workspace once.
 
-`.${s}pkgs/a${s}pubspec.yaml` is included in the workspace, both from:
+`.${s}pkgs${s}a${s}pubspec.yaml` is included in the workspace, both from:
 * `.${s}pkgs${s}pubspec.yaml` and
 * .${s}pubspec.yaml.''',
       environment: {'_PUB_TEST_SDK_VERSION': '3.7.0'},


### PR DESCRIPTION
Can happen eg. when:
* root includes `a` and  `a/b`
* `a` includes `b`

An alternative would be to allow this and canonicalize, but I'm not sure about the implications, so my intuition is to restrict here.