### PR TITLE
Add `--recurse-submodules` to clone in git sources, so submodules are handled properly

### DIFF
--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -682,7 +682,7 @@ class GitSource extends CachedSource {
     // Git on Windows does not seem to automatically create the destination
     // directory.
     ensureDir(to);
-    final args = ['clone', if (mirror) '--mirror', from, to];
+    final args = ['clone', if (mirror) '--mirror', '--recurse-submodules', from, to];
 
     await git.run(args);
   }


### PR DESCRIPTION
Makes sure that submodules are handled properly when git package sources are cloned.

See #2807 2807

Very small PR, but untested as I don't have time to setup a build environment at the moment. Thus, this needs to be tested and verified. However this _should just work(tm)_

Imposes limit on git version >= 2.13

Please advise if you request further work from me, as I'd _very much_ appreciate this (or an alternative solution) getting merged.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
