### PR TITLE
Make solve traces more precise for workspace members

### DIFF
--- a/lib/src/solver/package_lister.dart
+++ b/lib/src/solver/package_lister.dart
@@ -277,7 +277,7 @@ class PackageLister {
           ..._rootPackage!.workspaceChildren.map((p) {
             return PackageRange(
               PackageRef(p.name, RootDescription(p.dir)),
-              VersionConstraint.any,
+              p.version,
             );
           }),
           ...pubspec.dependencyOverrides.values,

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -268,7 +268,7 @@ void main() {
     await pubGet(
       environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
       error: contains(
-        'Because every version of a depends on foo from unknown source "posted", version solving failed.',
+        'Because a depends on foo from unknown source "posted", version solving failed.',
       ),
     );
   });


### PR DESCRIPTION
By making a constraint on the exact package version of the workspace child we avoid the solver telling us that "every versions of" the package does something.
Relates to #4127 