### PR TITLE
Don't print 'Resolving dependencies in `../..`...' Use absolute path instead

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -516,7 +516,9 @@ See $workspacesDocUrl for more information.''',
   }) async {
     workspaceRoot; // This will throw early if pubspec.yaml could not be found.
     summaryOnly = summaryOnly || _summaryOnlyEnvironment;
-    final suffix = workspaceRoot.dir == '.' ? '' : ' in `${workspaceRoot.dir}`';
+    final suffix = workspaceRoot.dir == '.'
+        ? ''
+        : ' in `${workspaceRoot.presentationDir}`';
 
     if (enforceLockfile && !fileExists(lockFilePath)) {
       throw ApplicationException('''

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -36,6 +36,13 @@ class Package {
   /// The path to the directory containing the package.
   final String dir;
 
+  /// A version of [dir] adapted for presenting in the terminal.
+  ///
+  /// If [dir] is just a parent directory like ../.. it gets replaced with
+  /// the absolute dir.
+  late String presentationDir =
+      p.isWithin(dir, '.') ? p.normalize(p.absolute(dir)) : dir;
+
   /// The name of the package.
   String get name => pubspec.name;
 

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -327,13 +327,16 @@ void main() {
     await pubGet(
       environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
       workingDirectory: p.join(sandbox, appPath, 'pkgs'),
-      output: contains('Resolving dependencies in `..`...'),
+      output: contains(
+        'Resolving dependencies in `${p.join(sandbox, appPath)}`...',
+      ),
     );
-    final s = p.separator;
     await pubGet(
       environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
       workingDirectory: p.join(sandbox, appPath, 'pkgs', 'a'),
-      output: contains('Resolving dependencies in `..$s..`...'),
+      output: contains(
+        'Resolving dependencies in `${p.join(sandbox, appPath)}`...',
+      ),
     );
 
     await pubGet(
@@ -351,7 +354,9 @@ void main() {
         appPath,
         'pkgs',
       ),
-      output: contains('Resolving dependencies in `..`...'),
+      output: contains(
+        'Resolving dependencies in `${p.join(sandbox, appPath)}`...',
+      ),
     );
   });
 


### PR DESCRIPTION
Part of #4127 