### PR TITLE
Revert "Fix package name when refreshing binstubs (#4205)"

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -372,7 +372,7 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
   /// Returns an [Entrypoint] loaded with the active package if found.
   Future<Entrypoint> find(String name) async {
     final lockFilePath = _getLockFilePath(name);
-    late final LockFile lockFile;
+    late LockFile lockFile;
     try {
       lockFile = LockFile.load(lockFilePath, cache.sources);
     } on IOException {
@@ -380,7 +380,11 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
       dataError('No active package ${log.bold(name)}.');
     }
 
+    // Remove the package itself from the lockfile. We put it in there so we
+    // could find and load the [Package] object, but normally an entrypoint
+    // doesn't expect to be in its own lockfile.
     final id = lockFile.packages[name]!;
+    lockFile = lockFile.removePackage(name);
 
     Entrypoint entrypoint;
     if (id.source is CachedSource) {
@@ -621,7 +625,7 @@ try:
         log.fine('Replacing old binstub $file');
         deleteEntry(file);
         _createBinStub(
-          activatedPackage(entrypoint),
+          entrypoint.workspaceRoot,
           p.basenameWithoutExtension(file),
           binStubScript,
           overwrite: true,
@@ -942,19 +946,5 @@ fi
     final pattern = RegExp(RegExp.escape(name) + r': ([a-zA-Z0-9_-]+)');
     final match = pattern.firstMatch(source);
     return match == null ? null : match[1];
-  }
-}
-
-/// The package that was activated.
-///
-/// * For path packages this is [Entrypoint.workspaceRoot].
-/// * For cached packages this is the sole dependency of
-///   [Entrypoint.workspaceRoot].
-Package activatedPackage(Entrypoint entrypoint) {
-  if (entrypoint.isCachedGlobal) {
-    final dep = entrypoint.workspaceRoot.dependencies.keys.single;
-    return entrypoint.cache.load(entrypoint.lockFile.packages[dep]!);
-  } else {
-    return entrypoint.workspaceRoot;
   }
 }

--- a/test/global/binstubs/binstub_runs_global_run_if_no_snapshot_test.dart
+++ b/test/global/binstubs/binstub_runs_global_run_if_no_snapshot_test.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
@@ -25,62 +22,6 @@ void main() {
       args: ['global', 'activate', '--source', 'path', '../foo'],
       output: contains('Installed executable foo-script.'),
     );
-
-    await d.dir(cachePath, [
-      d.dir('bin', [
-        d.file(
-          binStubName('foo-script'),
-          contains('global run foo:script'),
-        ),
-      ]),
-    ]).validate();
-  });
-
-  test(
-      'the binstubs of hosted package runs pub global run if there is no snapshot',
-      () async {
-    final server = await servePackages();
-    server.serve(
-      'foo',
-      '1.0.0',
-      contents: [
-        d.dir('bin', [d.file('script.dart', "main() => print('ok');")]),
-      ],
-      pubspec: {
-        'name': 'foo',
-        'executables': {'foo-script': 'script'},
-      },
-    );
-
-    await runPub(
-      args: ['global', 'activate', 'foo'],
-      output: contains('Installed executable foo-script.'),
-    );
-
-    await d.dir(cachePath, [
-      d.dir('bin', [
-        d.file(
-          binStubName('foo-script'),
-          contains('global run foo:script'),
-        ),
-      ]),
-    ]).validate();
-
-    // Force refresh of snapshot/binstub
-    Directory(
-      p.join(d.sandbox, cachePath, 'global_packages', 'foo', 'bin'),
-    ).deleteSync(recursive: true);
-    final binstub = p.join(
-      d.sandbox,
-      cachePath,
-      'bin',
-      'foo-script${Platform.isWindows ? '.bat' : ''}',
-    );
-    final result =
-        await Process.run(binstub, [], environment: getPubTestEnvironment());
-    expect(result.stderr, '');
-    expect(result.exitCode, 0);
-    expect(result.stdout, contains('ok'));
 
     await d.dir(cachePath, [
       d.dir('bin', [


### PR DESCRIPTION
This reverts commit ed20b45589766d6fd135e93460b9e8255ccba519 (#4205) because it is causing the Flutter build to fail with concurrency issues. See https://github.com/flutter/flutter/issues/147609

@sigurdm 
---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
