### PR TITLE
Use UTC for testing timestamps passed to git

### DIFF
--- a/test/descriptor/git.dart
+++ b/test/descriptor/git.dart
@@ -60,8 +60,8 @@ class GitRepoDescriptor extends DirectoryDescriptor {
       'GIT_COMMITTER_NAME': 'Pub Test',
       'GIT_COMMITTER_EMAIL': 'pub@dartlang.org',
       // To make stable commits ids we fix the date.
-      'GIT_COMMITTER_DATE': DateTime(1970).toIso8601String(),
-      'GIT_AUTHOR_DATE': DateTime(1970).toIso8601String(),
+      'GIT_COMMITTER_DATE': DateTime.utc(1970).toIso8601String(),
+      'GIT_AUTHOR_DATE': DateTime.utc(1970).toIso8601String(),
     };
 
     return git.run(


### PR DESCRIPTION
Suddenly my macos git complains that:
```
stderr: fatal: invalid date format: 1970-01-01T00:00:00.000
```

Not sure why that is, and when it stopped working (most of the time I develop on linux). Mac CI seems to be running fine.

But disregarding that utc time seems to be the right thing here.

For reference:
```dart
main() {
  print(DateTime(1970).toIso8601String());
  print(DateTime.utc(1970).toIso8601String());
}
```
prints
```
1970-01-01T00:00:00.000
1970-01-01T00:00:00.000Z
```

The last one makes git happy on my mac.