### PR TITLE
Reapply binstub fix

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -372,7 +372,7 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
   /// Returns an [Entrypoint] loaded with the active package if found.
   Future<Entrypoint> find(String name) async {
     final lockFilePath = _getLockFilePath(name);
-    late LockFile lockFile;
+    late final LockFile lockFile;
     try {
       lockFile = LockFile.load(lockFilePath, cache.sources);
     } on IOException {
@@ -380,11 +380,7 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
       dataError('No active package ${log.bold(name)}.');
     }
 
-    // Remove the package itself from the lockfile. We put it in there so we
-    // could find and load the [Package] object, but normally an entrypoint
-    // doesn't expect to be in its own lockfile.
     final id = lockFile.packages[name]!;
-    lockFile = lockFile.removePackage(name);
 
     Entrypoint entrypoint;
     if (id.source is CachedSource) {
@@ -625,7 +621,7 @@ try:
         log.fine('Replacing old binstub $file');
         deleteEntry(file);
         _createBinStub(
-          entrypoint.workspaceRoot,
+          activatedPackage(entrypoint),
           p.basenameWithoutExtension(file),
           binStubScript,
           overwrite: true,
@@ -946,5 +942,19 @@ fi
     final pattern = RegExp(RegExp.escape(name) + r': ([a-zA-Z0-9_-]+)');
     final match = pattern.firstMatch(source);
     return match == null ? null : match[1];
+  }
+}
+
+/// The package that was activated.
+///
+/// * For path packages this is [Entrypoint.workspaceRoot].
+/// * For cached packages this is the sole dependency of
+///   [Entrypoint.workspaceRoot].
+Package activatedPackage(Entrypoint entrypoint) {
+  if (entrypoint.isCachedGlobal) {
+    final dep = entrypoint.workspaceRoot.dependencies.keys.single;
+    return entrypoint.cache.load(entrypoint.lockFile.packages[dep]!);
+  } else {
+    return entrypoint.workspaceRoot;
   }
 }

--- a/test/global/binstubs/binstub_runs_global_run_if_no_snapshot_test.dart
+++ b/test/global/binstubs/binstub_runs_global_run_if_no_snapshot_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
@@ -22,6 +25,62 @@ void main() {
       args: ['global', 'activate', '--source', 'path', '../foo'],
       output: contains('Installed executable foo-script.'),
     );
+
+    await d.dir(cachePath, [
+      d.dir('bin', [
+        d.file(
+          binStubName('foo-script'),
+          contains('global run foo:script'),
+        ),
+      ]),
+    ]).validate();
+  });
+
+  test(
+      'the binstubs of hosted package runs pub global run if there is no snapshot',
+      () async {
+    final server = await servePackages();
+    server.serve(
+      'foo',
+      '1.0.0',
+      contents: [
+        d.dir('bin', [d.file('script.dart', "main() => print('ok');")]),
+      ],
+      pubspec: {
+        'name': 'foo',
+        'executables': {'foo-script': 'script'},
+      },
+    );
+
+    await runPub(
+      args: ['global', 'activate', 'foo'],
+      output: contains('Installed executable foo-script.'),
+    );
+
+    await d.dir(cachePath, [
+      d.dir('bin', [
+        d.file(
+          binStubName('foo-script'),
+          contains('global run foo:script'),
+        ),
+      ]),
+    ]).validate();
+
+    // Force refresh of snapshot/binstub
+    Directory(
+      p.join(d.sandbox, cachePath, 'global_packages', 'foo', 'bin'),
+    ).deleteSync(recursive: true);
+    final binstub = p.join(
+      d.sandbox,
+      cachePath,
+      'bin',
+      'foo-script${Platform.isWindows ? '.bat' : ''}',
+    );
+    final result =
+        await Process.run(binstub, [], environment: getPubTestEnvironment());
+    expect(result.stderr, '');
+    expect(result.exitCode, 0);
+    expect(result.stdout, contains('ok'));
 
     await d.dir(cachePath, [
       d.dir('bin', [


### PR DESCRIPTION
Reapply "Fix package name when refreshing binstubs (#4205)" (#4255)

Fix the underlying problem, where `p.join(tempdir, binstubPath)` evaluates to `binstubPath` because it is absolute. Therefore we did not chmod the binstub in a tempdir before moving it 🤦 .

Also avoids deleting a binstub before refreshing it, so an outside observer will never see a missing binstub. Only either before or after.

Should fix https://github.com/flutter/flutter/issues/147609