### PR TITLE
Cache canonicalized version of paths in path dependencies

### DIFF
--- a/lib/src/source/path.dart
+++ b/lib/src/source/path.dart
@@ -270,6 +270,9 @@ class PathDescription extends Description {
   final String path;
   final bool relative;
 
+  // Canonicalization is rather slow - cache the result;
+  late final String _canonicalizedPath = canonicalize(path);
+
   PathDescription(this.path, this.relative) : assert(!p.isRelative(path));
   @override
   String format() {
@@ -294,11 +297,11 @@ class PathDescription extends Description {
   @override
   bool operator ==(Object other) {
     return other is PathDescription &&
-        canonicalize(path) == canonicalize(other.path);
+        _canonicalizedPath == other._canonicalizedPath;
   }
 
   @override
-  int get hashCode => canonicalize(path).hashCode;
+  int get hashCode => _canonicalizedPath.hashCode;
 }
 
 class ResolvedPathDescription extends ResolvedDescription {


### PR DESCRIPTION
The `canonicalize` function is very slow, and the solver compares these a number of times.

This attempt of migrating the sdk to use workspaces https://dart-review.googlesource.com/c/sdk/+/397164?tab=comments has all third-party dependencies overridden as path-dependencies. 71 dependencies.

With current pub, this takes 2.245s to resolve on my machine.
After this fix it takes: 0.117s to resolve!

Also this avoid potential issues of inconsistencies if files change during resolution (although, still don't do that).