### PR TITLE
Don't emit timestamp in .dart_tool/package_config.json

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -501,7 +501,6 @@ See $workspacesDocUrl for more information.''',
     final packageConfig = PackageConfig(
       configVersion: 2,
       packages: entries,
-      generated: DateTime.now(),
       generator: 'pub',
       generatorVersion: sdk.version,
       additionalProperties: {

--- a/lib/src/package_config.dart
+++ b/lib/src/package_config.dart
@@ -19,11 +19,6 @@ class PackageConfig {
   /// Packages configured.
   List<PackageConfigEntry> packages;
 
-  /// Date-time the `.dart_tool/package_config.json` file was generated.
-  ///
-  /// `null` if not given.
-  DateTime? generated;
-
   /// Tool that generated the `.dart_tool/package_config.json` file.
   ///
   /// For `pub` this is always `'pub'`.
@@ -46,7 +41,6 @@ class PackageConfig {
   PackageConfig({
     required this.configVersion,
     required this.packages,
-    this.generated,
     this.generator,
     this.generatorVersion,
     Map<String, dynamic>? additionalProperties,
@@ -98,16 +92,6 @@ class PackageConfig {
       packages.add(PackageConfigEntry.fromJson(entry as Object));
     }
 
-    // Read the 'generated' property
-    DateTime? generated;
-    final generatedRaw = root['generated'];
-    if (generatedRaw != null) {
-      if (generatedRaw is! String) {
-        throwFormatException('generated', 'must be a string, if given');
-      }
-      generated = DateTime.parse(generatedRaw);
-    }
-
     // Read the 'generator' property
     final generator = root['generator'];
     if (generator is! String?) {
@@ -136,7 +120,6 @@ class PackageConfig {
     return PackageConfig(
       configVersion: configVersion,
       packages: packages,
-      generated: generated,
       generator: generator,
       generatorVersion: generatorVersion,
       additionalProperties: Map.fromEntries(
@@ -158,7 +141,6 @@ class PackageConfig {
   Map<String, Object?> toJson() => {
     'configVersion': configVersion,
     'packages': packages.map((p) => p.toJson()).toList(),
-    'generated': generated?.toUtc().toIso8601String(),
     'generator': generator,
     'generatorVersion': generatorVersion?.toString(),
   }..addAll(additionalProperties);

--- a/test/descriptor/package_config.dart
+++ b/test/descriptor/package_config.dart
@@ -28,7 +28,6 @@ class PackageConfigFileDescriptor extends Descriptor {
       packages: _packages,
       generatorVersion: Version.parse(_generatorVersion),
       generator: 'pub',
-      generated: DateTime.now().toUtc(),
       additionalProperties: {
         'pubCache': p.toUri(_pubCache).toString(),
         if (_flutterRoot != null)
@@ -94,9 +93,6 @@ class PackageConfigFileDescriptor extends Descriptor {
     );
 
     final expected = PackageConfig.fromJson(_config.toJson());
-    // omit generated date-time and packages
-    expected.generated = null; // comparing timestamps is unnecessary.
-    config.generated = null;
     expected.packages = []; // Already compared packages (ignoring ordering)
     config.packages = [];
     expect(

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -122,7 +122,6 @@ MSG : Logs written to $SANDBOX/cache/log/pub_log.txt.
 [E]    |   "languageVersion": "3.0"
 [E]    |   }
 [E]    |   ],
-[E]    |   "generated": "$TIME",
 [E]    |   "generator": "pub",
 [E]    |   "generatorVersion": "3.1.2+3",
 [E]    |   "pubCache": "file://$SANDBOX/cache"
@@ -309,7 +308,6 @@ FINE: Contents:
    |   "languageVersion": "3.0"
    |   }
    |   ],
-   |   "generated": "$TIME",
    |   "generator": "pub",
    |   "generatorVersion": "3.1.2+3",
    |   "pubCache": "file://$SANDBOX/cache"


### PR DESCRIPTION
We don't rely on the timestamp anywhere I know of

It gets in the way of dependency tracking

The field is optional according to https://github.com/dart-lang/language/blob/main/accepted/2.8/language-versioning/package-config-file-v2.md#:~:text=The%20following%20optional%20properties%20of%20the%20top%2Dlevel%20object%20allows%20the%20generator%20to%20specify%20metadata%20about%20the%20file.%20They%20can%20all%20be%20omitted%2C%20but%20if%20they%20are%20present%2C%20they%20should%20have%20the%20expected%20format.

Fixes https://github.com/dart-lang/sdk/issues/60371