### PR TITLE
feat: allow fixed flutter version constraints.

### DIFF
--- a/lib/src/lock_file.dart
+++ b/lib/src/lock_file.dart
@@ -147,9 +147,6 @@ class LockFile {
               originalConstraint,
               defaultUpperBoundConstraint: null,
             ),
-            'flutter' => SdkConstraint.interpretFlutterSdkConstraint(
-              originalConstraint,
-            ),
             _ => SdkConstraint(originalConstraint),
           };
         },

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -251,10 +251,7 @@ environment:
           _packageName,
           _FileType.pubspec,
         );
-        constraints[name] =
-            name == 'flutter'
-                ? SdkConstraint.interpretFlutterSdkConstraint(constraint)
-                : SdkConstraint(constraint);
+        constraints[name] = SdkConstraint(constraint);
       });
     }
     return constraints;
@@ -814,21 +811,6 @@ class SdkConstraint {
       );
     }
     return SdkConstraint(constraint, originalConstraint: originalConstraint);
-  }
-
-  // Flutter constraints get special treatment, as Flutter won't be using
-  // semantic versioning to mark breaking releases. We simply ignore upper
-  // bounds.
-  factory SdkConstraint.interpretFlutterSdkConstraint(
-    VersionConstraint constraint,
-  ) {
-    if (constraint is VersionRange) {
-      return SdkConstraint(
-        VersionRange(min: constraint.min, includeMin: constraint.includeMin),
-        originalConstraint: constraint,
-      );
-    }
-    return SdkConstraint(constraint);
   }
 
   /// The language version of a constraint is determined from how it is written.


### PR DESCRIPTION
Previously there was code to treat x.y.z as >=x.y.z, specifically for the flutter sdk version constratint.  This change removes that which allows app authors to specify an upper bound on the flutter version constraint for their projects.

This isn't actually ready for landing, because I haven't yet been able to successfully get a clean run of pub tests locally on my mac (maybe they aren't expected to run cleanly on a mac?) even without any changes to pub.
