### PR TITLE
Use relative path in package_config.json when PUB_CACHE is relative

### DIFF
--- a/lib/src/source/cached.dart
+++ b/lib/src/source/cached.dart
@@ -44,8 +44,13 @@ abstract class CachedSource extends Source {
     PackageId id,
     SystemCache cache, {
     String? relativeFrom,
-  }) =>
-      getDirectoryInCache(id, cache);
+  }) {
+    final dir = getDirectoryInCache(id, cache);
+    if (p.isRelative(dir)) {
+      return p.relative(dir, from: relativeFrom);
+    }
+    return dir;
+  }
 
   String getDirectoryInCache(PackageId id, SystemCache cache);
 

--- a/lib/src/system_cache.dart
+++ b/lib/src/system_cache.dart
@@ -39,8 +39,9 @@ class SystemCache {
   String get tempDir => p.join(rootDir, '_temp');
 
   static String defaultDir = (() {
-    if (Platform.environment.containsKey('PUB_CACHE')) {
-      return p.absolute(Platform.environment['PUB_CACHE']!);
+    final envCache = Platform.environment['PUB_CACHE'];
+    if (envCache != null) {
+      return envCache;
     } else if (Platform.isWindows) {
       // %LOCALAPPDATA% is used as the cache location over %APPDATA%, because
       // the latter is synchronised between devices when the user roams between


### PR DESCRIPTION
This was the case until https://github.com/dart-lang/pub/pull/4171 . I believe that was a regression.