### PR TITLE
Also use absolute path in solve report, when root is a parent

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -565,7 +565,7 @@ Try running `$topLevelProgram pub get` to create `$lockFilePath`.''');
 
     final report = SolveReport(
       type,
-      workspaceRoot.dir,
+      workspaceRoot.presentationDir,
       workspaceRoot.pubspec,
       workspaceRoot.allOverridesInWorkspace,
       lockFile,

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -346,11 +346,15 @@ void main() {
         ]),
       ]),
     ]).create();
+    final absoluteAppPath = p.join(sandbox, appPath);
     await pubGet(
       environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
       workingDirectory: p.join(sandbox, appPath, 'pkgs'),
-      output: contains(
-        'Resolving dependencies in `${p.join(sandbox, appPath)}`...',
+      output: allOf(
+        contains(
+          'Resolving dependencies in `$absoluteAppPath`...',
+        ),
+        contains('Got dependencies in `$absoluteAppPath`'),
       ),
     );
     await pubGet(


### PR DESCRIPTION
Follow-up to https://github.com/dart-lang/pub/pull/4231

```
/usr/local/google/home/sigurdm/projects/pub-dev/app > dart pub get
Resolving dependencies in `/usr/local/google/home/sigurdm/projects/pub-dev`...  # <--- already fixed here
Downloading packages... 
  archive 3.5.1 (3.6.0 available)
 [...]
  web_socket_channel 2.4.5 (3.0.0 available)
Got dependencies in `..`! # <------ now fixing this.
14 packages have newer versions incompatible wit
```