### PR TITLE
Don't rewrite pubspec.lock and workspace_ref if not modified

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -405,7 +405,7 @@ See $workspacesDocUrl for more information.''',
   Future<void> writePackageConfigFiles() async {
     ensureDir(p.dirname(packageConfigPath));
 
-    _writeIfDifferent(
+    writeTextFilesIfDifferent(
       packageConfigPath,
       await _packageConfigFile(
         cache,
@@ -416,7 +416,7 @@ See $workspacesDocUrl for more information.''',
                 ?.effectiveConstraint,
       ),
     );
-    _writeIfDifferent(packageGraphPath, await _packageGraphFile(cache));
+    writeTextFilesIfDifferent(packageGraphPath, await _packageGraphFile(cache));
 
     if (workspaceRoot.workspaceChildren.isNotEmpty) {
       for (final package in workspaceRoot.transitiveWorkspace) {
@@ -524,17 +524,6 @@ See $workspacesDocUrl for more information.''',
       '  ',
     ).convert(packageConfig.toJson());
     return '$jsonText\n';
-  }
-
-  void _writeIfDifferent(String path, String newContent) {
-    // Compare to the present package_config.json
-    // For purposes of equality we don't care about the `generated` timestamp.
-    final originalText = tryReadTextFile(path);
-    if (originalText != newContent) {
-      writeTextFile(path, newContent);
-    } else {
-      log.fine('`$path` is unchanged. Not rewriting.');
-    }
   }
 
   /// Gets all dependencies of the [workspaceRoot] package.

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -405,7 +405,7 @@ See $workspacesDocUrl for more information.''',
   Future<void> writePackageConfigFiles() async {
     ensureDir(p.dirname(packageConfigPath));
 
-    writeTextFilesIfDifferent(
+    writeTextFileIfDifferent(
       packageConfigPath,
       await _packageConfigFile(
         cache,
@@ -416,7 +416,7 @@ See $workspacesDocUrl for more information.''',
                 ?.effectiveConstraint,
       ),
     );
-    writeTextFilesIfDifferent(packageGraphPath, await _packageGraphFile(cache));
+    writeTextFileIfDifferent(packageGraphPath, await _packageGraphFile(cache));
 
     if (workspaceRoot.workspaceChildren.isNotEmpty) {
       for (final package in workspaceRoot.transitiveWorkspace) {
@@ -430,7 +430,7 @@ See $workspacesDocUrl for more information.''',
         final workspaceRef = const JsonEncoder.withIndent(
           '  ',
         ).convert({'workspaceRoot': relativeRootPath});
-        writeTextFile(workspaceRefPath, '$workspaceRef\n');
+        writeTextFileIfDifferent(workspaceRefPath, '$workspaceRef\n');
       }
     }
   }

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -257,7 +257,7 @@ void writeTextFile(
   File(file).writeAsStringSync(contents, encoding: encoding);
 }
 
-void writeTextFilesIfDifferent(String path, String newContent) {
+void writeTextFileIfDifferent(String path, String newContent) {
   // Compare to the present package_config.json
   // For purposes of equality we don't care about the `generated` timestamp.
   final originalText = tryReadTextFile(path);

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -257,6 +257,17 @@ void writeTextFile(
   File(file).writeAsStringSync(contents, encoding: encoding);
 }
 
+void writeTextFilesIfDifferent(String path, String newContent) {
+  // Compare to the present package_config.json
+  // For purposes of equality we don't care about the `generated` timestamp.
+  final originalText = tryReadTextFile(path);
+  if (originalText != newContent) {
+    writeTextFile(path, newContent);
+  } else {
+    log.fine('`$path` is unchanged. Not rewriting.');
+  }
+}
+
 /// Reads the contents of the binary file [file].
 void writeBinaryFile(String file, Uint8List data) {
   log.io('Writing ${data.length} bytes to file $file.');

--- a/lib/src/lock_file.dart
+++ b/lib/src/lock_file.dart
@@ -406,7 +406,7 @@ ${yamlToString(data)}
         detectWindowsLineEndings(readTextFile(lockFilePath));
 
     final serialized = serialize(p.dirname(lockFilePath), cache);
-    writeTextFile(
+    writeTextFilesIfDifferent(
       lockFilePath,
       windowsLineEndings ? serialized.replaceAll('\n', '\r\n') : serialized,
     );

--- a/lib/src/lock_file.dart
+++ b/lib/src/lock_file.dart
@@ -406,7 +406,7 @@ ${yamlToString(data)}
         detectWindowsLineEndings(readTextFile(lockFilePath));
 
     final serialized = serialize(p.dirname(lockFilePath), cache);
-    writeTextFilesIfDifferent(
+    writeTextFileIfDifferent(
       lockFilePath,
       windowsLineEndings ? serialized.replaceAll('\n', '\r\n') : serialized,
     );


### PR DESCRIPTION
We did this for package_config. No reason not to do the same for the other files, rather it causes trouble not to.
Fixes #4588 