### PR TITLE
Remove some unnecessary analysis options

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,11 +1,6 @@
 include: package:lints/recommended.yaml
 
 analyzer:
-  errors:
-    unused_import: error
-    unused_local_variable: error
-    dead_code: error
-    todo: ignore
   exclude:
    - lib/src/third_party/**
 


### PR DESCRIPTION
The upgrade of some warnings to errors was intended to make external CI
a closer match to google3. Since then we have started using
`--fatal-infos` which makes it unnecessary to make these errors.

The TODO ignore is unnecessary because the analysis server no longer
includes TODO comments in the list of diagnostics.
