### PR TITLE
Add test for issue when excluding a nested dir from a higher level gitignore file

### DIFF
--- a/test/validator/gitignore_test.dart
+++ b/test/validator/gitignore_test.dart
@@ -51,6 +51,13 @@ void main() {
       ]),
       exit_codes.DATA,
     );
+
+    // Check that you can unignore certain files too.
+    await d.dir('myapp', [
+      d.file('.gitignore', '*.txt\n!foo.txt'),
+    ]).create();
+
+    await expectValidation(contains('Package has 0 warnings.'), 0);
   });
 
   test('should not fail on non-ascii unicode character', () async {
@@ -119,6 +126,17 @@ void main() {
         ),
       ]),
       exit_codes.DATA,
+      workingDirectory: packageRoot,
+    );
+
+    // Check that you can unignore certain dirs from a higher level gitignore.
+    await d.dir('reporoot', [
+      d.file('.gitignore', '*.txt\n!myapp/'),
+    ]).create();
+
+    await expectValidation(
+      contains('Package has 0 warnings.'),
+      0,
       workingDirectory: packageRoot,
     );
   });


### PR DESCRIPTION
Repro test for https://github.com/dart-lang/pub/issues/4300

I don't see a good mechanism for skipping individual parts of a test so this can just land after the issue is fixed (or close this and write different tests)