### PR TITLE
Use `-z` for `git ls-files`

### DIFF
--- a/lib/src/command_runner.dart
+++ b/lib/src/command_runner.dart
@@ -203,7 +203,8 @@ class PubCommandRunner extends CommandRunner<int> implements PubTopLevel {
     final pubRoot = p.dirname(p.dirname(p.fromUri(Platform.script)));
     try {
       actualRev =
-          git.runSync(['rev-parse', 'HEAD'], workingDir: pubRoot).single;
+          (git.runSync(['rev-parse', 'HEAD'], workingDir: pubRoot) as String)
+              .trim();
     } on git.GitException catch (_) {
       // When building for Debian, pub isn't checked out via git.
       return;

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -775,7 +775,7 @@ Future flushThenExit(int status) {
 /// The spawned process will inherit its parent's environment variables. If
 /// [environment] is provided, that will be used to augment (not replace) the
 /// the inherited variables.
-Future<PubProcessResult> runProcess(
+Future<ProcessResult> runProcess(
   String executable,
   List<String> args, {
   String? workingDir,
@@ -806,13 +806,8 @@ Future<PubProcessResult> runProcess(
       );
     }
 
-    final pubResult = PubProcessResult(
-      result.stdout as String,
-      result.stderr as String,
-      result.exitCode,
-    );
-    log.processResult(executable, pubResult);
-    return pubResult;
+    log.processResult(executable, result);
+    return result;
   });
 }
 
@@ -857,7 +852,7 @@ Future<PubProcess> startProcess(
 }
 
 /// Like [runProcess], but synchronous.
-PubProcessResult runProcessSync(
+ProcessResult runProcessSync(
   String executable,
   List<String> args, {
   String? workingDir,
@@ -883,13 +878,8 @@ PubProcessResult runProcessSync(
   } on IOException catch (e) {
     throw RunProcessException('Pub failed to run subprocess `$executable`: $e');
   }
-  final pubResult = PubProcessResult(
-    result.stdout as String,
-    result.stderr as String,
-    result.exitCode,
-  );
-  log.processResult(executable, pubResult);
-  return pubResult;
+  log.processResult(executable, result);
+  return result;
 }
 
 /// A wrapper around [Process] that exposes `dart:async`-style APIs.
@@ -1230,16 +1220,10 @@ ByteStream createTarGz(
 }
 
 /// Contains the results of invoking a [Process] and waiting for it to complete.
-class PubProcessResult {
-  final List<String> stdout;
-  final List<String> stderr;
-  final int exitCode;
+extension PubProcessResult on ProcessResult {
+  List<String> get stdoutLines => _toLines(this.stdout as String);
+  List<String> get stderrLines => _toLines(this.stderr as String);
 
-  PubProcessResult(String stdout, String stderr, this.exitCode)
-      : stdout = _toLines(stdout),
-        stderr = _toLines(stderr);
-
-  // TODO(rnystrom): Remove this and change to returning one string.
   static List<String> _toLines(String output) {
     final lines = const LineSplitter().convert(output);
 
@@ -1250,7 +1234,7 @@ class PubProcessResult {
     return lines;
   }
 
-  bool get success => exitCode == exit_codes.SUCCESS;
+  bool get success => this.exitCode == exit_codes.SUCCESS;
 }
 
 /// The location for dart-specific configuration.

--- a/lib/src/log.dart
+++ b/lib/src/log.dart
@@ -251,18 +251,22 @@ void process(
 }
 
 /// Logs the results of running [executable].
-void processResult(String executable, PubProcessResult result) {
+void processResult(String executable, ProcessResult result) {
   // Log it all as one message so that it shows up as a single unit in the logs.
   final buffer = StringBuffer();
   buffer.writeln('Finished $executable. Exit code ${result.exitCode}.');
 
-  void dumpOutput(String name, List<String> output) {
+  void dumpOutput(String name, dynamic output) {
+    if (output is! String) {
+      buffer.writeln('Binary output on $name.');
+      return;
+    }
     if (output.isEmpty) {
       buffer.writeln('Nothing output on $name.');
     } else {
       buffer.writeln('$name:');
       var numLines = 0;
-      for (var line in output) {
+      for (var line in output.split('\n')) {
         if (++numLines > 1000) {
           buffer.writeln('[${output.length - 1000}] more lines of output '
               'truncated...]');

--- a/lib/src/validator/analyze.dart
+++ b/lib/src/validator/analyze.dart
@@ -32,7 +32,7 @@ class AnalyzeValidator extends Validator {
       ['analyze', ...entries, p.join(package.dir, 'pubspec.yaml')],
     );
     if (result.exitCode != 0) {
-      final limitedOutput = limitLength(result.stdout.join('\n'), 1000);
+      final limitedOutput = limitLength(result.stdout as String, 1000);
       warnings
           .add('`dart analyze` found the following issue(s):\n$limitedOutput');
     }

--- a/test/descriptor/git.dart
+++ b/test/descriptor/git.dart
@@ -46,15 +46,16 @@ class GitRepoDescriptor extends DirectoryDescriptor {
   /// [parent] defaults to [sandbox].
   Future<String> revParse(String ref, [String? parent]) async {
     final output = await _runGit(['rev-parse', ref], parent);
-    return output[0];
+    return (output as String).trim();
   }
 
   /// Runs a Git command in this repository.
   ///
   /// [parent] defaults to [sandbox].
-  Future runGit(List<String> args, [String? parent]) => _runGit(args, parent);
+  Future<void> runGit(List<String> args, [String? parent]) =>
+      _runGit(args, parent);
 
-  Future<List<String>> _runGit(List<String> args, String? parent) {
+  Future<dynamic> _runGit(List<String> args, String? parent) {
     // Explicitly specify the committer information. Git needs this to commit
     // and we don't want to rely on the buildbots having this already set up.
     final environment = {


### PR DESCRIPTION
This gives more reliably parsable output.

Main changes are in `lib/src/validator/gitignore.dart`.

Required refactor of `runProcess()` to not output split lines, but according to the encoding (following `Process.run()`).

