### PR TITLE
Remove debug logging statements

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -845,8 +845,6 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
               lockFile.packages.containsKey(packageName);
         });
         if (hasExtraMappings) {
-          log.fine(packagePathsMapping.toString());
-          log.fine(lockFile.packages.toString());
           return false;
         }
 


### PR DESCRIPTION
I don't really think these help us.

They were added in https://github.com/dart-lang/pub/pull/4171/files#diff-fdb8ce649c4af89ef6afd8c67bdd9e51e661161792256adba203cbd241f64ad2R706