### PR TITLE
Fix add package with offline flag

### DIFF
--- a/lib/src/command/add.dart
+++ b/lib/src/command/add.dart
@@ -88,6 +88,8 @@ For example:
 
   @override
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-add';
+  @override
+  bool get isOffline => argResults.flag('offline');
 
   AddCommand() {
     argParser.addFlag(

--- a/test/add/common/add_test.dart
+++ b/test/add/common/add_test.dart
@@ -1148,4 +1148,14 @@ dependency_overrides:
 
     await pubAdd(args: ['foo'], output: contains('+ foo 1.0.0'));
   });
+
+  test('`--offline` works', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0');
+    await runPub(args: ['cache', 'add', 'foo', '--version', '1.0.0']);
+
+    await d.appDir().create();
+    server.serve('foo', '2.0.0');
+    await pubAdd(args: ['foo', '--offline']);
+  });
 }


### PR DESCRIPTION

  Fix an issue that prevented users from adding cached packages using the --offline flag through the **add** command line when the system is offline.
  
  Steps:
  
  Run the following command in an offline state (no internet connection):
  `dart pub add package_name --offline`
