### PR TITLE
Fix flutter version update on fast path

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -1123,7 +1123,7 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
         return null;
       }
       if (packageConfig.additionalProperties['flutterVersion'] !=
-          (flutter.isAvailable ? null : flutter.version)) {
+          (flutter.isAvailable ? flutter.version.toString() : null)) {
         log.fine('Flutter has updated since last invocation.');
         return null;
       }

--- a/test/embedding/ensure_pubspec_resolved.dart
+++ b/test/embedding/ensure_pubspec_resolved.dart
@@ -297,7 +297,9 @@ void testEnsurePubspecResolved() {
         await pubGet(
           environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')},
         );
-
+        await _noImplicitPubGet(
+          environment: {'FLUTTER_ROOT': p.join(d.sandbox, 'flutter')},
+        );
         await d.dir('flutter', [d.flutterVersion('0.9.0')]).create();
 
         server.serve(


### PR DESCRIPTION
Double bug!

The branches of the conditional were swapped, **and** the comparison was between a `String` and a `Version`.