### PR TITLE
Fix handling of ignore patterns ending in *

### DIFF
--- a/lib/src/ignore.dart
+++ b/lib/src/ignore.dart
@@ -404,6 +404,7 @@ _IgnoreParseResult _parseIgnorePattern(String pattern, bool ignoreCase) {
 
   var current = first;
   String? peekChar() => current >= end ? null : pattern[current];
+  String? previous() => current < 2 ? null : pattern[current - 2];
 
   var expr = '';
 
@@ -477,8 +478,8 @@ _IgnoreParseResult _parseIgnorePattern(String pattern, bool ignoreCase) {
         } else {
           expr += '.*';
         }
-      } else if (peekChar() == '/' || peekChar() == null) {
-        // /a/* should not match '/a/'
+      } else if ((previous() == '/') && peekChar() == null) {
+        // /a/* should not match '/a/', so we require at least one character
         expr += '[^/]+';
       } else {
         // Handle a single '*'

--- a/test/ignore_test.dart
+++ b/test/ignore_test.dart
@@ -823,6 +823,9 @@ final testData = [
     'src/file.txt': true,
     'folder/other.txt': true,
     'sub/folder/file.txt': true,
+    'f': true,
+    'f/a': true,
+    'a/f': true,
   }),
   TestData.single('*f', {
     'file.txt': false,


### PR DESCRIPTION
#4551

We should only do the special casing when the `*` comes directly after the `/`.
