### PR TITLE
Don't rewrite package_config and package_graph if unchanged

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -413,7 +413,6 @@ See $workspacesDocUrl for more information.''',
                 .sdkConstraints[sdk.identifier]
                 ?.effectiveConstraint,
       ),
-      ignoredProperties: ['generated'],
     );
     _writeIfDifferent(packageGraphPath, await _packageGraphFile(cache));
 
@@ -530,10 +529,7 @@ See $workspacesDocUrl for more information.''',
     // For purposes of equality we don't care about the `generated` timestamp.
     final originalText = tryReadTextFile(path);
     if (originalText != newContent) {
-      writeTextFile(
-        path,
-        '${const JsonEncoder.withIndent('  ').convert(newContent)}\n',
-      );
+      writeTextFile(path, newContent);
     } else {
       log.fine('`$path` is unchanged. Not rewriting.');
     }

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -413,6 +413,7 @@ See $workspacesDocUrl for more information.''',
                 .sdkConstraints[sdk.identifier]
                 ?.effectiveConstraint,
       ),
+      // Ignore the "generated" timestamp, if it's the only thing that changed.
       ignoredProperties: ['generated'],
     );
     _writeJsonIfDifferent(packageGraphPath, await _packageGraphJson(cache));

--- a/lib/src/package_config.dart
+++ b/lib/src/package_config.dart
@@ -19,11 +19,6 @@ class PackageConfig {
   /// Packages configured.
   List<PackageConfigEntry> packages;
 
-  /// Date-time the `.dart_tool/package_config.json` file was generated.
-  ///
-  /// `null` if not given.
-  DateTime? generated;
-
   /// Tool that generated the `.dart_tool/package_config.json` file.
   ///
   /// For `pub` this is always `'pub'`.
@@ -46,7 +41,6 @@ class PackageConfig {
   PackageConfig({
     required this.configVersion,
     required this.packages,
-    this.generated,
     this.generator,
     this.generatorVersion,
     Map<String, dynamic>? additionalProperties,
@@ -98,16 +92,6 @@ class PackageConfig {
       packages.add(PackageConfigEntry.fromJson(entry as Object));
     }
 
-    // Read the 'generated' property
-    DateTime? generated;
-    final generatedRaw = root['generated'];
-    if (generatedRaw != null) {
-      if (generatedRaw is! String) {
-        throwFormatException('generated', 'must be a string, if given');
-      }
-      generated = DateTime.parse(generatedRaw);
-    }
-
     // Read the 'generator' property
     final generator = root['generator'];
     if (generator is! String?) {
@@ -136,7 +120,6 @@ class PackageConfig {
     return PackageConfig(
       configVersion: configVersion,
       packages: packages,
-      generated: generated,
       generator: generator,
       generatorVersion: generatorVersion,
       additionalProperties: Map.fromEntries(
@@ -158,7 +141,6 @@ class PackageConfig {
   Map<String, Object?> toJson() => {
     'configVersion': configVersion,
     'packages': packages.map((p) => p.toJson()).toList(),
-    'generated': generated?.toUtc().toIso8601String(),
     'generator': generator,
     'generatorVersion': generatorVersion?.toString(),
   }..addAll(additionalProperties);

--- a/test/descriptor/package_config.dart
+++ b/test/descriptor/package_config.dart
@@ -28,7 +28,6 @@ class PackageConfigFileDescriptor extends Descriptor {
       packages: _packages,
       generatorVersion: Version.parse(_generatorVersion),
       generator: 'pub',
-      generated: DateTime.now().toUtc(),
       additionalProperties: {
         'pubCache': p.toUri(_pubCache).toString(),
         if (_flutterRoot != null)
@@ -94,9 +93,6 @@ class PackageConfigFileDescriptor extends Descriptor {
     );
 
     final expected = PackageConfig.fromJson(_config.toJson());
-    // omit generated date-time and packages
-    expected.generated = null; // comparing timestamps is unnecessary.
-    config.generated = null;
     expected.packages = []; // Already compared packages (ignoring ordering)
     config.packages = [];
     expect(

--- a/test/package_config_file_test.dart
+++ b/test/package_config_file_test.dart
@@ -332,13 +332,14 @@ void main() {
       );
       final packageGraph = jsonDecode(packageGraphFile.readAsStringSync());
       final packageGraphTimestamp = packageGraphFile.lastModifiedSync();
+      final s = p.separator;
       await pubGet(
         silent: allOf(
           contains(
-            '`.dart_tool/package_config.json` is unchanged. Not rewriting.',
+            '`.dart_tool${s}package_config.json` is unchanged. Not rewriting.',
           ),
           contains(
-            '`.dart_tool/package_graph.json` is unchanged. Not rewriting.',
+            '`.dart_tool${s}package_graph.json` is unchanged. Not rewriting.',
           ),
         ),
       );

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -122,7 +122,6 @@ MSG : Logs written to $SANDBOX/cache/log/pub_log.txt.
 [E]    |   "languageVersion": "3.0"
 [E]    |   }
 [E]    |   ],
-[E]    |   "generated": "$TIME",
 [E]    |   "generator": "pub",
 [E]    |   "generatorVersion": "3.1.2+3",
 [E]    |   "pubCache": "file://$SANDBOX/cache"
@@ -309,7 +308,6 @@ FINE: Contents:
    |   "languageVersion": "3.0"
    |   }
    |   ],
-   |   "generated": "$TIME",
    |   "generator": "pub",
    |   "generatorVersion": "3.1.2+3",
    |   "pubCache": "file://$SANDBOX/cache"


### PR DESCRIPTION
Based on textual equality

Also removes the timestamp from package_config.json

Fixes https://github.com/dart-lang/sdk/issues/60371