### PR TITLE
Allow globs in workspace definitions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   convert: ^3.1.1
   crypto: ^3.0.3
   frontend_server_client: ^4.0.0
+  glob: ^2.1.2
   http: ^1.1.2
   http_multi_server: ^3.2.1
   http_parser: ^4.0.2


### PR DESCRIPTION
Part of #4127

Initially we thought we would not allow globs, because resolving them would be on the hot path of `ensureResolutionUpToDate` and thus `dart run`.

But I think we are getting close to the conclusion that the fast path of `ensureResolutionUpToDate` only should depend on `.dart_tool/package_config.json`, not parsing and resolving pubspec.yamls - thus we can allow globs.

There is still the issue that `executableForCommand` needs to know if a package is a direct dependency or not. We might want to solve that issue before landing this. Discussing in https://github.com/dart-lang/pub/issues/4222