### PR TITLE
Use forward slashes in paths when using path dependencies from git dependencies

### DIFF
--- a/lib/src/source/path.dart
+++ b/lib/src/source/path.dart
@@ -103,11 +103,13 @@ class PathSource extends Source {
           '"$description" is an absolute path, it can\'t be referenced from a git pubspec.',
         );
       }
-      final resolvedPath = p.url.joinAll([
-        containingDescription.path,
-        ...p.posix.split(dir),
-      ]);
-      if (!p.isWithin('.', resolvedPath)) {
+      final resolvedPath = p.url.normalize(
+        p.url.joinAll([
+          containingDescription.path,
+          ...p.posix.split(dir),
+        ]),
+      );
+      if (!(p.isWithin('.', resolvedPath) || p.equals('.', resolvedPath))) {
         throw FormatException(
           'the path "$description" cannot refer outside the git repository $resolvedPath.',
         );
@@ -118,12 +120,7 @@ class PathSource extends Source {
           url: containingDescription.url,
           relative: containingDescription.relative,
           ref: containingDescription.ref,
-          path: p.normalize(
-            p.join(
-              containingDescription.path,
-              dir,
-            ),
-          ),
+          path: resolvedPath,
         ),
       );
     } else if (containingDescription is HostedDescription) {

--- a/test/get/git/check_out_transitive_test.dart
+++ b/test/get/git/check_out_transitive_test.dart
@@ -2,10 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:pub/src/exit_codes.dart';
 import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
@@ -100,16 +103,60 @@ void main() {
     ensureGit();
 
     await d.git('foo.git', [
+      d.dir('pkgs', [
+        d.dir('foo', [
+          d.libPubspec(
+            'foo',
+            '1.0.0',
+            deps: {
+              'bar': {'path': '../bar'},
+            },
+          ),
+        ]),
+        d.dir('bar', [d.libPubspec('bar', '1.0.0')]),
+      ]),
+    ]).create();
+
+    await d.appDir(
+      dependencies: {
+        'foo': {
+          'git': {
+            'url': p
+                .toUri(p.absolute(d.sandbox, appPath, '../foo.git'))
+                .toString(),
+            'path': 'pkgs/foo',
+          },
+        },
+      },
+    ).create();
+
+    await pubGet();
+    final lockFile = loadYaml(
+      File(p.join(d.sandbox, appPath, 'pubspec.lock')).readAsStringSync(),
+    );
+    expect(
+      lockFile['packages']['bar']['description']['path'],
+      'pkgs/bar',
+      reason: 'Use forward slashes for path',
+    );
+  });
+
+  test(
+      'can have relative path dependencies to the repo root dir transitively from Git',
+      () async {
+    ensureGit();
+
+    await d.git('foo.git', [
       d.dir('foo', [
         d.libPubspec(
           'foo',
           '1.0.0',
           deps: {
-            'bar': {'path': '../bar'},
+            'bar': {'path': '..'},
           },
         ),
       ]),
-      d.dir('bar', [d.libPubspec('bar', '1.0.0')]),
+      d.libPubspec('bar', '1.0.0'),
     ]).create();
 
     await d.appDir(


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/4314