### PR TITLE
Fix a batch of long lines

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,6 +25,7 @@ linter:
     - cancel_subscriptions
     - directives_ordering
     - library_annotations
+    - lines_longer_than_80_chars
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
     - no_runtimeType_toString

--- a/lib/src/authentication/client.dart
+++ b/lib/src/authentication/client.dart
@@ -22,8 +22,8 @@ class _AuthenticatedClient extends http.BaseClient {
   /// Constructs Http client wrapper that injects `authorization` header to
   /// requests and handles authentication errors.
   ///
-  /// [_credential] might be `null`. In that case `authorization` header will not
-  /// be injected to requests.
+  /// [_credential] might be `null`. In that case `authorization` header will
+  /// not be injected to requests.
   _AuthenticatedClient(this._inner, this._credential);
 
   final http.BaseClient _inner;

--- a/lib/src/authentication/credential.dart
+++ b/lib/src/authentication/credential.dart
@@ -87,9 +87,9 @@ class Credential {
   /// Environment variable name that stores token value
   final String? env;
 
-  /// Unknown fields found in pub-tokens.json. The fields might be created by the
-  /// future version of pub tool. We don't want to override them when using the
-  /// old SDK.
+  /// Unknown fields found in pub-tokens.json. The fields might be created by
+  /// the future version of pub tool. We don't want to override them when using
+  /// the old SDK.
   final Map<String, dynamic> unknownFields;
 
   /// Serializes [Credential] into json format.

--- a/lib/src/command.dart
+++ b/lib/src/command.dart
@@ -236,9 +236,11 @@ and attaching the relevant parts of that log file.
         } on ApplicationException {
           e = null;
         }
+        final protectedArguments =
+            _topCommand.argResults!.arguments.map(protectArgument).join(' ');
         log.dumpTranscriptToFile(
           transcriptPath,
-          'dart pub ${_topCommand.argResults!.arguments.map(protectArgument).join(' ')}',
+          'dart pub $protectedArguments',
           e,
         );
 

--- a/lib/src/command/add.dart
+++ b/lib/src/command/add.dart
@@ -97,9 +97,12 @@ For example:
       hide: true,
     );
 
-    // Following options are hidden/deprecated in favor of the new syntax: [dev:]<package>[:descriptor] ...
-    // To avoid breaking changes we keep supporting them, but hide them from --help to discourage
-    // further use. Combining these with new syntax will fail.
+    // Following options are hidden/deprecated in favor of the new syntax:
+    //   [dev:]<package>[:descriptor] ...
+    //
+    // To avoid breaking changes we keep supporting them,
+    // but hide them from --help to discourage further use.
+    // Combining these with new syntax will fail.
     argParser.addOption(
       'git-url',
       help: 'Git URL of the package',
@@ -228,7 +231,8 @@ Specify multiple sdk packages with descriptors.''');
       final resultPackage = solveResult.packages
           .firstWhere((packageId) => packageId.name == name);
 
-      /// Assert that [resultPackage] is within the original user's expectations.
+      /// Assert that [resultPackage] is within the original user's
+      /// expectations.
       final constraint = update.constraint;
       if (constraint != null && !constraint.allows(resultPackage.version)) {
         final dependencyOverrides = resolutionPubspec.dependencyOverrides;
@@ -332,7 +336,8 @@ Specify multiple sdk packages with descriptors.''');
     } else {
       if (dependencyNames.contains(name)) {
         log.message(
-          '"$name" is already in "dependencies". Will try to update the constraint.',
+          '"$name" is already in "dependencies". '
+          'Will try to update the constraint.',
         );
         dependencies.removeWhere((element) => element.name == name);
       }
@@ -368,8 +373,8 @@ Specify multiple sdk packages with descriptors.''');
     r'(?::(?<descriptor>.*))?$',
   );
 
-  /// Split [arg] on ':' and interpret it with the flags in [argResult] either as
-  /// an old-style or a new-style descriptor to produce a PackageRef].
+  /// Split [arg] on ':' and interpret it with the flags in [argResult] either
+  /// as an old-style or a new-style descriptor to produce a PackageRef].
   _ParseResult _parsePackage(String arg, ArgResults argResults) {
     var isDev = argResults.flag('dev');
     var isOverride = false;
@@ -502,7 +507,8 @@ Specify multiple sdk packages with descriptors.''');
       }
       if (couldParseAsNewStyle) {
         usageException(
-          '--dev, --path, --sdk, --git-url, --git-path and --git-ref cannot be combined with a descriptor.',
+          '--dev, --path, --sdk, --git-url, --git-path and --git-ref '
+          'cannot be combined with a descriptor.',
         );
       } else {
         usageException('Invalid version constraint: ${e.message}');
@@ -629,7 +635,8 @@ Specify multiple sdk packages with descriptors.''');
               },
             },
             cache.sources,
-            // Resolve relative paths relative to current, not where the pubspec.yaml is.
+            // Resolve relative paths relative to current, not where the
+            // pubspec.yaml is.
             containingDescription: RootDescription(p.current),
           );
         } on FormatException catch (e) {
@@ -716,7 +723,8 @@ Specify multiple sdk packages with descriptors.''');
       }
 
       /// Remove the package from dev_dependencies if we are adding it to
-      /// dependencies. Refer to [_addPackageToPubspec] for additional discussion.
+      /// dependencies. Refer to [_addPackageToPubspec] for additional
+      /// discussion.
       if (!update.isDev && !update.isOverride) {
         final devDependenciesNode = yamlEditor
             .parseAt(['dev_dependencies'], orElse: () => YamlScalar.wrap(null));

--- a/lib/src/command/cache_preload.dart
+++ b/lib/src/command/cache_preload.dart
@@ -21,8 +21,9 @@ class CachePreloadCommand extends PubCommand {
   @override
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-cache';
 
-  /// The `cache preload` command is hidden by default, because it's really only intended for
-  /// `flutter` to use when pre-loading `PUB_CACHE` after being installed from `zip` archive.
+  /// The `cache preload` command is hidden by default, because it's really only
+  /// intended for `flutter` to use when pre-loading `PUB_CACHE` after being
+  /// installed from `zip` archive.
   @override
   bool get hidden => true;
 

--- a/lib/src/command/cache_repair.dart
+++ b/lib/src/command/cache_repair.dart
@@ -38,15 +38,17 @@ class CacheRepairCommand extends PubCommand {
 
     if (successes.isNotEmpty) {
       final packages = pluralize('package', successes.length);
+      final count = log.green(successes.length.toString());
       log.message(
-        'Reinstalled ${log.green(successes.length.toString())} $packages.',
+        'Reinstalled $count $packages.',
       );
     }
 
     if (failures.isNotEmpty) {
       final packages = pluralize('package', failures.length);
+      final count = log.red(failures.length.toString());
       final buffer = StringBuffer(
-        'Failed to reinstall ${log.red(failures.length.toString())} $packages:\n',
+        'Failed to reinstall $count $packages:\n',
       );
 
       for (var failure in failures) {
@@ -64,15 +66,17 @@ class CacheRepairCommand extends PubCommand {
         await globals.repairActivatedPackages();
     if (repairSuccesses.isNotEmpty) {
       final packages = pluralize('package', repairSuccesses.length);
+      final count = log.green(repairSuccesses.length.toString());
       log.message(
-        'Reactivated ${log.green(repairSuccesses.length.toString())} $packages.',
+        'Reactivated $count $packages.',
       );
     }
 
     if (repairFailures.isNotEmpty) {
       final packages = pluralize('package', repairFailures.length);
+      final count = log.red(repairFailures.length.toString());
       log.message(
-        'Failed to reactivate ${log.red(repairFailures.length.toString())} $packages:',
+        'Failed to reactivate $count $packages:',
       );
       log.message(
         repairFailures.map((name) => '- ${log.bold(name)}').join('\n'),

--- a/lib/src/command/dependency_services.dart
+++ b/lib/src/command/dependency_services.dart
@@ -38,8 +38,8 @@ class DependencyServicesReportCommand extends PubCommand {
   @override
   String get name => 'report';
   @override
-  String get description =>
-      'Output a machine-digestible report of the upgrade options for each dependency.';
+  String get description => 'Output a machine-digestible report of '
+      'the upgrade options for each dependency.';
   @override
   String get argumentsDescription => '[options]';
 
@@ -329,7 +329,8 @@ class DependencyServicesApplyCommand extends PubCommand {
             );
           } else {
             fail(
-              'The dependency $targetPackage does not have a map or string as a description',
+              'The dependency $targetPackage does not have '
+              'a map or string as a description',
             );
           }
         } else if (targetVersion != null) {
@@ -389,7 +390,8 @@ class DependencyServicesApplyCommand extends PubCommand {
           final versions = await cache.getVersions(updatedRef);
           if (versions.isEmpty) {
             dataError(
-              'Found no versions of $targetPackage with git revision `$targetRevision`.',
+              'Found no versions of $targetPackage with '
+              'git revision `$targetRevision`.',
             );
           }
           // GitSource can only return a single version.
@@ -407,7 +409,8 @@ class DependencyServicesApplyCommand extends PubCommand {
             targetRevision == null &&
             !(lockFileYaml['packages'] as Map).containsKey(targetPackage)) {
           dataError(
-            'Trying to remove non-existing transitive dependency $targetPackage.',
+            'Trying to remove non-existing '
+            'transitive dependency $targetPackage.',
           );
         }
       }
@@ -452,7 +455,8 @@ class DependencyServicesApplyCommand extends PubCommand {
             );
           }
         }
-        // Only if we originally had a lock-file we write the resulting lockfile back.
+        // Only if we originally had a lock-file we write the resulting lockfile
+        // back.
         if (updatedLockfile != null) {
           final updatedPackages = <PackageId>[];
           for (var package in solveResult.packages) {
@@ -575,7 +579,8 @@ Map<String, PackageRange>? _dependencySetOfPackage(
 
 /// Return a constraint compatible with [newVersion].
 ///
-/// By convention if the original constraint is pinned we return [newVersion]. Otherwise use [VersionConstraint.compatibleWith].
+/// By convention if the original constraint is pinned we return [newVersion].
+/// Otherwise use [VersionConstraint.compatibleWith].
 VersionConstraint _bumpConstraint(
   VersionConstraint original,
   Version newVersion,
@@ -594,9 +599,11 @@ VersionConstraint _bumpConstraint(
   );
 }
 
-/// Return a constraint compatible with [newVersion], but including [original] as well.
+/// Return a constraint compatible with [newVersion], but including [original]
+/// as well.
 ///
-/// By convention if the original constraint is pinned, we don't widen the constraint but return [newVersion] instead.
+/// By convention if the original constraint is pinned, we don't widen the
+/// constraint but return [newVersion] instead.
 VersionConstraint _widenConstraint(
   VersionConstraint original,
   Version newVersion,

--- a/lib/src/command/deps.dart
+++ b/lib/src/command/deps.dart
@@ -77,12 +77,14 @@ class DepsCommand extends PubCommand {
     if (argResults.flag('json')) {
       if (argResults.wasParsed('dev')) {
         usageException(
-          'Cannot combine --json and --dev.\nThe json output contains the dependency type in the output.',
+          'Cannot combine --json and --dev.\n'
+          'The json output contains the dependency type in the output.',
         );
       }
       if (argResults.wasParsed('executables')) {
         usageException(
-          'Cannot combine --json and --executables.\nThe json output always lists available executables.',
+          'Cannot combine --json and --executables.\n'
+          'The json output always lists available executables.',
         );
       }
       if (argResults.wasParsed('style')) {
@@ -368,7 +370,8 @@ class DepsCommand extends PubCommand {
   String _labelPackage(Package package) =>
       '${log.bold(package.name)} ${package.version}';
 
-  /// Gets the names of the non-immediate dependencies of the workspace packages.
+  /// Gets the names of the non-immediate dependencies of the workspace
+  /// packages.
   Future<Set<String>> _getTransitiveDependencies() async {
     final transitive = await _getAllDependencies();
     for (final root in entrypoint.workspaceRoot.transitiveWorkspace) {

--- a/lib/src/command/get.dart
+++ b/lib/src/command/get.dart
@@ -37,8 +37,8 @@ class GetCommand extends PubCommand {
     argParser.addFlag(
       'enforce-lockfile',
       negatable: false,
-      help:
-          'Enforce pubspec.lock. Fail resolution if pubspec.lock does not satisfy pubspec.yaml',
+      help: 'Enforce pubspec.lock. '
+          'Fail resolution if pubspec.lock does not satisfy pubspec.yaml',
     );
 
     argParser.addFlag(

--- a/lib/src/command/global_activate.dart
+++ b/lib/src/command/global_activate.dart
@@ -73,8 +73,8 @@ class GlobalActivateCommand extends PubCommand {
     argParser.addOption(
       'hosted-url',
       abbr: 'u',
-      help:
-          'A custom pub server URL for the package. Only applies when using the `hosted` source.',
+      help: 'A custom pub server URL for the package. '
+          'Only applies when using the `hosted` source.',
     );
   }
 
@@ -115,7 +115,8 @@ class GlobalActivateCommand extends PubCommand {
         (argResults.option('git-path') != null ||
             argResults.option('git-ref') != null)) {
       usageException(
-        'Options `--git-path` and `--git-ref` can only be used with --source=git.',
+        'Options `--git-path` and `--git-ref` '
+        'can only be used with --source=git.',
       );
     }
 
@@ -156,7 +157,8 @@ class GlobalActivateCommand extends PubCommand {
 
         if (!packageNameRegExp.hasMatch(package)) {
           final suggestion = dirExists(package)
-              ? '\n\nDid you mean `$topLevelProgram pub global activate --source path ${escapeShellArgument(package)}`?'
+              ? '\n\nDid you mean `$topLevelProgram pub global activate '
+                  '--source path ${escapeShellArgument(package)}`?'
               : '';
 
           usageException('Not a valid package name: "$package"$suggestion');

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -94,8 +94,8 @@ class LishCommand extends PubCommand {
     argParser.addFlag(
       'skip-validation',
       negatable: false,
-      help:
-          'Publish without validation and resolution (this will ignore errors).',
+      help: 'Publish without validation and resolution '
+          '(this will ignore errors).',
     );
     argParser.addOption(
       'server',
@@ -110,8 +110,8 @@ class LishCommand extends PubCommand {
     );
     argParser.addOption(
       'from-archive',
-      help:
-          'Publish from a .tar.gz archive instead of current folder. Implies `--skip-validation`.',
+      help: 'Publish from a .tar.gz archive instead of current folder. '
+          'Implies `--skip-validation`.',
       valueHelp: '[archive.tar.gz]',
       hide: true,
     );
@@ -328,9 +328,14 @@ the \$PUB_HOSTED_URL environment variable.''',
     // Show the package contents so the user can verify they look OK.
     final package = entrypoint.workPackage;
     final host = computeHost(package.pubspec);
+    final fileTree = tree.fromFiles(
+      filesAndEmptyDirs,
+      baseDir: entrypoint.workPackage.dir,
+      showFileSizes: true,
+    );
     log.message(
       'Publishing ${package.name} ${package.version} to $host:\n'
-      '${tree.fromFiles(filesAndEmptyDirs, baseDir: entrypoint.workPackage.dir, showFileSizes: true)}',
+      '$fileTree',
     );
 
     final packageBytes = await createTarGz(
@@ -338,8 +343,9 @@ the \$PUB_HOSTED_URL environment variable.''',
       baseDir: entrypoint.workPackage.dir,
     ).toBytes();
 
+    final totalSize = _readableFileSize(packageBytes.length);
     log.message(
-      '\nTotal compressed archive size: ${_readableFileSize(packageBytes.length)}.\n',
+      '\nTotal compressed archive size: $totalSize.\n',
     );
 
     final validationResult =
@@ -402,7 +408,8 @@ the \$PUB_HOSTED_URL environment variable.''',
   /// Throws if there are errors and the upload should not
   /// proceed.
   ///
-  /// Returns a summary of warnings and hints if there are any, otherwise `null`.
+  /// Returns a summary of warnings and hints if there are any, otherwise
+  /// `null`.
   Future<({int warningsCount, int hintsCount})> _validate(
     Uint8List packageBytes,
     List<String> files,
@@ -444,8 +451,8 @@ the \$PUB_HOSTED_URL environment variable.''',
     log.message('\nPublishing is forever; packages cannot be unpublished.'
         '\nPolicy details are available at https://pub.dev/policy\n');
 
-    var message =
-        'Do you want to publish ${package.pubspec.name} ${package.pubspec.version} to $host';
+    var message = 'Do you want to publish '
+        '${package.pubspec.name} ${package.pubspec.version} to $host';
     if (package.hintCount != 0 || package.warningCount != 0) {
       message = '${package.warningsCountMessage}. $message';
     }

--- a/lib/src/command/login.dart
+++ b/lib/src/command/login.dart
@@ -28,7 +28,8 @@ class LoginCommand extends PubCommand {
       final userInfo = await _retrieveUserInfo();
       if (userInfo == null) {
         log.warning('Could not retrieve your user-details.\n'
-            'You might have to run `$topLevelProgram pub logout` to delete your credentials and try again.');
+            'You might have to run `$topLevelProgram pub logout` '
+            'to delete your credentials and try again.');
       } else {
         log.message('You are now logged in as $userInfo');
       }
@@ -36,7 +37,8 @@ class LoginCommand extends PubCommand {
       final userInfo = await _retrieveUserInfo();
       if (userInfo == null) {
         log.warning('Your credentials seems broken.\n'
-            'Run `$topLevelProgram pub logout` to delete your credentials and try again.');
+            'Run `$topLevelProgram pub logout` '
+            'to delete your credentials and try again.');
       }
       log.warning('You are already logged in as $userInfo\n'
           'Run `$topLevelProgram pub logout` to log out and try again.');

--- a/lib/src/command/outdated.dart
+++ b/lib/src/command/outdated.dart
@@ -68,8 +68,8 @@ class OutdatedCommand extends PubCommand {
     argParser.addOption(
       'mode',
       help: 'Highlight versions with PROPERTY.\n'
-          'Only packages currently missing that PROPERTY will be included unless '
-          '--show-all.',
+          'Only packages currently missing that PROPERTY will be included '
+          'unless --show-all.',
       valueHelp: 'PROPERTY',
       allowed: ['outdated', 'null-safety'],
       defaultsTo: 'outdated',
@@ -299,7 +299,8 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
 
       var isCurrentAffectedByAdvisory = false;
       if (currentVersionDetails != null) {
-        // Filter out advisories added to `ignored_advisores` in the root pubspec.
+        // Filter out advisories added to `ignored_advisores` in the root
+        // pubspec.
         packageAdvisories = packageAdvisories
             .where(
               (adv) => entrypoint.workspaceRoot.pubspec.ignoredAdvisories
@@ -671,10 +672,10 @@ Future<void> _outputHuman(
             'an older version.\n'
             'To update it, use `$topLevelProgram pub upgrade`.');
       } else {
-        log.message(
-            '\n$upgradable upgradable dependencies are locked (in pubspec.lock) '
-            'to older versions.\n'
-            'To update these dependencies, use `$topLevelProgram pub upgrade`.');
+        log.message('\n$upgradable upgradable dependencies are locked '
+            '(in pubspec.lock) to older versions.\n'
+            'To update these dependencies, '
+            'use `$topLevelProgram pub upgrade`.');
       }
     }
 
@@ -683,15 +684,17 @@ Future<void> _outputHuman(
         rows.isNotEmpty &&
         (directRows.isNotEmpty || devRows.isNotEmpty)) {
       log.message(
-          "You are already using the newest resolvable versions listed in the 'Resolvable' column.\n"
-          "Newer versions, listed in 'Latest', may not be mutually compatible.");
+          'You are already using the newest resolvable versions listed in the '
+          "'Resolvable' column.\n"
+          "Newer versions, listed in 'Latest', "
+          'may not be mutually compatible.');
     } else if (directRows.isEmpty && devRows.isEmpty) {
       log.message(mode.allSafe);
     }
   } else {
     log.message('\nNo pubspec.lock found. There are no Current versions.\n'
-        'Run `$topLevelProgram pub get` to create a pubspec.lock with versions matching your '
-        'pubspec.yaml.');
+        'Run `$topLevelProgram pub get` to create a pubspec.lock '
+        'with versions matching your pubspec.yaml.');
   }
   if (notAtResolvable != 0) {
     if (notAtResolvable == 1) {
@@ -815,8 +818,8 @@ Showing outdated packages$directoryDescription.
       '''No resolution was found. Try running `$topLevelProgram pub upgrade --dry-run` to explore why.''';
 
   @override
-  String get upgradeConstrained =>
-      'edit pubspec.yaml, or run `$topLevelProgram pub upgrade --major-versions`';
+  String get upgradeConstrained => 'edit pubspec.yaml, '
+      'or run `$topLevelProgram pub upgrade --major-versions`';
 
   @override
   String get allSafe => 'all dependencies are up-to-date.';
@@ -1117,8 +1120,8 @@ bool hasDependency(Package workspaceRoot, String name) {
       .any((p) => p.dependencies.containsKey(name));
 }
 
-/// Whether the package [name] is dev-depended on directly anywhere in the workspace
-/// rooted at [workspaceRoot].
+/// Whether the package [name] is dev-depended on directly anywhere in the
+/// workspace rooted at [workspaceRoot].
 bool hasDevDependency(Package workspaceRoot, String name) {
   return workspaceRoot.transitiveWorkspace
       .any((p) => p.devDependencies.containsKey(name));

--- a/lib/src/command/remove.dart
+++ b/lib/src/command/remove.dart
@@ -160,8 +160,9 @@ To remove a dependency override of a package prefix the package name with
         }
       }
       if (!found) {
+        final pubspecPath = entrypoint.workPackage.pubspecPath;
         log.warning(
-          'Package "$name" was not found in ${entrypoint.workPackage.pubspecPath}!',
+          'Package "$name" was not found in $pubspecPath!',
         );
       }
     }

--- a/lib/src/command/token_list.dart
+++ b/lib/src/command/token_list.dart
@@ -18,8 +18,8 @@ class TokenListCommand extends PubCommand {
   Future<void> runProtected() async {
     if (cache.tokenStore.credentials.isNotEmpty) {
       log.message(
-        'You have secret tokens for ${cache.tokenStore.credentials.length} package '
-        'repositories:',
+        'You have secret tokens for ${cache.tokenStore.credentials.length} '
+        'package repositories:',
       );
       for (final token in cache.tokenStore.credentials) {
         log.message(token.url.toString());

--- a/lib/src/command/unpack.dart
+++ b/lib/src/command/unpack.dart
@@ -124,7 +124,8 @@ in a directory `foo-<version>`.
         deleteEntry(destinationDir);
       } else {
         fail(
-          'Target directory `$destinationDir` already exists. Use --force to overwrite.',
+          'Target directory `$destinationDir` already exists. '
+          'Use --force to overwrite.',
         );
       }
     }
@@ -183,7 +184,8 @@ in a directory `foo-<version>`.
             'environment': {'sdk': sdk.version.toString()},
           },
           cache.sources,
-          // Resolve relative paths relative to current, not where the pubspec.yaml is.
+          // Resolve relative paths relative to current, not where the
+          // pubspec.yaml is.
           location: p.toUri(p.join(p.current, 'descriptor')),
           containingDescription: RootDescription('.'),
         );

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -166,7 +166,8 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
   }
 
   /// Return names of packages to be upgraded, and throws [UsageException] if
-  /// any package names not in the direct dependencies or dev_dependencies are given.
+  /// any package names not in the direct dependencies or dev_dependencies are
+  /// given.
   ///
   /// This assumes that `--major-versions` was passed.
   List<String> _directDependenciesToUpgrade() {

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -153,7 +153,8 @@ Future<void> precompile({
     // This should make this slightly easier to recognize in error reports.
     if (!fileExists(temporaryIncrementalDill)) {
       log.error(
-        'Compilation did not produce any result. Expected file at `$temporaryIncrementalDill`',
+        'Compilation did not produce any result. '
+        'Expected file at `$temporaryIncrementalDill`',
         result.dillOutput,
       );
     }

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -133,7 +133,8 @@ class Entrypoint {
     }
     if (pubspecsMet.isEmpty) {
       throw FileException(
-        'Found no `pubspec.yaml` file in `${p.normalize(p.absolute(workingDir))}` or parent directories',
+        'Found no `pubspec.yaml` file in '
+        '`${p.normalize(p.absolute(workingDir))}` or parent directories',
         p.join(workingDir, 'pubspec.yaml'),
       );
     } else {
@@ -216,8 +217,8 @@ See $workspacesDocUrl for more information.''',
           e.message,
           e.span,
           explanation: 'Failed parsing lock file:',
-          hint:
-              'Consider deleting the file and running `$topLevelProgram pub get` to recreate it.',
+          hint: 'Consider deleting the file and running '
+              '`$topLevelProgram pub get` to recreate it.',
         );
       }
     }
@@ -244,7 +245,8 @@ See $workspacesDocUrl for more information.''',
       packageConfigRaw = readTextFile(packageConfigPath);
     } on FileException {
       dataError(
-        'The "$packageConfigPath" file does not exist, please run "$topLevelProgram pub get".',
+        'The "$packageConfigPath" file does not exist, '
+        'please run "$topLevelProgram pub get".',
       );
     }
     late PackageConfig result;
@@ -275,8 +277,8 @@ See $workspacesDocUrl for more information.''',
 
   Future<PackageGraph> _createPackageGraph() async {
     // TODO(sigurdm): consider having [ensureUptoDate] and [acquireDependencies]
-    // return the package-graph, such it by construction will always made from an
-    // up-to-date package-config.
+    // return the package-graph, such it by construction will always made from
+    // an up-to-date package-config.
     await ensureUpToDate(workspaceRoot.dir, cache: cache);
     final packages = {
       for (var packageEntry in packageConfig.nonInjectedPackages)
@@ -756,8 +758,8 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
     /// Whether the lockfile is out of date with respect to the dependencies'
     /// pubspecs.
     ///
-    /// If any mutable pubspec contains dependencies that are not in the lockfile
-    /// or that don't match what's in there, this will return `false`.
+    /// If any mutable pubspec contains dependencies that are not in the
+    /// lockfile or that don't match what's in there, this will return `false`.
     bool isLockFileUpToDate(
       LockFile lockFile,
       Package root, {
@@ -786,7 +788,8 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
         if (sdkVersion != null) {
           if (!constraint.effectiveConstraint.allows(sdkVersion)) {
             log.fine(
-              '`$lockFilePath` requires $sdkName $constraint. Current version is $sdkVersion',
+              '`$lockFilePath` requires $sdkName $constraint. '
+              'Current version is $sdkVersion',
             );
             return false;
           }
@@ -840,17 +843,17 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
     }) {
       /// Determines if [lockFile] agrees with the given [packagePathsMapping].
       ///
-      /// The [packagePathsMapping] is a mapping from package names to paths where
-      /// the packages are located. (The library is located under
-      /// `lib/` relative to the path given).
+      /// The [packagePathsMapping] is a mapping from package names to paths
+      /// where the packages are located.
+      /// (The library is located under `lib/` relative to the path given).
       bool isPackagePathsMappingUpToDateWithLockfile(
         Map<String, String> packagePathsMapping, {
         required String lockFilePath,
         required String packageConfigPath,
       }) {
-        // Check that [packagePathsMapping] does not contain more packages than what
-        // is required. This could lead to import statements working, when they are
-        // not supposed to work.
+        // Check that [packagePathsMapping] does not contain more packages than
+        // what is required. This could lead to import statements working, when
+        // they are not supposed to work.
         final hasExtraMappings = !packagePathsMapping.keys.every((packageName) {
           return packageName == root.name ||
               lockFile.packages.containsKey(packageName);
@@ -864,8 +867,8 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
         return lockFile.packages.values.every((lockFileId) {
           // It's very unlikely that the lockfile is invalid here, but it's not
           // impossible—for example, the user may have a very old application
-          // package with a checked-in lockfile that's newer than the pubspec, but
-          // that contains SDK dependencies.
+          // package with a checked-in lockfile that's newer than the pubspec,
+          // but that contains SDK dependencies.
           if (lockFileId.source is UnknownSource) return false;
 
           final packagePath = packagePathsMapping[lockFileId.name];
@@ -885,8 +888,8 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
           }
 
           // For cached sources, make sure the directory exists and looks like a
-          // package. This is also done by [_arePackagesAvailable] but that may not
-          // be run if the lockfile is newer than the pubspec.
+          // package. This is also done by [_arePackagesAvailable] but that may
+          // not be run if the lockfile is newer than the pubspec.
           if (source is CachedSource && !dirExists(lockFilePackagePath) ||
               !fileExists(p.join(lockFilePackagePath, 'pubspec.yaml'))) {
             return false;
@@ -903,7 +906,8 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
         // Pub always makes a packageUri of lib/
         if (pkg.packageUri == null || pkg.packageUri.toString() != 'lib/') {
           log.fine(
-            'The "$packageConfigPath" file is not recognized by this pub version.',
+            'The "$packageConfigPath" file is not recognized '
+            'by this pub version.',
           );
           return false;
         }
@@ -943,8 +947,8 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
         }
 
         try {
-          // Load `pubspec.yaml` and extract language version to compare with the
-          // language version from `package_config.json`.
+          // Load `pubspec.yaml` and extract language version to compare with
+          // the language version from `package_config.json`.
           final languageVersion = cache.load(id).pubspec.languageVersion;
           if (pkg.languageVersion != languageVersion) {
             final relativePubspecPath = p.join(
@@ -1028,7 +1032,8 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
         final workspaceRefText = tryReadTextFile(potentialWorkspaceRefPath);
         if (workspaceRefText == null) {
           log.fine(
-            '`$potentialPubspacPath` exists without corresponding `$potentialPubspacPath` or `$potentialWorkspaceRefPath`.',
+            '`$potentialPubspacPath` exists without corresponding '
+            '`$potentialPubspacPath` or `$potentialWorkspaceRefPath`.',
           );
           return null;
         } else {
@@ -1050,7 +1055,8 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
               packageConfigStat = tryStatFile(potentialPackageConfigPath2);
               if (packageConfigStat == null) {
                 log.fine(
-                  '`$potentialWorkspaceRefPath` points to non-existing `$potentialPackageConfigPath2`',
+                  '`$potentialWorkspaceRefPath` points to non-existing '
+                  '`$potentialPackageConfigPath2`',
                 );
                 return null;
               } else {
@@ -1070,7 +1076,8 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
               }
             } else {
               log.fine(
-                '`$potentialWorkspaceRefPath` is missing "workspaceRoot" property',
+                '`$potentialWorkspaceRefPath` is missing '
+                '"workspaceRoot" property',
               );
               return null;
             }
@@ -1129,7 +1136,9 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       final rootCacheUrl = p.toUri(p.absolute(cache.rootDir)).toString();
       if (packageConfig.additionalProperties['pubCache'] != rootCacheUrl) {
         log.fine(
-          'The pub cache has moved from ${packageConfig.additionalProperties['pubCache']} to $rootCacheUrl since last invocation.',
+          'The pub cache has moved from '
+          '${packageConfig.additionalProperties['pubCache']} to $rootCacheUrl '
+          'since last invocation.',
         );
         return null;
       }
@@ -1154,7 +1163,8 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
             rootDir,
             '.dart_tool',
             package.rootUri
-                // Important to use `toFilePath()` here rather than `path`, as it handles Url-decoding.
+                // Important to use `toFilePath()` here rather than `path`, as
+                // it handles Url-decoding.
                 .toFilePath(),
             'pubspec.yaml',
           ),
@@ -1425,8 +1435,9 @@ See https://dart.dev/go/sdk-constraint
     return result;
   }
 
-  /// Unless [dryRun], loads `pubspec.yaml` of each [package] in [changeSet] and applies the
-  /// changes to its (dev)-dependencies using yaml_edit to preserve textual structure.
+  /// Unless [dryRun], loads `pubspec.yaml` of each [package] in [changeSet] and
+  /// applies the changes to its (dev)-dependencies using yaml_edit to preserve
+  /// textual structure.
   ///
   /// Outputs a summary of changes done or would have been done if not [dryRun].
   void applyChanges(ChangeSet changeSet, bool dryRun) {
@@ -1466,7 +1477,8 @@ See https://dart.dev/go/sdk-constraint
       } else {
         final changed = dryRun ? 'Would change' : 'Changed';
         log.message('\n$changed ${changesToWorkspaceRoot.length} '
-            '${pluralize('constraint', changesToWorkspaceRoot.length)} in pubspec.yaml:');
+            '${pluralize('constraint', changesToWorkspaceRoot.length)} '
+            'in pubspec.yaml:');
         changesToWorkspaceRoot.forEach((from, to) {
           log.message('  ${from.name}: ${from.constraint} -> ${to.constraint}');
         });
@@ -1481,7 +1493,8 @@ See https://dart.dev/go/sdk-constraint
         if (changesToPackage.isEmpty) continue;
         final changed = dryRun ? 'Would change' : 'Changed';
         log.message('\n$changed ${changesToPackage.length} '
-            '${pluralize('constraint', changesToPackage.length)} in ${package.pubspecPath}:');
+            '${pluralize('constraint', changesToPackage.length)} '
+            'in ${package.pubspecPath}:');
         changesToPackage.forEach((from, to) {
           log.message('  ${from.name}: ${from.constraint} -> ${to.constraint}');
         });

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -351,8 +351,10 @@ Future<DartExecutableWithPackageConfig> getExecutableForCommand(
   )?.$1;
 
   if (rootPackageName == null) {
+    final configPath =
+        p.join(workspaceRootDir, '.dart_tool', 'package_config.json');
     throw CommandResolutionFailedException._(
-      '${p.join(workspaceRootDir, '.dart_tool', 'package_config.json')} did not contain its own root package',
+      '$configPath did not contain its own root package',
       CommandResolutionIssue.fileNotFound,
     );
   }

--- a/lib/src/flutter_releases.dart
+++ b/lib/src/flutter_releases.dart
@@ -100,6 +100,6 @@ class FlutterRelease {
     required this.channel,
   });
   @override
-  String toString() =>
-      'FlutterRelease(flutter=$flutterVersion, dart=$dartVersion, channel=$channel)';
+  String toString() => 'FlutterRelease'
+      '(flutter=$flutterVersion, dart=$dartVersion, channel=$channel)';
 }

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -648,8 +648,8 @@ try:
   /// existing binstubs in other packages will be overwritten by this one's.
   /// Otherwise, the previous ones will be preserved.
   ///
-  /// If [suggestIfNotOnPath] is `true` (the default), this will warn the user if
-  /// the bin directory isn't on their path.
+  /// If [suggestIfNotOnPath] is `true` (the default), this will warn the user
+  /// if the bin directory isn't on their path.
   void _updateBinStubs(
     Entrypoint entrypoint,
     Package package,

--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -222,8 +222,10 @@ void handleJsonSuccess(http.Response response) {
       parsed['success']['message'] is! String) {
     invalidServerResponse(response);
   }
+  final sanitizedMessage =
+      sanitizeForTerminal(parsed['success']['message'] as String);
   log.message(
-    'Message from server: ${log.green(sanitizeForTerminal(parsed['success']['message'] as String))}',
+    'Message from server: ${log.green(sanitizedMessage)}',
   );
 }
 
@@ -245,8 +247,9 @@ void handleJsonError(http.BaseResponse response) {
       error['message'] is! String) {
     invalidServerResponse(response);
   }
+  final sanitizedMessage = sanitizeForTerminal(error['message'] as String);
   fail(
-    'Message from server: ${log.red(sanitizeForTerminal(error['message'] as String))}',
+    'Message from server: ${log.red(sanitizedMessage)}',
   );
 }
 
@@ -270,7 +273,8 @@ void handleGCSError(http.BaseResponse response) {
       final code = getTagText('Code');
       // TODO(sigurdm): we could hard-code nice error messages for known codes.
       final message = getTagText('Message');
-      // `Details` are not specified in the doc above, but have been observed in actual responses.
+      // `Details` are not specified in the doc above, but have been observed in
+      // actual responses.
       final details = getTagText('Details');
       if (code != null) {
         log.error('Server error code: ${sanitizeForTerminal(code)}');

--- a/lib/src/ignore.dart
+++ b/lib/src/ignore.dart
@@ -169,8 +169,8 @@ final class Ignore {
   /// Represents paths normalized  using '/' as directory separator. The empty
   /// relative path is '.', no '..' are allowed.
   ///
-  /// [beneath] must start with [root] and even if it is a directory it should not
-  /// end with '/', if [beneath] is not provided, everything under root is
+  /// [beneath] must start with [root] and even if it is a directory it should
+  /// not end with '/', if [beneath] is not provided, everything under root is
   /// included.
   ///
   /// [listDir] should enumerate the immediate contents of a given directory,

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -383,15 +383,15 @@ List<String> listDir(
         if (entity is Link) return false;
         if (includeHidden) return true;
 
-        // Using substring here is generally problematic in cases where dir has one
-        // or more trailing slashes. If you do listDir("foo"), you'll get back
-        // paths like "foo/bar". If you do listDir("foo/"), you'll get "foo/bar"
-        // (note the trailing slash was dropped. If you do listDir("foo//"), you'll
-        // get "foo//bar".
+        // Using substring here is generally problematic in cases where dir has
+        // one or more trailing slashes. If you do listDir("foo"), you'll get
+        // back paths like "foo/bar". If you do listDir("foo/"), you'll get
+        // "foo/bar" (note the trailing slash was dropped. If you do
+        // listDir("foo//"), you'll get "foo//bar".
         //
-        // This means if you strip off the prefix, the resulting string may have a
-        // leading separator (if the prefix did not have a trailing one) or it may
-        // not. However, since we are only using the results of that to call
+        // This means if you strip off the prefix, the resulting string may have
+        // a leading separator (if the prefix did not have a trailing one) or it
+        // may not. However, since we are only using the results of that to call
         // contains() on, the leading separator is harmless.
         assert(entity.path.startsWith(dir));
         var pathInDir = entity.path.substring(dir.length);
@@ -571,7 +571,8 @@ bool _isDirectoryNotEmptyException(FileSystemException e) {
       // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/asm-generic/errno-base.h#n21
       // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/asm-generic/errno.h#n20
       (Platform.isLinux && (errorCode == 39 || errorCode == 17)) ||
-          // On Windows this may fail with ERROR_DIR_NOT_EMPTY or ERROR_ALREADY_EXISTS
+          // On Windows this may fail with ERROR_DIR_NOT_EMPTY or
+          // ERROR_ALREADY_EXISTS
           // https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
           (Platform.isWindows && (errorCode == 145 || errorCode == 183)) ||
           // On MacOS rename will fail with ENOTEMPTY if directory exists.
@@ -739,7 +740,8 @@ bool get terminalOutputForStdout {
     return true;
   } else {
     throw DataException(
-      'Environment variable ${EnvironmentKeys.forceTerminalOutput} has unsupported value: $environmentValue.',
+      'Environment variable ${EnvironmentKeys.forceTerminalOutput} '
+      'has unsupported value: $environmentValue.',
     );
   }
 }

--- a/lib/src/oauth2.dart
+++ b/lib/src/oauth2.dart
@@ -440,8 +440,8 @@ class _AuthorizationCodeGrant {
   /// be specified via [scopes]. The scope strings are specific to the
   /// authorization server and may be found in its documentation. Note that you
   /// may not be granted access to every scope you request; you may check the
-  /// [Credentials.scopes] field of [_Client.credentials] to see which scopes you
-  /// were granted.
+  /// [Credentials.scopes] field of [_Client.credentials] to see which scopes
+  /// you were granted.
   ///
   /// An opaque [state] string may also be passed that will be present in the
   /// query parameters provided to the redirect URL.
@@ -682,7 +682,8 @@ class _AuthorizationException implements Exception {
 /// This means that any request may throw an [_AuthorizationException] if the
 /// refresh is not authorized for some reason, a [FormatException] if the
 /// authorization server provides ill-formatted responses, or an
-/// [_ExpirationException] if the credentials are expired and can't be refreshed.
+/// [_ExpirationException] if the credentials are expired and can't be
+/// refreshed.
 ///
 /// The client will also throw an [_AuthorizationException] if the resource
 /// server returns a 401 response with a WWW-Authenticate header indicating that
@@ -1208,7 +1209,8 @@ Credentials _handleAccessTokenResponse(
           expiresIn = double.parse(expiresIn).toInt();
         } on FormatException {
           throw FormatException(
-            'parameter "expires_in" could not be parsed as in, was: "$expiresIn"',
+            'parameter "expires_in" could not be parsed as int, '
+            'was: "$expiresIn"',
           );
         }
       } else if (expiresIn is! int) {

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -181,7 +181,8 @@ class Package {
         } on FileException catch (e) {
           throw FileException(
             '${e.message}\n'
-            'That was included in the workspace of ${p.join(dir, 'pubspec.yaml')}.',
+            'That was included in the workspace of '
+            '${p.join(dir, 'pubspec.yaml')}.',
             e.path,
           );
         }
@@ -322,7 +323,8 @@ See $workspacesDocUrl for more information.
                 rules,
                 onInvalidPattern: (pattern, exception) {
                   log.warning(
-                    '$ignoreFile had invalid pattern $pattern. ${exception.message}',
+                    '$ignoreFile had invalid pattern $pattern. '
+                    '${exception.message}',
                   );
                 },
                 // Ignore case on macOS and Windows, because `git clone` and

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -37,8 +37,9 @@ class Pubspec extends PubspecBase {
   // initialization can throw a [PubspecException], that error should also be
   // exposed through [allErrors].
 
-  /// The fields of [pubspecOverridesFilename]. `null` if no such file exists or has
-  /// to be considered.
+  /// The fields of [pubspecOverridesFilename].
+  ///
+  /// `null` if no such file exists or has to be considered.
   final YamlMap? _overridesFileFields;
 
   String? get _packageName => fields['name'] != null ? name : null;
@@ -70,7 +71,8 @@ class Pubspec extends PubspecBase {
     final r = fields.nodes['workspace'];
     if (r != null && !languageVersion.supportsWorkspaces) {
       _error(
-        '`workspace` and `resolution` requires at least language version ${LanguageVersion.firstVersionWithWorkspaces}',
+        '`workspace` and `resolution` requires at least language version '
+        '${LanguageVersion.firstVersionWithWorkspaces}',
         r.span,
       );
     }
@@ -100,7 +102,8 @@ class Pubspec extends PubspecBase {
     final r = fields.nodes['resolution'];
     if (r != null && !languageVersion.supportsWorkspaces) {
       _error(
-        '`workspace` and `resolution` requires at least language version ${LanguageVersion.firstVersionWithWorkspaces}',
+        '`workspace` and `resolution` requires at least language version '
+        '${LanguageVersion.firstVersionWithWorkspaces}',
         r.span,
       );
     }
@@ -148,7 +151,8 @@ class Pubspec extends PubspecBase {
   /// Dependencies here will replace any dependency on a package with the same
   /// name anywhere in the dependency graph.
   ///
-  /// These can occur both in the pubspec.yaml file and the [pubspecOverridesFilename].
+  /// These can occur both in the pubspec.yaml file and the
+  /// [pubspecOverridesFilename].
   Map<String, PackageRange> get dependencyOverrides {
     if (_dependencyOverrides != null) return _dependencyOverrides!;
     final pubspecOverridesFields = _overridesFileFields;
@@ -157,7 +161,8 @@ class Pubspec extends PubspecBase {
         final keyNode = key as YamlNode;
         if (!const {'dependency_overrides'}.contains(keyNode.value)) {
           throw SourceSpanApplicationException(
-            'pubspec_overrides.yaml only supports the `dependency_overrides` field.',
+            'pubspec_overrides.yaml only supports the '
+            '`dependency_overrides` field.',
             keyNode.span,
           );
         }
@@ -346,7 +351,8 @@ class Pubspec extends PubspecBase {
             ((String? name) => throw StateError('No source registry given')),
         _overridesFileFields = null,
         // This is a dummy value.
-        // Dependencies should already be resolved, so we never need to do relative resolutions.
+        // Dependencies should already be resolved, so we never need to do
+        // relative resolutions.
         _containingDescription = RootDescription('.'),
         super(
           fields == null ? YamlMap() : YamlMap.wrap(fields),
@@ -488,7 +494,8 @@ class Pubspec extends PubspecBase {
     return errors;
   }
 
-  /// Returns a list of errors relevant to consuming this pubspec as a dependency
+  /// Returns a list of errors relevant to consuming this pubspec as a
+  /// dependency.
   ///
   /// This will return at most one error for each field.
   List<SourceSpanApplicationException> get dependencyErrors =>

--- a/lib/src/pubspec_parse.dart
+++ b/lib/src/pubspec_parse.dart
@@ -18,10 +18,11 @@ final packageNameRegExp =
     RegExp('^${identifierRegExp.pattern}(\\.${identifierRegExp.pattern})*\$');
 
 /// Helper class for pubspec parsing to:
-/// - extract the fields and methods that are reusable outside of `pub` client, and
+/// - extract the fields and methods that are reusable outside of `pub` client
 /// - help null-safety migration a bit.
 ///
-/// This class should be eventually extracted to a separate library, or re-merged with `Pubspec`.
+/// This class should be eventually extracted to a separate library, or
+/// re-merged with `Pubspec`.
 abstract class PubspecBase {
   /// All pubspec fields.
   ///

--- a/lib/src/solver/failure.dart
+++ b/lib/src/solver/failure.dart
@@ -215,9 +215,15 @@ class _Writer {
       final conflictLine = _lineNumbers[conflictClause.conflict];
       final otherLine = _lineNumbers[conflictClause.other];
       if (conflictLine != null && otherLine != null) {
+        final reason = conflictClause.conflict.andToString(
+          conflictClause.other,
+          detailsForCause,
+          conflictLine,
+          otherLine,
+        );
         _write(
           incompatibility,
-          'Because ${conflictClause.conflict.andToString(conflictClause.other, detailsForCause, conflictLine, otherLine)}, $incompatibilityString.',
+          'Because $reason, $incompatibilityString.',
           numbered: numbered,
         );
       } else if (conflictLine != null || otherLine != null) {
@@ -281,9 +287,11 @@ class _Writer {
 
       final derivedLine = _lineNumbers[derived];
       if (derivedLine != null) {
+        final reason =
+            ext.andToString(derived, detailsForCause, null, derivedLine);
         _write(
           incompatibility,
-          'Because ${ext.andToString(derived, detailsForCause, null, derivedLine)}, $incompatibilityString.',
+          'Because $reason, $incompatibilityString.',
           numbered: numbered,
         );
       } else if (_isCollapsible(derived)) {
@@ -319,11 +327,11 @@ class _Writer {
         );
       }
     } else {
+      final reason = conflictClause.conflict
+          .andToString(conflictClause.other, detailsForCause);
       _write(
         incompatibility,
-        'Because '
-        '${conflictClause.conflict.andToString(conflictClause.other, detailsForCause)}, '
-        '$incompatibilityString.',
+        'Because $reason, $incompatibilityString.',
         numbered: numbered,
       );
     }

--- a/lib/src/solver/incompatibility.dart
+++ b/lib/src/solver/incompatibility.dart
@@ -435,8 +435,10 @@ class Incompatibility {
     } else if (latter.cause is NoVersionsIncompatibilityCause) {
       buffer.write("which doesn't match any versions");
     } else if (latter.cause is PackageNotFoundIncompatibilityCause) {
-      buffer.write("which doesn't exist "
-          '(${(latter.cause as PackageNotFoundIncompatibilityCause).exception.message})');
+      final cause = (latter.cause as PackageNotFoundIncompatibilityCause)
+          .exception
+          .message;
+      buffer.write("which doesn't exist ($cause)");
     } else {
       buffer.write('which is forbidden');
     }

--- a/lib/src/solver/partial_solution.dart
+++ b/lib/src/solver/partial_solution.dart
@@ -98,7 +98,8 @@ class PartialSolution {
       if (removed.isDecision) _decisions.remove(removed.package.name);
     }
 
-    // Re-compute [_positive] and [_negative] for the packages that were removed.
+    // Re-compute [_positive] and [_negative] for the packages that were
+    // removed.
     for (var package in packages) {
       _positive.remove(package);
       _negative.remove(package);

--- a/lib/src/solver/report.dart
+++ b/lib/src/solver/report.dart
@@ -281,7 +281,8 @@ $contentHashesDocumentationUrl
         packageCountString = '$outdatedPackagesCount packages have';
       }
       message('$packageCountString newer versions incompatible with '
-          'dependency constraints.\nTry `$topLevelProgram pub outdated` for more information.');
+          'dependency constraints.\n'
+          'Try `$topLevelProgram pub outdated` for more information.');
     }
   }
 

--- a/lib/src/solver/solve_suggestions.dart
+++ b/lib/src/solver/solve_suggestions.dart
@@ -82,11 +82,14 @@ Future<String?> suggestResolutionAlternatives(
   if (suggestions.isEmpty) return null;
   final tryOne = suggestions.length == 1
       ? 'You can try the following suggestion to make the pubspec resolve:'
-      : 'You can try one of the following suggestions to make the pubspec resolve:';
+      : 'You can try one of the following suggestions '
+          'to make the pubspec resolve:';
 
   suggestions.sort((a, b) => a.priority.compareTo(b.priority));
+  final topSuggestions =
+      suggestions.take(5).map((e) => e.suggestion).join('\n');
 
-  return '\n$tryOne\n${suggestions.take(5).map((e) => e.suggestion).join('\n')}';
+  return '\n$tryOne\n$topSuggestions';
 }
 
 class _ResolutionSuggestion {
@@ -164,11 +167,13 @@ class _ResolutionContext {
     }
     return _ResolutionSuggestion(
       runningFromFlutter
-          ? '* Try using the Flutter SDK version: ${bestRelease.flutterVersion}. '
+          ? '* Try using the Flutter SDK version: '
+              '${bestRelease.flutterVersion}.'
           :
           // Here we assume that any Dart version included in a Flutter
           // release can also be found as a released Dart SDK.
-          '* Try using the Dart SDK version: ${bestRelease.dartVersion}. See https://dart.dev/get-dart.',
+          '* Try using the Dart SDK version: ${bestRelease.dartVersion}. '
+              'See https://dart.dev/get-dart.',
     );
   }
 
@@ -206,19 +211,19 @@ class _ResolutionContext {
     final addDescription = packageAddDescription(entrypoint, resolvingPackage);
 
     var priority = 1;
-    var suggestion =
-        '* Try updating your constraint on $name: $topLevelProgram pub add $addDescription';
+    var suggestion = '* Try updating your constraint on $name: '
+        '$topLevelProgram pub add $addDescription';
     if (originalConstraint is VersionRange) {
       final min = originalConstraint.min;
       if (min != null) {
         if (resolvingPackage.version < min) {
           priority = 3;
-          suggestion =
-              '* Consider downgrading your constraint on $name: $topLevelProgram pub add $addDescription';
+          suggestion = '* Consider downgrading your constraint on $name: '
+              '$topLevelProgram pub add $addDescription';
         } else {
           priority = 2;
-          suggestion =
-              '* Try upgrading your constraint on $name: $topLevelProgram pub add $addDescription';
+          suggestion = '* Try upgrading your constraint on $name: '
+              '$topLevelProgram pub add $addDescription';
         }
       }
     }
@@ -264,12 +269,14 @@ class _ResolutionContext {
           .map((e) => packageAddDescription(entrypoint, e))
           .join(' ');
       return _ResolutionSuggestion(
-        '* Try updating the following constraints: $topLevelProgram pub add $formattedConstraints',
+        '* Try updating the following constraints: '
+        '$topLevelProgram pub add $formattedConstraints',
         priority: 4,
       );
     } else {
       return _ResolutionSuggestion(
-        '* Try an upgrade of your constraints: $topLevelProgram pub upgrade --major-versions',
+        '* Try an upgrade of your constraints: '
+        '$topLevelProgram pub upgrade --major-versions',
         priority: 4,
       );
     }


### PR DESCRIPTION
Enable lines_longer_than_80_chars lint and fix the first ~100
diagnostics.

Only a very small number felt like they might be toil during normal
editing.
The vast majority felt like they would be mostly unobtrusive if they had
surfaced during normal editing instead of all in a batch.

Quite a few of the fixes improve readability. None of the fixes harm
readability.
