### PR TITLE
`outdated` show transitive dependencies by default

### DIFF
--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -103,6 +103,7 @@ class OutdatedCommand extends PubCommand {
     argParser.addFlag(
       'transitive',
       help: 'Show transitive dependencies.',
+      defaultsTo: true,
     );
     argParser.addOption(
       'directory',

--- a/test/testdata/goldens/help_test/pub outdated --help.txt
+++ b/test/testdata/goldens/help_test/pub outdated --help.txt
@@ -14,6 +14,7 @@ Usage: pub outdated [options]
     --[no-]prereleases             Include prereleases in latest version.
     --[no-]show-all                Include dependencies that are already fulfilling --mode.
     --[no-]transitive              Show transitive dependencies.
+                                   (defaults to on)
 -C, --directory=<dir>              Run this in the directory <dir>.
 
 Run "pub help" to see global options.

--- a/test/testdata/goldens/outdated/outdated_test/do not report ignored advisories.txt
+++ b/test/testdata/goldens/outdated/outdated_test/do not report ignored advisories.txt
@@ -68,6 +68,9 @@ Package Name  Current  Upgradable  Resolvable  Latest
 direct dependencies:
 foo           *1.0.0   1.2.0       1.2.0       1.2.0   
 
+transitive dependencies:
+transitive    1.2.3    -           -           1.2.3   
+
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `dart pub upgrade`.
 

--- a/test/testdata/goldens/outdated/outdated_test/do not show advisories if no version is affected.txt
+++ b/test/testdata/goldens/outdated/outdated_test/do not show advisories if no version is affected.txt
@@ -68,6 +68,9 @@ Package Name  Current  Upgradable  Resolvable  Latest
 direct dependencies:
 foo           *1.0.0   1.2.0       1.2.0       1.2.0   
 
+transitive dependencies:
+transitive    1.2.3    -           -           1.2.3   
+
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `dart pub upgrade`.
 

--- a/test/testdata/goldens/outdated/outdated_test/does not allow arguments - handles bad flags.txt
+++ b/test/testdata/goldens/outdated/outdated_test/does not allow arguments - handles bad flags.txt
@@ -15,6 +15,7 @@ $ pub outdated random_argument
 [STDERR]     --[no-]show-all                Include dependencies that are already
 [STDERR]                                    fulfilling --mode.
 [STDERR]     --[no-]transitive              Show transitive dependencies.
+[STDERR]                                    (defaults to on)
 [STDERR] -C, --directory=<dir>              Run this in the directory <dir>.
 [STDERR] 
 [STDERR] Run "pub help" to see global options.
@@ -38,6 +39,7 @@ $ pub outdated --bad_flag
 [STDERR]     --[no-]show-all                Include dependencies that are already
 [STDERR]                                    fulfilling --mode.
 [STDERR]     --[no-]transitive              Show transitive dependencies.
+[STDERR]                                    (defaults to on)
 [STDERR] -C, --directory=<dir>              Run this in the directory <dir>.
 [STDERR] 
 [STDERR] Run "pub help" to see global options.

--- a/test/testdata/goldens/outdated/outdated_test/newer versions available.txt
+++ b/test/testdata/goldens/outdated/outdated_test/newer versions available.txt
@@ -146,7 +146,15 @@ retracted     *1.0.1 (retracted)  *1.0.1 (retracted)  *1.0.1 (retracted)  1.0.0
 dev_dependencies:
 builder       *1.2.3              *1.3.0              2.0.0               2.0.0   
 
-2 upgradable dependencies are locked (in pubspec.lock) to older versions.
+transitive dependencies:
+transitive    *1.2.3              *1.3.0              *1.3.0              2.0.0   
+transitive2   -                   -                   1.0.0               1.0.0   
+
+transitive dev_dependencies:
+dev_trans     *1.0.0              -                   *1.0.0              2.0.0   
+transitive3   -                   -                   1.0.0               1.0.0   
+
+3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `dart pub upgrade`.
 
 2  dependencies are constrained to versions that are older than a resolvable version.
@@ -198,7 +206,15 @@ retracted      *1.0.1 (retracted)  *1.0.1 (retracted)  *1.0.1 (retracted)  1.0.0
 dev_dependencies:
 builder        *1.2.3              *1.3.0              2.0.0               2.0.0         
 
-2 upgradable dependencies are locked (in pubspec.lock) to older versions.
+transitive dependencies:
+transitive     *1.2.3              *1.3.0              *1.3.0              2.0.0         
+transitive2    -                   -                   1.0.0               1.0.0         
+
+transitive dev_dependencies:
+dev_trans      *1.0.0              -                   *1.0.0              2.0.0         
+transitive3    -                   -                   1.0.0               1.0.0         
+
+3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `dart pub upgrade`.
 
 2  dependencies are constrained to versions that are older than a resolvable version.
@@ -223,7 +239,15 @@ retracted     *1.0.1 (retracted)  *1.0.1 (retracted)  *1.0.1 (retracted)  1.0.0
 dev_dependencies:
 builder       *1.2.3              *1.3.0              *2.0.0              3.0.0-alpha  
 
-2 upgradable dependencies are locked (in pubspec.lock) to older versions.
+transitive dependencies:
+transitive    *1.2.3              *1.3.0              *1.3.0              2.0.0        
+transitive2   -                   -                   1.0.0               1.0.0        
+
+transitive dev_dependencies:
+dev_trans     *1.0.0              -                   *1.0.0              2.0.0        
+transitive3   -                   -                   1.0.0               1.0.0        
+
+3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `dart pub upgrade`.
 
 2  dependencies are constrained to versions that are older than a resolvable version.
@@ -245,8 +269,11 @@ direct dependencies:
 foo           *1.2.3              *1.3.0              3.0.0               3.0.0   
 retracted     *1.0.1 (retracted)  *1.0.1 (retracted)  *1.0.1 (retracted)  1.0.0   
 
-1 upgradable dependency is locked (in pubspec.lock) to an older version.
-To update it, use `dart pub upgrade`.
+transitive dependencies:
+transitive    *1.2.3              2.0.0               2.0.0               2.0.0   
+
+2 upgradable dependencies are locked (in pubspec.lock) to older versions.
+To update these dependencies, use `dart pub upgrade`.
 
 1 dependency is constrained to a version that is older than a resolvable version.
 To update it, edit pubspec.yaml, or run `dart pub upgrade --major-versions`.
@@ -270,7 +297,15 @@ retracted     *1.0.1 (retracted)  *1.0.1 (retracted)  *1.0.1 (retracted)  1.0.0
 dev_dependencies:
 builder       *1.2.3              *1.3.0              2.0.0               2.0.0   
 
-2 upgradable dependencies are locked (in pubspec.lock) to older versions.
+transitive dependencies:
+transitive    *1.2.3              *1.3.0              *1.3.0              2.0.0   
+transitive2   -                   -                   1.0.0               1.0.0   
+
+transitive dev_dependencies:
+dev_trans     *1.0.0              -                   *1.0.0              2.0.0   
+transitive3   -                   -                   1.0.0               1.0.0   
+
+3 upgradable dependencies are locked (in pubspec.lock) to older versions.
 To update these dependencies, use `dart pub upgrade`.
 
 2  dependencies are constrained to versions that are older than a resolvable version.

--- a/test/testdata/goldens/outdated/outdated_test/only report unignored advisory.txt
+++ b/test/testdata/goldens/outdated/outdated_test/only report unignored advisory.txt
@@ -82,6 +82,9 @@ Package Name  Current            Upgradable  Resolvable  Latest
 direct dependencies:
 foo           *1.0.0 (advisory)  1.2.0       1.2.0       1.2.0   
 
+transitive dependencies:
+transitive    1.2.3              -           -           1.2.3   
+
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `dart pub upgrade`.
 

--- a/test/testdata/goldens/outdated/outdated_test/show advisory - all versions.txt
+++ b/test/testdata/goldens/outdated/outdated_test/show advisory - all versions.txt
@@ -82,6 +82,9 @@ Package Name  Current            Upgradable        Resolvable        Latest
 direct dependencies:
 foo           *1.0.0 (advisory)  1.2.0 (advisory)  1.2.0 (advisory)  1.2.0 (advisory)  
 
+transitive dependencies:
+transitive    1.2.3              -                 -                 1.2.3             
+
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `dart pub upgrade`.
 

--- a/test/testdata/goldens/outdated/outdated_test/show advisory - current also retracted.txt
+++ b/test/testdata/goldens/outdated/outdated_test/show advisory - current also retracted.txt
@@ -84,6 +84,9 @@ Package Name  Current                        Upgradable  Resolvable  Latest
 direct dependencies:
 foo           *1.0.0 (retracted) (advisory)  1.2.0       1.2.0       1.2.0   
 
+transitive dependencies:
+transitive    1.2.3                          -           -           1.2.3   
+
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `dart pub upgrade`.
 

--- a/test/testdata/goldens/outdated/outdated_test/show advisory - current, same package mentioned twice.txt
+++ b/test/testdata/goldens/outdated/outdated_test/show advisory - current, same package mentioned twice.txt
@@ -82,6 +82,9 @@ Package Name  Current            Upgradable  Resolvable  Latest
 direct dependencies:
 foo           *1.0.0 (advisory)  1.2.0       1.2.0       1.2.0   
 
+transitive dependencies:
+transitive    1.2.3              -           -           1.2.3   
+
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `dart pub upgrade`.
 

--- a/test/testdata/goldens/outdated/outdated_test/show advisory - current.txt
+++ b/test/testdata/goldens/outdated/outdated_test/show advisory - current.txt
@@ -82,6 +82,9 @@ Package Name  Current            Upgradable  Resolvable  Latest
 direct dependencies:
 foo           *1.0.0 (advisory)  1.2.0       1.2.0       1.2.0   
 
+transitive dependencies:
+transitive    1.2.3              -           -           1.2.3   
+
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `dart pub upgrade`.
 

--- a/test/testdata/goldens/outdated/outdated_test/show advisory - latest also discontinued.txt
+++ b/test/testdata/goldens/outdated/outdated_test/show advisory - latest also discontinued.txt
@@ -84,6 +84,9 @@ Package Name  Current  Upgradable        Resolvable        Latest
 direct dependencies:
 foo           *1.0.0   1.2.0 (advisory)  1.2.0 (advisory)  1.2.0 (advisory)  (discontinued)  
 
+transitive dependencies:
+transitive    1.2.3    -                 -                 1.2.3             
+
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `dart pub upgrade`.
 

--- a/test/testdata/goldens/outdated/outdated_test/show advisory - latest.txt
+++ b/test/testdata/goldens/outdated/outdated_test/show advisory - latest.txt
@@ -82,6 +82,9 @@ Package Name  Current  Upgradable        Resolvable        Latest
 direct dependencies:
 foo           *1.0.0   1.2.0 (advisory)  1.2.0 (advisory)  1.2.0 (advisory)  
 
+transitive dependencies:
+transitive    1.2.3    -                 -                 1.2.3             
+
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `dart pub upgrade`.
 

--- a/test/testdata/goldens/outdated/outdated_test/show advisory - several advisories.txt
+++ b/test/testdata/goldens/outdated/outdated_test/show advisory - several advisories.txt
@@ -88,6 +88,9 @@ Package Name  Current            Upgradable        Resolvable        Latest
 direct dependencies:
 foo           *1.0.0 (advisory)  1.2.0 (advisory)  1.2.0 (advisory)  1.2.0 (advisory)  
 
+transitive dependencies:
+transitive    1.2.3              -                 -                 1.2.3             
+
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `dart pub upgrade`.
 

--- a/test/testdata/goldens/outdated/outdated_test/show discontinued and retracted.txt
+++ b/test/testdata/goldens/outdated/outdated_test/show discontinued and retracted.txt
@@ -102,6 +102,9 @@ direct dependencies:
 bar           *1.0.0 (retracted)  *1.0.0 (retracted)  *1.0.0 (retracted)  -       (discontinued)  
 foo           *1.0.0 (retracted)  1.2.0               1.2.0               1.2.0   (discontinued)  
 
+transitive dependencies:
+transitive    1.2.3               1.2.3               1.2.3               1.2.3   
+
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `dart pub upgrade`.
 

--- a/test/testdata/goldens/outdated/outdated_test/show discontinued with no latest version.txt
+++ b/test/testdata/goldens/outdated/outdated_test/show discontinued with no latest version.txt
@@ -73,6 +73,9 @@ direct dependencies:
 bar           1.0.0               1.0.0               1.0.0               1.0.0   
 baz           1.0.0               1.0.0               1.0.0               1.0.0   (discontinued)  
 foo           *1.2.3 (retracted)  *1.2.3 (retracted)  *1.2.3 (retracted)  -       (discontinued)  
+
+transitive dependencies:
+transitive    1.2.3               1.2.3               1.2.3               1.2.3   
 You are already using the newest resolvable versions listed in the 'Resolvable' column.
 Newer versions, listed in 'Latest', may not be mutually compatible.
 

--- a/test/testdata/goldens/outdated/outdated_test/show discontinued.txt
+++ b/test/testdata/goldens/outdated/outdated_test/show discontinued.txt
@@ -37,6 +37,9 @@ direct dependencies:
 bar           1.0.0    1.0.0       1.0.0       1.0.0   
 baz           1.0.0    1.0.0       1.0.0       1.0.0   (discontinued)  
 foo           1.2.3    1.2.3       1.2.3       1.2.3   (discontinued)  
+
+transitive dependencies:
+transitive    1.2.3    1.2.3       1.2.3       1.2.3   
 You are already using the newest resolvable versions listed in the 'Resolvable' column.
 Newer versions, listed in 'Latest', may not be mutually compatible.
 

--- a/test/testdata/goldens/outdated/outdated_test/show retracted.txt
+++ b/test/testdata/goldens/outdated/outdated_test/show retracted.txt
@@ -74,6 +74,9 @@ Package Name  Current             Upgradable  Resolvable  Latest
 direct dependencies:
 foo           *1.0.0 (retracted)  1.2.0       1.2.0       1.2.0   
 
+transitive dependencies:
+transitive    1.2.3               -           -           1.2.3   
+
 1 upgradable dependency is locked (in pubspec.lock) to an older version.
 To update it, use `dart pub upgrade`.
 


### PR DESCRIPTION
https://github.com/dart-lang/pub/issues/4273