### PR TITLE
Mark package-configs as active when writing

### DIFF
--- a/doc/cache_layout.md
+++ b/doc/cache_layout.md
@@ -248,11 +248,11 @@ one directory.
 
 When implemented `dart pub cache gc` will look through all the package configs,
 and mark all cached packages in the cache used by those projects `alive`. If a
-package config doesn't exist, it is ignored.
+package config doesn't exist, it is ignored, and the file marking it is deleted.
 
 All other packages in the cache are removed.
 
-Packages that are installed in the cache within 1 hour are not deleted. This is
+Packages that are installed in the cache within 1 day are not deleted. This is
 to minimize the risk of race-conditions.  
 
 ## Logs

--- a/doc/cache_layout.md
+++ b/doc/cache_layout.md
@@ -242,7 +242,7 @@ In order to be able to prune the cache (`dart pub cache gc`) pub keeps a tally o
 each time it writes a `.dart_tool/package_config.json` file (an activation).
 
 The directory is laid out such that each file-name is the hex-encoded sha256
-hash of the absolute file-uri of the path the the package config.
+hash of the absolute file-uri of the path of the package config.
 
 The first two bytes are used for a subdirectory, to prevent too many files in
 one directory.

--- a/doc/cache_layout.md
+++ b/doc/cache_layout.md
@@ -34,7 +34,7 @@ Here are the top-level folders you can find in a Pub cache.
 ```plaintext
 $PUB_CACHE/
 ├── global_packages/  # Globally activated packages
-├── active_packages/  # Information about packages that this cache caches for.
+├── active_roots/     # Information about packages that this cache caches for.
 ├── bin/              # Executables compiled from globally activated packages.
 ├── git/              # Cloned git packages
 ├── hosted/           # Hosted package downloads
@@ -234,9 +234,8 @@ $PUB_CACHE/bin/
 └── stagehand
 ```
 
-# Active packages
-$PUB_CACHE/active_packages/
-└── active_packages
+# Active roots
+$PUB_CACHE/active_roots/
 
 In order to be able to prune the cache (`dart pub cache gc`) pub keeps a tally of
 each time it writes a `.dart_tool/package_config.json` file (an activation).
@@ -254,11 +253,11 @@ package config doesn't exist, it is ignored.
 All other packages in the cache are removed.
 
 Packages that are installed in the cache within 1 hour are not deleted. This is
-to minimize the risk of race-conditions.
+to minimize the risk of race-conditions.  
 
 ## Logs
 
 When pub crashes or is run with `--verbose` it will create a
 `$PUB_CACHE/log/pub_log.txt` with the dart sdk version, platform, `$PUB_CACHE`,
-`$PUB_HOSTED_URL`, `pubspec.yaml`, `pubspec.lock`, current command, verbose log and
-stack-trace.
+`$PUB_HOSTED_URL`, `pubspec.yaml`, `pubspec.lock`, current command, verbose log
+and stack-trace.

--- a/doc/cache_layout.md
+++ b/doc/cache_layout.md
@@ -34,6 +34,7 @@ Here are the top-level folders you can find in a Pub cache.
 ```plaintext
 $PUB_CACHE/
 ├── global_packages/  # Globally activated packages
+├── active_packages/  # Information about packages that this cache caches for.
 ├── bin/              # Executables compiled from globally activated packages.
 ├── git/              # Cloned git packages
 ├── hosted/           # Hosted package downloads
@@ -232,6 +233,28 @@ $PUB_CACHE/bin/
 ├── mono_repo
 └── stagehand
 ```
+
+# Active packages
+$PUB_CACHE/active_packages/
+└── active_packages
+
+In order to be able to prune the cache (`dart pub cache gc`) pub keeps a tally of
+each time it writes a `.dart_tool/package_config.json` file (an activation).
+
+The directory is laid out such that each file-name is the hex-encoded sha256
+hash of the absolute file-uri of the path the the package config.
+
+The first two bytes are used for a subdirectory, to prevent too many files in
+one directory.
+
+When implemented `dart pub cache gc` will look through all the package configs,
+and mark all cached packages in the cache used by those projects `alive`. If a
+package config doesn't exist, it is ignored.
+
+All other packages in the cache are removed.
+
+Packages that are installed in the cache within 1 hour are not deleted. This is
+to minimize the potential for race-conditions.
 
 ## Logs
 

--- a/doc/cache_layout.md
+++ b/doc/cache_layout.md
@@ -254,7 +254,7 @@ package config doesn't exist, it is ignored.
 All other packages in the cache are removed.
 
 Packages that are installed in the cache within 1 hour are not deleted. This is
-to minimize the potential for race-conditions.
+to minimize the risk of race-conditions.
 
 ## Logs
 

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -402,6 +402,8 @@ See $workspacesDocUrl for more information.''',
   /// If the workspace is non-trivial: For each package in the workspace write:
   /// `.dart_tool/pub/workspace_ref.json` with a pointer to the workspace root
   /// package dir.
+  ///
+  /// Also marks the package active in `PUB_CACHE/active_packages/`.
   Future<void> writePackageConfigFiles() async {
     ensureDir(p.dirname(packageConfigPath));
 
@@ -432,6 +434,9 @@ See $workspacesDocUrl for more information.''',
         ).convert({'workspaceRoot': relativeRootPath});
         writeTextFileIfDifferent(workspaceRefPath, '$workspaceRef\n');
       }
+    }
+    if (lockFile.packages.values.any((id) => id.source is CachedSource)) {
+      cache.markPackageActive(packageConfigPath);
     }
   }
 

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -403,7 +403,7 @@ See $workspacesDocUrl for more information.''',
   /// `.dart_tool/pub/workspace_ref.json` with a pointer to the workspace root
   /// package dir.
   ///
-  /// Also marks the package active in `PUB_CACHE/active_packages/`.
+  /// Also marks the package active in `PUB_CACHE/active_roots/`.
   Future<void> writePackageConfigFiles() async {
     ensureDir(p.dirname(packageConfigPath));
 
@@ -436,7 +436,7 @@ See $workspacesDocUrl for more information.''',
       }
     }
     if (lockFile.packages.values.any((id) => id.source is CachedSource)) {
-      cache.markPackageActive(packageConfigPath);
+      cache.markRootActive(packageConfigPath);
     }
   }
 

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -293,10 +293,14 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
 
       lockFile.writeToFile(p.join(tempDir, 'pubspec.lock'), cache);
 
+      final packageDir = _packageDir(name);
+      tryDeleteEntry(packageDir);
+      tryRenameDir(tempDir, packageDir);
+
       // Load the package graph from [result] so we don't need to re-parse all
       // the pubspecs.
       final entrypoint = Entrypoint.global(
-        root,
+        packageForConstraint(dep, packageDir),
         lockFile,
         cache,
         solveResult: result,
@@ -305,9 +309,6 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
       await entrypoint.writePackageConfigFiles();
 
       await entrypoint.precompileExecutables();
-
-      tryDeleteEntry(_packageDir(name));
-      tryRenameDir(tempDir, _packageDir(name));
     }
 
     final entrypoint = Entrypoint.global(

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -257,6 +257,10 @@ void writeTextFile(
   File(file).writeAsStringSync(contents, encoding: encoding);
 }
 
+/// Reads the file at [path] and writes [newContent] to it, if it is different
+/// from [newContent].
+///
+/// If the file doesn't exist it is always written.
 void writeTextFileIfDifferent(String path, String newContent) {
   // Compare to the present package_config.json
   // For purposes of equality we don't care about the `generated` timestamp.

--- a/lib/src/system_cache.dart
+++ b/lib/src/system_cache.dart
@@ -405,18 +405,18 @@ https://dart.dev/go/pub-cache
 
   bool _hasMaintainedCache = false;
 
-  late final _activePackagesDir = p.join(rootDir, 'active_packages');
+  late final _activeRootsDir = p.join(rootDir, 'active_roots');
 
   /// Returns the paths of all packages_configs registered in
-  /// [_activePackagesDir].
-  List<String> activePackages() {
+  /// [_activeRootsDir].
+  List<String> activeRoots() {
     final List<String> files;
     try {
-      files = listDir(_activePackagesDir, includeDirs: false, recursive: true);
+      files = listDir(_activeRootsDir, includeDirs: false, recursive: true);
     } on IOException {
       return [];
     }
-    final activePackages = <String>[];
+    final activeRoots = <String>[];
     for (final file in files) {
       final Object? decoded;
       try {
@@ -447,14 +447,14 @@ https://dart.dev/go/pub-cache
         tryDeleteEntry(file);
         continue;
       }
-      activePackages.add(uri.toFilePath());
+      activeRoots.add(uri.toFilePath());
     }
-    return activePackages;
+    return activeRoots;
   }
 
-  /// Adds a file to the `PUB_CACHE/active_packages/` dir indicating
+  /// Adds a file to the `PUB_CACHE/active_roots/` dir indicating
   /// [packageConfigPath] is active.
-  void markPackageActive(String packageConfigPath) {
+  void markRootActive(String packageConfigPath) {
     final canonicalFileUri =
         p.toUri(p.canonicalize(packageConfigPath)).toString();
 
@@ -463,7 +463,7 @@ https://dart.dev/go/pub-cache
     final firstTwo = hash.substring(0, 2);
     final theRest = hash.substring(2);
 
-    final dir = p.join(_activePackagesDir, firstTwo);
+    final dir = p.join(_activeRootsDir, firstTwo);
     ensureDir(dir);
 
     final filename = p.join(dir, theRest);

--- a/test/cache/gc_test.dart
+++ b/test/cache/gc_test.dart
@@ -1,0 +1,90 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as p;
+import 'package:pub/src/system_cache.dart';
+import 'package:pub/src/utils.dart';
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+void main() async {
+  test('marks a package active on pub get and global activate', () async {
+    final server = await servePackages();
+
+    server.serve('foo', '1.0.0');
+    server.serve('bar', '1.0.0');
+
+    await runPub(args: ['global', 'activate', 'foo']);
+
+    // Without cached dependencies we don't register the package
+    await d.dir('app_none', [d.appPubspec()]).create();
+
+    await d.appDir(dependencies: {'bar': '1.0.0'}).create();
+
+    await d.dir('app_hosted', [
+      d.appPubspec(dependencies: {'bar': '^1.0.0'}),
+    ]).create();
+
+    await d.git('lib', [d.libPubspec('lib', '1.0.0')]).create();
+
+    await d.dir('app_git', [
+      d.appPubspec(
+        dependencies: {
+          'lib': {'git': '../lib'},
+        },
+      ),
+    ]).create();
+
+    await d.dir('app_path', [
+      d.appPubspec(
+        dependencies: {
+          'lib': {'path': '../lib'},
+        },
+      ),
+    ]).create();
+
+    await pubGet(workingDirectory: p.join(d.sandbox, 'app_none'));
+    await pubGet(workingDirectory: p.join(d.sandbox, 'app_hosted'));
+    await pubGet(workingDirectory: p.join(d.sandbox, 'app_git'));
+    await pubGet(workingDirectory: p.join(d.sandbox, 'app_path'));
+
+    final markingFiles =
+        Directory(
+          p.join(d.sandbox, cachePath, 'active_packages'),
+        ).listSync(recursive: true).whereType<File>().toList();
+
+    expect(markingFiles, hasLength(3));
+
+    for (final file in markingFiles) {
+      final uri =
+          (jsonDecode(file.readAsStringSync()) as Map)['package_config']
+              as String;
+      final hash = hexEncode(sha256.convert(utf8.encode(uri)).bytes);
+      final hashFileName =
+          '${p.basename(p.dirname(file.path))}${p.basename(file.path)}';
+      expect(hashFileName, hash);
+    }
+
+    expect(markingFiles, hasLength(3));
+
+    expect(
+      SystemCache(rootDir: p.join(d.sandbox, cachePath)).activePackages(),
+      {
+        p.join(d.sandbox, 'app_hosted', '.dart_tool', 'package_config.json'),
+        p.join(d.sandbox, 'app_git', '.dart_tool', 'package_config.json'),
+
+        p.join(
+          d.sandbox,
+          cachePath,
+          'global_packages',
+          'foo',
+          '.dart_tool',
+          'package_config.json',
+        ),
+      },
+    );
+  });
+}

--- a/test/cache/gc_test.dart
+++ b/test/cache/gc_test.dart
@@ -73,16 +73,22 @@ void main() async {
     expect(
       SystemCache(rootDir: p.join(d.sandbox, cachePath)).activePackages(),
       {
-        p.join(d.sandbox, 'app_hosted', '.dart_tool', 'package_config.json'),
-        p.join(d.sandbox, 'app_git', '.dart_tool', 'package_config.json'),
+        p.canonicalize(
+          p.join(d.sandbox, 'app_hosted', '.dart_tool', 'package_config.json'),
+        ),
+        p.canonicalize(
+          p.join(d.sandbox, 'app_git', '.dart_tool', 'package_config.json'),
+        ),
 
-        p.join(
-          d.sandbox,
-          cachePath,
-          'global_packages',
-          'foo',
-          '.dart_tool',
-          'package_config.json',
+        p.canonicalize(
+          p.join(
+            d.sandbox,
+            cachePath,
+            'global_packages',
+            'foo',
+            '.dart_tool',
+            'package_config.json',
+          ),
         ),
       },
     );

--- a/test/cache/gc_test.dart
+++ b/test/cache/gc_test.dart
@@ -53,7 +53,7 @@ void main() async {
 
     final markingFiles =
         Directory(
-          p.join(d.sandbox, cachePath, 'active_packages'),
+          p.join(d.sandbox, cachePath, 'active_roots'),
         ).listSync(recursive: true).whereType<File>().toList();
 
     expect(markingFiles, hasLength(3));
@@ -70,27 +70,24 @@ void main() async {
 
     expect(markingFiles, hasLength(3));
 
-    expect(
-      SystemCache(rootDir: p.join(d.sandbox, cachePath)).activePackages(),
-      {
-        p.canonicalize(
-          p.join(d.sandbox, 'app_hosted', '.dart_tool', 'package_config.json'),
-        ),
-        p.canonicalize(
-          p.join(d.sandbox, 'app_git', '.dart_tool', 'package_config.json'),
-        ),
+    expect(SystemCache(rootDir: p.join(d.sandbox, cachePath)).activeRoots(), {
+      p.canonicalize(
+        p.join(d.sandbox, 'app_hosted', '.dart_tool', 'package_config.json'),
+      ),
+      p.canonicalize(
+        p.join(d.sandbox, 'app_git', '.dart_tool', 'package_config.json'),
+      ),
 
-        p.canonicalize(
-          p.join(
-            d.sandbox,
-            cachePath,
-            'global_packages',
-            'foo',
-            '.dart_tool',
-            'package_config.json',
-          ),
+      p.canonicalize(
+        p.join(
+          d.sandbox,
+          cachePath,
+          'global_packages',
+          'foo',
+          '.dart_tool',
+          'package_config.json',
         ),
-      },
-    );
+      ),
+    });
   });
 }

--- a/test/embedding/embedding_test.dart
+++ b/test/embedding/embedding_test.dart
@@ -553,8 +553,8 @@ String _filter(String input) {
         r'"archive_sha256":"$SHA256"',
       )
       .replaceAll(
-        RegExp(r'active_packages/[0-9a-f]{2}/[0-9a-f]{62}', multiLine: true),
-        r'active_packages/$HH/$HASH',
+        RegExp(r'active_roots/[0-9a-f]{2}/[0-9a-f]{62}', multiLine: true),
+        r'active_roots/$HH/$HASH',
       )
       /// TODO(sigurdm): This hack suppresses differences in stack-traces
       /// between dart 2.17 and 2.18. Remove when 2.18 is stable.

--- a/test/embedding/embedding_test.dart
+++ b/test/embedding/embedding_test.dart
@@ -437,7 +437,13 @@ main() {
 
 String _filter(String input) {
   return input
-      .replaceAll(p.toUri(d.sandbox).toString(), r'file://$SANDBOX')
+      .replaceAll(
+        RegExp(
+          RegExp.escape(p.toUri(d.sandbox).toString()),
+          caseSensitive: false,
+        ),
+        r'file://$SANDBOX',
+      )
       .replaceAll(d.sandbox, r'$SANDBOX')
       .replaceAll(Platform.pathSeparator, '/')
       .replaceAll(Platform.operatingSystem, r'$OS')

--- a/test/embedding/embedding_test.dart
+++ b/test/embedding/embedding_test.dart
@@ -546,6 +546,10 @@ String _filter(String input) {
         RegExp(r'"archive_sha256":"[0-9a-f]{64}"', multiLine: true),
         r'"archive_sha256":"$SHA256"',
       )
+      .replaceAll(
+        RegExp(r'active_packages/[0-9a-f]{2}/[0-9a-f]{62}', multiLine: true),
+        r'active_packages/$HH/$HASH',
+      )
       /// TODO(sigurdm): This hack suppresses differences in stack-traces
       /// between dart 2.17 and 2.18. Remove when 2.18 is stable.
       .replaceAllMapped(

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -149,7 +149,7 @@ MSG : Logs written to $SANDBOX/cache/log/pub_log.txt.
 [E]    |   ],
 [E]    |   "configVersion": 1
 [E]    | }
-[E] IO  : Writing $N characters to text file $SANDBOX/cache/active_packages/2b/4cac0adeb65fd767481ef7e665228a6707acea19b855fc1a840422690a63d9.
+[E] IO  : Writing $N characters to text file $SANDBOX/cache/active_packages/$HH/$HASH.
 [E] FINE: Contents:
 [E]    | {"package_config":"file://$SANDBOX/myapp/.dart_tool/package_config.json"}
 [E] IO  : Writing $N characters to text file $SANDBOX/cache/log/pub_log.txt.
@@ -338,7 +338,7 @@ FINE: Contents:
    |   ],
    |   "configVersion": 1
    | }
-IO  : Writing $N characters to text file $SANDBOX/cache/active_packages/2b/4cac0adeb65fd767481ef7e665228a6707acea19b855fc1a840422690a63d9.
+IO  : Writing $N characters to text file $SANDBOX/cache/active_packages/$HH/$HASH.
 FINE: Contents:
    | {"package_config":"file://$SANDBOX/myapp/.dart_tool/package_config.json"}
 ---- End log transcript ----

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -149,7 +149,7 @@ MSG : Logs written to $SANDBOX/cache/log/pub_log.txt.
 [E]    |   ],
 [E]    |   "configVersion": 1
 [E]    | }
-[E] IO  : Writing $N characters to text file $SANDBOX/cache/active_packages/$HH/$HASH.
+[E] IO  : Writing $N characters to text file $SANDBOX/cache/active_roots/$HH/$HASH.
 [E] FINE: Contents:
 [E]    | {"package_config":"file://$SANDBOX/myapp/.dart_tool/package_config.json"}
 [E] IO  : Writing $N characters to text file $SANDBOX/cache/log/pub_log.txt.
@@ -338,7 +338,7 @@ FINE: Contents:
    |   ],
    |   "configVersion": 1
    | }
-IO  : Writing $N characters to text file $SANDBOX/cache/active_packages/$HH/$HASH.
+IO  : Writing $N characters to text file $SANDBOX/cache/active_roots/$HH/$HASH.
 FINE: Contents:
    | {"package_config":"file://$SANDBOX/myapp/.dart_tool/package_config.json"}
 ---- End log transcript ----

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -149,6 +149,9 @@ MSG : Logs written to $SANDBOX/cache/log/pub_log.txt.
 [E]    |   ],
 [E]    |   "configVersion": 1
 [E]    | }
+[E] IO  : Writing $N characters to text file $SANDBOX/cache/active_packages/2b/4cac0adeb65fd767481ef7e665228a6707acea19b855fc1a840422690a63d9.
+[E] FINE: Contents:
+[E]    | {"package_config":"file://$SANDBOX/myapp/.dart_tool/package_config.json"}
 [E] IO  : Writing $N characters to text file $SANDBOX/cache/log/pub_log.txt.
 
 -------------------------------- END OF OUTPUT ---------------------------------
@@ -335,6 +338,9 @@ FINE: Contents:
    |   ],
    |   "configVersion": 1
    | }
+IO  : Writing $N characters to text file $SANDBOX/cache/active_packages/2b/4cac0adeb65fd767481ef7e665228a6707acea19b855fc1a840422690a63d9.
+FINE: Contents:
+   | {"package_config":"file://$SANDBOX/myapp/.dart_tool/package_config.json"}
 ---- End log transcript ----
 -------------------------------- END OF OUTPUT ---------------------------------
 


### PR DESCRIPTION
This is preparing for a `dart pub cache gc` command for clearing up the cache.

By storing inside the cache where each "activated" package is, we enable "gc'ing" by finding all cached packages not referenced by an active package.

