### PR TITLE
Fix bug in ensureUpToDate fast path, when following workspaceRef

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -1040,7 +1040,6 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
                   p.absolute(
                     p.join(
                       p.dirname(potentialWorkspaceRefPath),
-                      workspaceRefText,
                       path,
                       '.dart_tool',
                       'package_config.json',
@@ -1048,6 +1047,21 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
                   ),
                 ),
               );
+              // print(
+              //   p.dirname(potentialWorkspaceRefPath),
+              // );
+              // print(p.join(
+              //     p.dirname(potentialWorkspaceRefPath), workspaceRefText));
+              // print(p.join(p.dirname(potentialWorkspaceRefPath),
+              //     workspaceRefText, path));
+              // print(p.join(
+              //   p.dirname(potentialWorkspaceRefPath),
+              //   workspaceRefText,
+              //   path,
+              //   '.dart_tool',
+              // ));
+              // print(p.join(p.dirname(potentialWorkspaceRefPath),
+              //     workspaceRefText, path, '.dart_tool', 'package_config.json'));
               packageConfigStat = tryStatFile(potentialPackageConfigPath2);
               if (packageConfigStat == null) {
                 log.fine(
@@ -1061,7 +1075,6 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
                     p.absolute(
                       p.join(
                         p.dirname(potentialWorkspaceRefPath),
-                        workspaceRefText,
                         path,
                       ),
                     ),
@@ -1225,7 +1238,7 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
 
     if (isResolutionUpToDate()
         case (final PackageConfig packageConfig, final String rootDir)) {
-      log.fine('Package Config up to date.');
+      log.fine('Package Config up to date. ${StackTrace.current}');
       return (packageConfig: packageConfig, rootDir: rootDir);
     }
     final entrypoint = Entrypoint(

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -1223,7 +1223,7 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
 
     if (isResolutionUpToDate()
         case (final PackageConfig packageConfig, final String rootDir)) {
-      log.fine('Package Config up to date. ${StackTrace.current}');
+      log.fine('Package Config up to date.');
       return (packageConfig: packageConfig, rootDir: rootDir);
     }
     final entrypoint = Entrypoint(

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -1047,21 +1047,6 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
                   ),
                 ),
               );
-              // print(
-              //   p.dirname(potentialWorkspaceRefPath),
-              // );
-              // print(p.join(
-              //     p.dirname(potentialWorkspaceRefPath), workspaceRefText));
-              // print(p.join(p.dirname(potentialWorkspaceRefPath),
-              //     workspaceRefText, path));
-              // print(p.join(
-              //   p.dirname(potentialWorkspaceRefPath),
-              //   workspaceRefText,
-              //   path,
-              //   '.dart_tool',
-              // ));
-              // print(p.join(p.dirname(potentialWorkspaceRefPath),
-              //     workspaceRefText, path, '.dart_tool', 'package_config.json'));
               packageConfigStat = tryStatFile(potentialPackageConfigPath2);
               if (packageConfigStat == null) {
                 log.fine(

--- a/test/embedding/ensure_pubspec_resolved.dart
+++ b/test/embedding/ensure_pubspec_resolved.dart
@@ -502,6 +502,10 @@ void testEnsurePubspecResolved() {
 
         await _noImplicitPubGet();
       });
+      // ignore: prefer_single_quotes
+      test("things are ok, even inside workspaces", () async {
+        await _noImplicitPubGet();
+      });
     });
   });
 }

--- a/test/embedding/ensure_pubspec_resolved.dart
+++ b/test/embedding/ensure_pubspec_resolved.dart
@@ -502,10 +502,6 @@ void testEnsurePubspecResolved() {
 
         await _noImplicitPubGet();
       });
-      // ignore: prefer_single_quotes
-      test("things are ok, even inside workspaces", () async {
-        await _noImplicitPubGet();
-      });
     });
   });
 }

--- a/test/embedding/get_executable_for_command.dart
+++ b/test/embedding/get_executable_for_command.dart
@@ -453,10 +453,20 @@ void testGetExecutableForCommand() {
               'a',
               '1.0.0',
               resolutionWorkspace: true,
+              extras: {
+                'workspace': ['sub'],
+              },
             ),
             d.dir('bin', [
               d.file('a.dart', 'main() {print(42);}'),
               d.file('tool.dart', 'main() {print(42);}'),
+            ]),
+            d.dir('sub', [
+              d.libPubspec(
+                'sub',
+                '1.0.0',
+                resolutionWorkspace: true,
+              ),
             ]),
           ]),
           d.dir('b', [
@@ -489,6 +499,24 @@ void testGetExecutableForCommand() {
         ),
         environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
         packageConfig: p.join('..', '..', '.dart_tool', 'package_config.json'),
+        resolution: ResolutionAttempt.fastPath,
+      );
+      await testGetExecutable(
+        'myapp',
+        p.join(d.sandbox, appPath, 'pkgs', 'a', 'sub'),
+        executable: p.join(
+          '..',
+          '..',
+          '..',
+          '.dart_tool',
+          'pub',
+          'bin',
+          'myapp',
+          'myapp.dart-3.5.0.snapshot',
+        ),
+        environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+        packageConfig:
+            p.join('..', '..', '..', '.dart_tool', 'package_config.json'),
         resolution: ResolutionAttempt.fastPath,
       );
 


### PR DESCRIPTION
We for some bogus reason added the text of the file in the path...

It happened to work by accident in the existing test cases.