### PR TITLE
Use `workPackage` instead of `rootpackage` when global-activating from path

### DIFF
--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -56,8 +56,8 @@ Future<int> runExecutable(
 
   // Make sure the package is an immediate dependency of the entrypoint or the
   // entrypoint itself.
-  if (entrypoint.workspaceRoot.name != executable.package &&
-      !entrypoint.workspaceRoot.immediateDependencies.containsKey(package)) {
+  if (entrypoint.workPackage.name != executable.package &&
+      !entrypoint.workPackage.immediateDependencies.containsKey(package)) {
     if ((await entrypoint.packageGraph).packages.containsKey(package)) {
       dataError('Package "$package" is not an immediate dependency.\n'
           'Cannot run executables in transitive dependencies.');

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -189,14 +189,15 @@ class GlobalPackages {
 
     // Get the package's dependencies.
     await entrypoint.acquireDependencies(SolveType.get);
-    final name = entrypoint.workspaceRoot.name;
+    final activatedPackage = entrypoint.workPackage;
+    final name = activatedPackage.name;
     _describeActive(name, cache);
 
     // Write a lockfile that points to the local package.
-    final fullPath = canonicalize(entrypoint.workspaceRoot.dir);
+    final fullPath = canonicalize(activatedPackage.dir);
     final id = cache.path.idFor(
       name,
-      entrypoint.workspaceRoot.version,
+      activatedPackage.version,
       fullPath,
       p.current,
     );
@@ -212,7 +213,7 @@ class GlobalPackages {
 
     _updateBinStubs(
       entrypoint,
-      entrypoint.workspaceRoot,
+      activatedPackage,
       executables,
       overwriteBinStubs: overwriteBinStubs,
     );
@@ -1031,6 +1032,6 @@ Package activatedPackage(Entrypoint entrypoint) {
     final dep = entrypoint.workspaceRoot.dependencies.keys.single;
     return entrypoint.cache.load(entrypoint.lockFile.packages[dep]!);
   } else {
-    return entrypoint.workspaceRoot;
+    return entrypoint.workPackage;
   }
 }

--- a/test/global/activate/activate_package_from_workspace.dart
+++ b/test/global/activate/activate_package_from_workspace.dart
@@ -1,0 +1,60 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_process/test_process.dart';
+
+import '../../descriptor.dart';
+import '../../test_pub.dart';
+import '../binstubs/utils.dart';
+
+void main() {
+  test('activating a package from path from a workspace works', () async {
+    await servePackages();
+    await dir(appPath, [
+      libPubspec(
+        'workspace',
+        '1.2.3',
+        extras: {
+          'workspace': ['pkgs/foo'],
+        },
+        sdk: '^3.5.0',
+      ),
+      dir('pkgs', [
+        dir('foo', [
+          libPubspec(
+            'foo',
+            '1.1.1',
+            extras: {
+              'executables': {'foo-script': 'foo'},
+            },
+            resolutionWorkspace: true,
+          ),
+          dir('bin', [file('foo.dart', "main() => print('path');")]),
+        ]),
+      ]),
+    ]).create();
+
+    await runPub(
+      args: ['global', 'activate', '-spath', 'pkgs/foo'],
+      environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+    );
+
+    await runPub(
+      args: ['global', 'run', 'foo'],
+      output: contains('path'),
+      environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+    );
+
+    final process = await TestProcess.start(
+      p.join(sandbox, cachePath, 'bin', binStubName('foo-script')),
+      [],
+      environment: {...getEnvironment(), '_PUB_TEST_SDK_VERSION': '3.5.0'},
+    );
+
+    expect(process.stdout, emitsThrough('path'));
+    await process.shouldExit();
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/4483
