### PR TITLE
Revert upgrade `--unlock-transitive`

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -515,7 +515,7 @@ See $workspacesDocUrl for more information.''',
   /// pubspec.yaml and all dependencies downloaded.
   Future<void> acquireDependencies(
     SolveType type, {
-    Iterable<String> unlock = const [],
+    Iterable<String>? unlock,
     bool dryRun = false,
     bool precompile = false,
     bool summaryOnly = false,
@@ -547,7 +547,7 @@ Try running `$topLevelProgram pub get` to create `$lockFilePath`.''');
           cache,
           workspaceRoot,
           lockFile: lockFile,
-          unlock: unlock,
+          unlock: unlock ?? [],
         );
       });
     } on SolveFailure catch (e) {
@@ -557,7 +557,7 @@ Try running `$topLevelProgram pub get` to create `$lockFilePath`.''');
           this,
           type,
           e.incompatibility,
-          unlock,
+          unlock ?? [],
           cache,
         ),
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   tar: ^2.0.0
   typed_data: ^1.3.2
   yaml: ^3.1.2
-  yaml_edit: ^2.2.1
+  yaml_edit: ^2.1.1
 
 dev_dependencies:
   checks: ^0.3.0

--- a/test/testdata/goldens/help_test/pub upgrade --help.txt
+++ b/test/testdata/goldens/help_test/pub upgrade --help.txt
@@ -10,7 +10,6 @@ Usage: pub upgrade [dependencies...]
 -n, --dry-run            Report what dependencies would change but don't change any.
     --[no-]precompile    Precompile executables in immediate dependencies.
     --tighten            Updates lower bounds in pubspec.yaml to match the resolved version.
-    --[no-]transitive    Also upgrades the transitive dependencies of the listed [dependencies]
     --major-versions     Upgrades packages to their latest resolvable versions, and updates pubspec.yaml.
 -C, --directory=<dir>    Run this in the directory <dir>.
 


### PR DESCRIPTION
Reverts 

```
commit a2026faf10828d79e6c0e09bca82f40cfe3eec0c (sigurdm/upgrade_unlock_transitive_deps, origin/master, origin/HEAD, upgrade_unlock_transitive_deps, master)
Author: Sigurd Meldgaard <sigurdm@google.com>
Date:   Fri Oct 4 13:18:46 2024 +0000

    Rename flag to --unlock-transitive

commit db8f497c86495410b13d701a4d4b810199b39d93
Author: Sigurd Meldgaard <sigurdm@google.com>
Date:   Thu Oct 3 14:26:03 2024 +0000

    Add flag `--transitive` to `pub upgrade`
```

They were landed in an incomplete state.