### PR TITLE
Include all directories in published tar.gz archive

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -303,9 +303,10 @@ the \$PUB_HOSTED_URL environment variable.''',
       await entrypoint.acquireDependencies(SolveType.get);
     }
 
-    // We want to preserve empty directories in the published archive, so
-    // first we list all files and directories, and then filter any non-empty
-    // directories away.
+    // For displaying the layout we only want to explicitly mention non-empty
+    // directories, so first we list all files and directories, and then filter
+    // any non-empty directories away.
+    // For validation it is practical to also maintain the list of files.
     final filesAndDirs = entrypoint.workPackage.listFiles(includeDirs: true);
 
     final files = <String>[];
@@ -333,7 +334,7 @@ the \$PUB_HOSTED_URL environment variable.''',
     );
 
     final packageBytes = await createTarGz(
-      filesAndEmptyDirs,
+      filesAndDirs,
       baseDir: entrypoint.workPackage.dir,
     ).toBytes();
 

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -1163,7 +1163,7 @@ ByteStream createTarGz(
   final tarContents = Stream.fromIterable(
     contents.map((entry) {
       entry = p.normalize(p.absolute(entry));
-      if (!p.isWithin(baseDir, entry)) {
+      if (!p.equals(baseDir, entry) && !p.isWithin(baseDir, entry)) {
         throw ArgumentError('Entry $entry is not inside $baseDir.');
       }
 

--- a/test/lish/empy_directories_test.dart
+++ b/test/lish/empy_directories_test.dart
@@ -44,16 +44,14 @@ void main() {
         File(p.join(d.sandbox, appPath, 'archive.tar.gz')).openRead(),
       ),
     );
-    var found = false;
+    final dirs = <String>[];
     while (await tarReader.moveNext()) {
       final entry = tarReader.current;
-      if (entry.name == 'lib/empty') {
-        found = true;
-        expect(entry.type, TypeFlag.dir);
+      if (entry.type == TypeFlag.dir) {
+        dirs.add(entry.name);
       }
     }
-    expect(found, isTrue);
-
+    expect(dirs, ['.', 'lib', 'lib/empty']);
     await d.credentialsFile(globalServer, 'access-token').create();
     final pub = await startPublish(globalServer);
 


### PR DESCRIPTION
Follow-up to https://github.com/dart-lang/pub/pull/4278

Including all directories explicitly seems to be what eg. GNU tar does.

We add the '.' base dir - not sure if that is right or wrong...