### PR TITLE
await exit code in publication test

### DIFF
--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -1347,6 +1347,7 @@ Consider removing one of the overrides.''',
     await confirmPublish(pub);
     handleUploadForm(server);
     handleUpload(server);
+    await pub.shouldExit(SUCCESS);
   });
 
   test(


### PR DESCRIPTION
The test is flaky without this.