### PR TITLE
Remove a stale statement in a doc comment

### DIFF
--- a/lib/src/validator/sdk_constraint.dart
+++ b/lib/src/validator/sdk_constraint.dart
@@ -11,7 +11,6 @@ import '../validator.dart';
 /// A validator of the SDK constraint.
 ///
 /// Validates that a package's SDK constraint:
-/// * doesn't use the "^" syntax.
 /// * has an upper bound.
 /// * is not depending on a prerelease, unless the package itself is a
 /// prerelease.


### PR DESCRIPTION
The caret syntax is allowed since #3672
