### PR TITLE
Refactor/login

### DIFF
--- a/lib/src/command/login.dart
+++ b/lib/src/command/login.dart
@@ -73,7 +73,7 @@ class LoginCommand extends PubCommand {
           'name': final String? name,
           'email': final String email,
         }) {
-          return _UserInfo(name, email);
+          return _UserInfo(name:name, email:email);
         } else {
           log.fine('Unexpected user info format: ${response.body}');
           return null;

--- a/lib/src/command/login.dart
+++ b/lib/src/command/login.dart
@@ -24,30 +24,28 @@ class LoginCommand extends PubCommand {
   @override
   Future<void> runProtected() async {
     final credentials = oauth2.loadCredentials();
+    final userInfo = await _retrieveUserInfo();
+
     if (credentials == null) {
-      final userInfo = await _retrieveUserInfo();
       if (userInfo == null) {
         log.warning(
-          'Could not retrieve your user-details.\n'
-          'You might have to run `$topLevelProgram pub logout` '
-          'to delete your credentials and try again.',
+          'Could not retrieve your user details.\n'
+          'Run `$topLevelProgram pub logout` to delete credentials and try '
+          'again.',
         );
       } else {
         log.message('You are now logged in as $userInfo');
       }
     } else {
-      final userInfo = await _retrieveUserInfo();
       if (userInfo == null) {
         log.warning(
-          'Your credentials seems broken.\n'
-          'Run `$topLevelProgram pub logout` '
-          'to delete your credentials and try again.',
+          'Your credentials seem to be broken.\n'
+          'Run `$topLevelProgram pub logout` to delete credentials and try '
+          'again.',
         );
+      } else {
+        log.message('You are already logged in as $userInfo');
       }
-      log.warning(
-        'You are already logged in as $userInfo\n'
-        'Run `$topLevelProgram pub logout` to log out and try again.',
-      );
     }
   }
 


### PR DESCRIPTION
What This PR Does
This PR refactors the internal login service logic, specifically the runProtected() and _retrieveUserInfo() methods, with the goal of:

- Improving code readability and maintainability

- Simplifying control flow

- Making log messages more actionable and less ambiguous

- Handling broken or missing credentials more gracefully

❓ Why I'm creating this PR
While trying to authenticate using dart pub login, I encountered this issue:
<img width="487" alt="image" src="https://github.com/user-attachments/assets/004e55b9-9d71-46e4-b7cd-8f831dba976a" />


`you are logged in as null`

This indicated broken or malformed credentials, and the current logging flow was not clear or helpful enough.
