### PR TITLE
Require re-activation of global packages after minor sdk upgrade

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -397,7 +397,19 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
         cache,
       );
     }
+    final generatorVersion = entrypoint.packageConfig.generatorVersion;
+    if (generatorVersion != null &&
+        (generatorVersion.major != sdk.version.major ||
+            generatorVersion.minor != sdk.version.minor)) {
+      dataError('''
+${log.bold(name)} was globally activated by Dart $generatorVersion.
 
+You are using ${sdk.version}. Please reactivate.
+
+run:
+`$topLevelProgram pub global activate $name` to reactivate.
+''');
+    }
     // Check that the SDK constraints the lockFile says we have are honored.
     lockFile.sdkConstraints.forEach((sdkName, constraint) {
       final sdk = sdks[sdkName];

--- a/test/global/run/fails_if_sdk_constraint_is_unmet_test.dart
+++ b/test/global/run/fails_if_sdk_constraint_is_unmet_test.dart
@@ -2,12 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
-import 'package:path/path.dart' as p;
 import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:test/test.dart';
-import 'package:yaml_edit/yaml_edit.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
@@ -40,7 +36,7 @@ void main() {
     server.serve(
       'foo',
       '1.0.0',
-      sdk: '^3.0.1',
+      sdk: '^3.1.2',
       contents: [
         d.dir('bin', [d.file('script.dart', "main(args) => print('123-OK');")]),
       ],
@@ -56,10 +52,10 @@ void main() {
     await runPub(
       environment: {
         // Not compatible with [defaultSdkConstraint].
-        '_PUB_TEST_SDK_VERSION': '3.0.0',
+        '_PUB_TEST_SDK_VERSION': '3.1.1',
       },
       args: ['global', 'run', 'foo:script'],
-      error: contains("foo as globally activated doesn't support Dart 3.0.0."),
+      error: contains("foo as globally activated doesn't support Dart 3.1.1."),
       exitCode: exit_codes.DATA,
     );
   });
@@ -85,7 +81,7 @@ void main() {
         '1.0.0',
         pubspec: {
           'environment': {
-            'sdk': '^3.0.1',
+            'sdk': '^3.1.2',
           },
         },
       );
@@ -98,11 +94,11 @@ void main() {
     );
 
     await runPub(
-      environment: {'_PUB_TEST_SDK_VERSION': '3.0.0'},
+      environment: {'_PUB_TEST_SDK_VERSION': '3.1.1'},
       args: ['global', 'run', 'foo:script'],
       error: contains(
         """
-foo as globally activated doesn't support Dart 3.0.0.
+foo as globally activated doesn't support Dart 3.1.1.
 
 try:
 `dart pub global activate foo` to reactivate.""",
@@ -111,7 +107,7 @@ try:
     );
   });
 
-  test('succeeds if SDK is upgraded from 2.19 to 3.0', () async {
+  test('succeed if there is a patch SDK upgrade from 3.0.0 to 3.0.1', () async {
     final server = await servePackages();
     server.serve(
       'foo',
@@ -126,22 +122,41 @@ try:
     );
 
     await runPub(
-      environment: {'_PUB_TEST_SDK_VERSION': '2.19.0'},
+      environment: {'_PUB_TEST_SDK_VERSION': '3.0.0'},
       args: ['global', 'activate', 'foo'],
     );
 
-    final lockFile = File(
-      p.join(d.sandbox, cachePath, 'global_packages', 'foo', 'pubspec.lock'),
+    await runPub(
+      environment: {'_PUB_TEST_SDK_VERSION': '3.0.1'},
+      args: ['global', 'run', 'foo:script'],
+      output: contains('123-OK'),
     );
-    final editor = YamlEditor(lockFile.readAsStringSync());
-    // This corresponds to what an older sdk would write, before the dart 3 hack
-    // was introduced:
-    editor.update(['sdks', 'dart'], '^2.19.0');
+  });
+
+  test('fail if there is a minor SDK upgrade from 3.0.0 to 3.1.0', () async {
+    final server = await servePackages();
+    server.serve(
+      'foo',
+      '1.0.0',
+      sdk: '^2.19.0',
+      contents: [
+        d.dir(
+          'bin',
+          [d.file('script.dart', "main(args) => print('123-OK');")],
+        ),
+      ],
+    );
 
     await runPub(
       environment: {'_PUB_TEST_SDK_VERSION': '3.0.0'},
+      args: ['global', 'activate', 'foo'],
+    );
+
+    await runPub(
+      environment: {'_PUB_TEST_SDK_VERSION': '3.1.0'},
       args: ['global', 'run', 'foo:script'],
-      output: contains('123-OK'),
+      error: contains('foo was globally activated by Dart 3.0.0'),
+      exitCode: exit_codes.DATA,
     );
   });
 }


### PR DESCRIPTION
This would alleviate https://github.com/dart-lang/pub/issues/4406

But it is also a kind of regression in that it requires more activations....

I was first attempting to solve this with `ensureUpToDate`, but that logic does not really look into the actual version numbers of sdk packages, and as such would also not detect a new version of package:_macros.

Also it requires an update if the minor version is updated, leading to more or less the same behavior as this.
