### PR TITLE
Disallow activating packages with non-lowercase letters

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -323,22 +323,13 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
 
   /// Shows the user the currently active package with [name], if any.
   LockFile? _describeActive(String name, SystemCache cache) {
-    // Check if we a package is already installed, only with a different casing.
-    try {
-      final packageDirs = listDir(_directory);
-      final differsByOnlyCasing = packageDirs.map(p.basename).firstWhereOrNull(
-            (d) => d != name && d.toLowerCase() == name.toLowerCase(),
-          );
+    final lower = name.toLowerCase();
+    if (name != lower) {
+      fail('''
+You can only activate packages with lower-case names.
 
-      if (differsByOnlyCasing != null) {
-        fail('''
-You are trying to activate `$name` but already have `$differsByOnlyCasing` which
-differs only by casing. `pub` does not allow that.
-
-Consider `$topLevelProgram pub global deactivate $differsByOnlyCasing`''');
-      }
-    } on IOException {
-      // Most likely the global_packages directory does not exist yet.
+Did you mean `$lower`?
+''');
     }
     final LockFile lockFile;
     final lockFilePath = _getLockFilePath(name);

--- a/test/global/activate/activate_casing_test.dart
+++ b/test/global/activate/activate_casing_test.dart
@@ -1,0 +1,42 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test(
+    'On case-insensitive systems, will not allow installing ',
+    () async {
+      final server = await servePackages();
+      server.serve(
+        'foo',
+        '1.0.0',
+        contents: [
+          d.dir('bin', [d.file('foo.dart', 'main() => print("hi"); ')]),
+        ],
+      );
+      server.serve(
+        'Foo',
+        '1.0.0',
+        contents: [
+          d.dir('bin', [d.file('foo.dart', 'main() => print("hi"); ')]),
+        ],
+      );
+
+      await runPub(args: ['global', 'activate', 'foo']);
+      await runPub(
+        args: ['global', 'activate', 'Foo'],
+        error: '''
+You are trying to activate `Foo` but already have `foo` which
+differs only by casing. `pub` does not allow that.
+
+Consider `dart pub global deactivate foo`''',
+        exitCode: 1,
+      );
+    },
+  );
+}

--- a/test/global/activate/activate_casing_test.dart
+++ b/test/global/activate/activate_casing_test.dart
@@ -2,6 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
@@ -9,16 +10,9 @@ import '../../test_pub.dart';
 
 void main() {
   test(
-    'On case-insensitive systems, will not allow installing ',
+    'We only allow activating lower-case package names',
     () async {
       final server = await servePackages();
-      server.serve(
-        'foo',
-        '1.0.0',
-        contents: [
-          d.dir('bin', [d.file('foo.dart', 'main() => print("hi"); ')]),
-        ],
-      );
       server.serve(
         'Foo',
         '1.0.0',
@@ -27,14 +21,22 @@ void main() {
         ],
       );
 
-      await runPub(args: ['global', 'activate', 'foo']);
+      await d.dir('foo', [d.libPubspec('Foo', '1.0.0')]).create();
       await runPub(
         args: ['global', 'activate', 'Foo'],
         error: '''
-You are trying to activate `Foo` but already have `foo` which
-differs only by casing. `pub` does not allow that.
+You can only activate packages with lower-case names.
 
-Consider `dart pub global deactivate foo`''',
+Did you mean `foo`?''',
+        exitCode: 1,
+      );
+
+      await runPub(
+        args: ['global', 'activate', '-spath', p.join(d.sandbox, 'foo')],
+        error: '''
+You can only activate packages with lower-case names.
+
+Did you mean `foo`?''',
         exitCode: 1,
       );
     },

--- a/test/global/activate/fails_when_active_package_is_corrupt_test.dart
+++ b/test/global/activate/fails_when_active_package_is_corrupt_test.dart
@@ -1,0 +1,52 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test(
+      'Complains if the current lockfile does not contain the expected package',
+      () async {
+    final server = await servePackages();
+    server.serve(
+      'foo',
+      '1.0.0',
+      contents: [
+        d.dir('bin', [d.file('foo.dart', 'main() => print("hi"); ')]),
+      ],
+    );
+
+    await runPub(args: ['global', 'activate', 'foo']);
+
+    // Write a bad pubspec.lock file.
+    final lockFilePath =
+        p.join(d.sandbox, cachePath, 'global_packages', 'foo', 'pubspec.lock');
+    File(lockFilePath).writeAsStringSync('''
+packages: {}
+sdks: {}
+''');
+
+    // Activating it again suggests deactivating the package.
+    await runPub(
+      args: ['global', 'activate', 'foo'],
+      error: '''
+Could not find `foo` in `$lockFilePath`.
+Your Pub cache might be corrupted.
+
+Consider `dart pub global deactivate foo`''',
+      exitCode: 1,
+    );
+
+    await runPub(
+      args: ['global', 'deactivate', 'foo'],
+      output: 'Removed package `foo`',
+    );
+  });
+}


### PR DESCRIPTION
Also handle a global lockfile without the right package name gracefully.

Fixes #4513 
