### PR TITLE
Add flag `--unlock-transitive` to `pub upgrade`

### DIFF
--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -71,7 +71,7 @@ class UpgradeCommand extends PubCommand {
     );
 
     argParser.addFlag(
-      'transitive',
+      'unlock-transitive',
       help: 'Also upgrades the transitive dependencies '
           'of the listed [dependencies]',
     );
@@ -115,7 +115,7 @@ class UpgradeCommand extends PubCommand {
   /// This allows the user to specify list of names that they want the
   /// upgrade command to affect.
   Future<List<String>> _computePackagesToUpgrade() async {
-    if (argResults.flag('transitive')) {
+    if (argResults.flag('unlock-transitive')) {
       final graph = await entrypoint.packageGraph;
       return argResults.rest
           .expand(

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -71,6 +71,12 @@ class UpgradeCommand extends PubCommand {
     );
 
     argParser.addFlag(
+      'transitive',
+      help: 'Also upgrades the transitive dependencies '
+          'of the listed [dependencies]',
+    );
+
+    argParser.addFlag(
       'major-versions',
       help: 'Upgrades packages to their latest resolvable versions, '
           'and updates pubspec.yaml.',
@@ -101,11 +107,27 @@ class UpgradeCommand extends PubCommand {
 
   bool get _precompile => argResults.flag('precompile');
 
+  late final Future<List<String>> _packagesToUpgrade =
+      _computePackagesToUpgrade();
+
   /// List of package names to upgrade, if empty then upgrade all packages.
   ///
   /// This allows the user to specify list of names that they want the
   /// upgrade command to affect.
-  List<String> get _packagesToUpgrade => argResults.rest;
+  Future<List<String>> _computePackagesToUpgrade() async {
+    if (argResults.flag('transitive')) {
+      final graph = await entrypoint.packageGraph;
+      return argResults.rest
+          .expand(
+            (package) =>
+                graph.transitiveDependencies(package).map((p) => p.name),
+          )
+          .toSet()
+          .toList();
+    } else {
+      return argResults.rest;
+    }
+  }
 
   bool get _upgradeNullSafety =>
       argResults.flag('nullsafety') || argResults.flag('null-safety');
@@ -142,7 +164,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
           );
         }
         final changes =
-            entrypoint.tighten(packagesToUpgrade: _packagesToUpgrade);
+            entrypoint.tighten(packagesToUpgrade: await _packagesToUpgrade);
         entrypoint.applyChanges(changes, _dryRun);
       }
     }
@@ -157,7 +179,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
   Future<void> _runUpgrade(Entrypoint e, {bool onlySummary = false}) async {
     await e.acquireDependencies(
       SolveType.upgrade,
-      unlock: _packagesToUpgrade,
+      unlock: await _packagesToUpgrade,
       dryRun: _dryRun,
       precompile: _precompile,
       summaryOnly: onlySummary,
@@ -171,7 +193,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
   /// given.
   ///
   /// This assumes that `--major-versions` was passed.
-  List<String> _directDependenciesToUpgrade() {
+  Future<List<String>> _directDependenciesToUpgrade() async {
     assert(_upgradeMajorVersions);
 
     final directDeps = {
@@ -180,12 +202,13 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
         ...package.devDependencies.keys,
       ],
     }.toList();
+    final packagesToUpgrade = await _packagesToUpgrade;
     final toUpgrade =
-        _packagesToUpgrade.isEmpty ? directDeps : _packagesToUpgrade;
+        packagesToUpgrade.isEmpty ? directDeps : packagesToUpgrade;
 
     // Check that all package names in upgradeOnly are direct-dependencies
     final notInDeps = toUpgrade.where((n) => !directDeps.contains(n));
-    if (toUpgrade.any(notInDeps.contains)) {
+    if (argResults.rest.any(notInDeps.contains)) {
       usageException('''
 Dependencies specified in `$topLevelProgram pub upgrade --major-versions <dependencies>` must
 be direct 'dependencies' or 'dev_dependencies', following packages are not:
@@ -198,7 +221,7 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
   }
 
   Future<void> _runUpgradeMajorVersions() async {
-    final toUpgrade = _directDependenciesToUpgrade();
+    final toUpgrade = await _directDependenciesToUpgrade();
     // Solve [resolvablePubspec] in-memory and consolidate the resolved
     // versions of the packages into a map for quick searching.
     final resolvedPackages = <String, PackageId>{};
@@ -267,7 +290,7 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
         }),
       );
       changes = entrypoint.tighten(
-        packagesToUpgrade: _packagesToUpgrade,
+        packagesToUpgrade: await _packagesToUpgrade,
         existingChanges: changes,
         packageVersions: solveResult.packages,
       );
@@ -279,7 +302,7 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
     // But without a specific package we want to get as many non-major updates
     // as possible (SolveType.upgrade).
     final solveType =
-        _packagesToUpgrade.isEmpty ? SolveType.upgrade : SolveType.get;
+        (await _packagesToUpgrade).isEmpty ? SolveType.upgrade : SolveType.get;
 
     entrypoint.applyChanges(changes, _dryRun);
     await entrypoint.withUpdatedRootPubspecs({
@@ -290,6 +313,7 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
       solveType,
       dryRun: _dryRun,
       precompile: !_dryRun && _precompile,
+      unlock: await _packagesToUpgrade,
     );
 
     // If any of the packages to upgrade are dependency overrides, then we

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -515,7 +515,7 @@ See $workspacesDocUrl for more information.''',
   /// pubspec.yaml and all dependencies downloaded.
   Future<void> acquireDependencies(
     SolveType type, {
-    Iterable<String>? unlock,
+    Iterable<String> unlock = const [],
     bool dryRun = false,
     bool precompile = false,
     bool summaryOnly = false,
@@ -547,7 +547,7 @@ Try running `$topLevelProgram pub get` to create `$lockFilePath`.''');
           cache,
           workspaceRoot,
           lockFile: lockFile,
-          unlock: unlock ?? [],
+          unlock: unlock,
         );
       });
     } on SolveFailure catch (e) {
@@ -557,7 +557,7 @@ Try running `$topLevelProgram pub get` to create `$lockFilePath`.''');
           this,
           type,
           e.incompatibility,
-          unlock ?? [],
+          unlock,
           cache,
         ),
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   tar: ^2.0.0
   typed_data: ^1.3.2
   yaml: ^3.1.2
-  yaml_edit: ^2.1.1
+  yaml_edit: ^2.2.1
 
 dev_dependencies:
   checks: ^0.3.0

--- a/test/testdata/goldens/help_test/pub upgrade --help.txt
+++ b/test/testdata/goldens/help_test/pub upgrade --help.txt
@@ -10,6 +10,7 @@ Usage: pub upgrade [dependencies...]
 -n, --dry-run            Report what dependencies would change but don't change any.
     --[no-]precompile    Precompile executables in immediate dependencies.
     --tighten            Updates lower bounds in pubspec.yaml to match the resolved version.
+    --[no-]transitive    Also upgrades the transitive dependencies of the listed [dependencies]
     --major-versions     Upgrades packages to their latest resolvable versions, and updates pubspec.yaml.
 -C, --directory=<dir>    Run this in the directory <dir>.
 

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -8,7 +8,7 @@ import '../descriptor.dart' as d;
 import '../test_pub.dart';
 
 void main() {
-  test('without --transitive, the transitive dependencies stay locked',
+  test('without --unlock-transitive, the transitive dependencies stay locked',
       () async {
     final server = await servePackages();
     server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
@@ -34,7 +34,7 @@ void main() {
     );
   });
 
-  test('`--transitive` dependencies gets unlocked', () async {
+  test('`--unlock-transitive` dependencies gets unlocked', () async {
     final server = await servePackages();
     server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
     server.serve('bar', '1.0.0');
@@ -54,7 +54,7 @@ void main() {
     server.serve('baz', '1.5.0');
 
     await pubUpgrade(
-      args: ['--transitive', 'foo'],
+      args: ['--unlock-transitive', 'foo'],
       output: allOf(
         contains('> foo 1.5.0'),
         contains('> bar 1.5.0'),
@@ -66,8 +66,9 @@ void main() {
   });
 
   test(
-      '`--major-versions` without `--transitive` does not allow transitive '
-      'dependencies to be upgraded along with the named packages', () async {
+      '`--major-versions` without `--unlock-transitive` does not allow '
+      'transitive dependencies to be upgraded along with the named packages',
+      () async {
     final server = await servePackages();
     server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
     server.serve('bar', '1.0.0');
@@ -93,7 +94,7 @@ void main() {
   });
 
   test(
-      '`--transitive --major-versions` allows transitive dependencies '
+      '`--unlock-transitive --major-versions` allows transitive dependencies '
       'be upgraded along with the named packages', () async {
     final server = await servePackages();
     server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
@@ -114,7 +115,7 @@ void main() {
     server.serve('baz', '1.5.0');
 
     await pubUpgrade(
-      args: ['--major-versions', '--transitive', 'foo'],
+      args: ['--major-versions', '--unlock-transitive', 'foo'],
       output: allOf(
         contains('> foo 2.0.0'),
         contains('> bar 1.5.0'),

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -1,0 +1,125 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+void main() {
+  test('without --transitive, the transitive dependencies stay locked',
+      () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
+    server.serve('bar', '1.0.0');
+
+    await d.appDir(
+      dependencies: {
+        'foo': '^1.0.0',
+      },
+    ).create();
+
+    await pubGet(output: contains('+ foo 1.0.0'));
+
+    server.serve('foo', '1.5.0', deps: {'bar': '^1.0.0'});
+    server.serve('bar', '1.5.0');
+
+    await pubUpgrade(
+      args: ['foo'],
+      output: allOf(
+        contains('> foo 1.5.0'),
+        isNot(contains('bar')),
+      ),
+    );
+  });
+
+  test('`--transitive` dependencies gets unlocked', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
+    server.serve('bar', '1.0.0');
+    server.serve('baz', '1.0.0');
+
+    await d.appDir(
+      dependencies: {
+        'foo': '^1.0.0',
+        'baz': '^1.0.0',
+      },
+    ).create();
+
+    await pubGet(output: contains('+ foo 1.0.0'));
+
+    server.serve('foo', '1.5.0', deps: {'bar': '^1.0.0'});
+    server.serve('bar', '1.5.0');
+    server.serve('baz', '1.5.0');
+
+    await pubUpgrade(
+      args: ['--transitive', 'foo'],
+      output: allOf(
+        contains('> foo 1.5.0'),
+        contains('> bar 1.5.0'),
+        isNot(
+          contains('baz 1.5.0'),
+        ), // Baz is not a transitive dependency of bar
+      ),
+    );
+  });
+
+  test(
+      '`--major-versions` without `--transitive` does not allow transitive '
+      'dependencies to be upgraded along with the named packages', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
+    server.serve('bar', '1.0.0');
+
+    await d.appDir(
+      dependencies: {
+        'foo': '^1.0.0',
+      },
+    ).create();
+
+    await pubGet(output: contains('+ foo 1.0.0'));
+
+    server.serve('foo', '2.0.0', deps: {'bar': '^1.0.0'});
+    server.serve('bar', '1.5.0');
+
+    await pubUpgrade(
+      args: ['--major-versions', 'foo'],
+      output: allOf(
+        contains('> foo 2.0.0'),
+        isNot(contains('bar 1.5.0')),
+      ),
+    );
+  });
+
+  test(
+      '`--transitive --major-versions` allows transitive dependencies '
+      'be upgraded along with the named packages', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
+    server.serve('bar', '1.0.0');
+    server.serve('baz', '1.0.0');
+
+    await d.appDir(
+      dependencies: {
+        'foo': '^1.0.0',
+        'baz': '^1.0.0',
+      },
+    ).create();
+
+    await pubGet(output: contains('+ foo 1.0.0'));
+
+    server.serve('foo', '2.0.0', deps: {'bar': '^1.0.0'});
+    server.serve('bar', '1.5.0');
+    server.serve('baz', '1.5.0');
+
+    await pubUpgrade(
+      args: ['--major-versions', '--transitive', 'foo'],
+      output: allOf(
+        contains('> foo 2.0.0'),
+        contains('> bar 1.5.0'),
+        isNot(contains('> baz 1.5.0')),
+      ),
+    );
+  });
+}


### PR DESCRIPTION
`pub upgrade x y z` will only unlock x, y and z, but with the new flag `pub upgrade --transitive x y z` will unlock those packages **and** their transitive dependencies.

Same for `--major-versions`.

Fixes https://github.com/dart-lang/pub/issues/3504

We could also consider making this the default behavior - it is most likely what people expect.