### PR TITLE
Respect upper bound of Flutter constraint in root packages after 3.9

### DIFF
--- a/lib/src/language_version.dart
+++ b/lib/src/language_version.dart
@@ -70,6 +70,9 @@ class LanguageVersion implements Comparable<LanguageVersion> {
   bool get forbidsUnknownDescriptionKeys =>
       this >= firstVersionForbidingUnknownDescriptionKeys;
 
+  bool get respectsFlutterBoundInRoots =>
+      this >= firstVersionRespectingFlutterBoundInRoots;
+
   /// Minimum language version at which short hosted syntax is supported.
   ///
   /// This allows `hosted` dependencies to be expressed as:
@@ -111,6 +114,10 @@ class LanguageVersion implements Comparable<LanguageVersion> {
   static const firstVersionForbidingUnknownDescriptionKeys = LanguageVersion(
     3,
     7,
+  );
+  static const firstVersionRespectingFlutterBoundInRoots = LanguageVersion(
+    3,
+    9,
   );
 
   /// Transform language version to string that can be parsed with

--- a/lib/src/lock_file.dart
+++ b/lib/src/lock_file.dart
@@ -149,6 +149,7 @@ class LockFile {
             ),
             'flutter' => SdkConstraint.interpretFlutterSdkConstraint(
               originalConstraint,
+              isRoot: false,
             ),
             _ => SdkConstraint(originalConstraint),
           };

--- a/lib/src/lock_file.dart
+++ b/lib/src/lock_file.dart
@@ -10,6 +10,7 @@ import 'package:source_span/source_span.dart';
 import 'package:yaml/yaml.dart';
 
 import 'io.dart';
+import 'language_version.dart';
 import 'package_name.dart';
 import 'pubspec.dart';
 import 'system_cache.dart';
@@ -150,6 +151,7 @@ class LockFile {
             'flutter' => SdkConstraint.interpretFlutterSdkConstraint(
               originalConstraint,
               isRoot: false,
+              languageVersion: LanguageVersion.defaultLanguageVersion,
             ),
             _ => SdkConstraint(originalConstraint),
           };

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:collection/collection.dart' hide mapMap;
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
@@ -829,7 +831,10 @@ class SdkConstraint {
     VersionConstraint constraint, {
     required bool isRoot,
   }) {
-    if (!isRoot && constraint is VersionRange) {
+    if ((!isRoot ||
+            (Platform.environment['PUB_IGNORE_FLUTTER_UPPER_BOUND'] ?? '')
+                .isNotEmpty) &&
+        constraint is VersionRange) {
       return SdkConstraint(
         VersionRange(min: constraint.min, includeMin: constraint.includeMin),
         originalConstraint: constraint,

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -253,7 +253,10 @@ environment:
         );
         constraints[name] =
             name == 'flutter'
-                ? SdkConstraint.interpretFlutterSdkConstraint(constraint)
+                ? SdkConstraint.interpretFlutterSdkConstraint(
+                  constraint,
+                  isRoot: _containingDescription is ResolvedRootDescription,
+                )
                 : SdkConstraint(constraint);
       });
     }
@@ -818,11 +821,15 @@ class SdkConstraint {
 
   // Flutter constraints get special treatment, as Flutter won't be using
   // semantic versioning to mark breaking releases. We simply ignore upper
-  // bounds.
+  // bounds for dependencies.
+  //
+  // For root packages we use the upper bound, allowing app developers to
+  // constrain the Flutter version.
   factory SdkConstraint.interpretFlutterSdkConstraint(
-    VersionConstraint constraint,
-  ) {
-    if (constraint is VersionRange) {
+    VersionConstraint constraint, {
+    required bool isRoot,
+  }) {
+    if (!isRoot && constraint is VersionRange) {
       return SdkConstraint(
         VersionRange(min: constraint.min, includeMin: constraint.includeMin),
         originalConstraint: constraint,

--- a/test/get/flutter_constraint_upper_bound_ignored_test.dart
+++ b/test/get/flutter_constraint_upper_bound_ignored_test.dart
@@ -9,28 +9,31 @@ import '../descriptor.dart' as d;
 import '../test_pub.dart';
 
 void main() {
-  test('pub get succeeds despite of "invalid" flutter upper bound', () async {
-    final fakeFlutterRoot = d.dir('fake_flutter_root', [
-      d.flutterVersion('1.23.0'),
-    ]);
-    await fakeFlutterRoot.create();
+  test(
+    'pub get succeeds despite of "invalid" flutter upper bound in dependency',
+    () async {
+      final fakeFlutterRoot = d.dir('fake_flutter_root', [
+        d.flutterVersion('1.23.0'),
+      ]);
+      await fakeFlutterRoot.create();
 
-    final server = await servePackages();
-    server.serve(
-      'foo',
-      '1.0.0',
-      pubspec: {
-        'environment': {'sdk': '^$testVersion', 'flutter': '>=0.5.0 <1.0.0'},
-      },
-    );
+      final server = await servePackages();
+      server.serve(
+        'foo',
+        '1.0.0',
+        pubspec: {
+          'environment': {'sdk': '^$testVersion', 'flutter': '>=0.5.0 <1.0.0'},
+        },
+      );
 
-    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+      await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
 
-    await pubGet(
-      exitCode: exit_codes.SUCCESS,
-      environment: {'FLUTTER_ROOT': fakeFlutterRoot.io.path},
-    );
-  });
+      await pubGet(
+        exitCode: exit_codes.SUCCESS,
+        environment: {'FLUTTER_ROOT': fakeFlutterRoot.io.path},
+      );
+    },
+  );
 
   test('pub get respects the bound of the root package', () async {
     final fakeFlutterRoot = d.dir('fake_flutter_root', [
@@ -58,6 +61,35 @@ void main() {
       ),
     );
   });
+
+  test(
+    'pub get ignores the bound of the root package if env-var is set',
+    () async {
+      final fakeFlutterRoot = d.dir('fake_flutter_root', [
+        d.flutterVersion('1.23.0'),
+      ]);
+      await fakeFlutterRoot.create();
+
+      await d
+          .appDir(
+            pubspec: {
+              'environment': {
+                'sdk': '^$testVersion',
+                'flutter': '>=0.5.0 <1.0.0',
+              },
+            },
+          )
+          .create();
+
+      await pubGet(
+        exitCode: 0,
+        environment: {
+          'FLUTTER_ROOT': fakeFlutterRoot.io.path,
+          'PUB_IGNORE_FLUTTER_UPPER_BOUND': 'true',
+        },
+      );
+    },
+  );
 
   test('pub get respects the bound of a workspace root package', () async {
     final fakeFlutterRoot = d.dir('fake_flutter_root', [

--- a/test/get/flutter_constraint_upper_bound_ignored_test.dart
+++ b/test/get/flutter_constraint_upper_bound_ignored_test.dart
@@ -35,7 +35,7 @@ void main() {
     },
   );
 
-  test('pub get respects the bound of the root package', () async {
+  test('pub get ignores the bound of the root package before 3.10', () async {
     final fakeFlutterRoot = d.dir('fake_flutter_root', [
       d.flutterVersion('1.23.0'),
     ]);
@@ -44,52 +44,45 @@ void main() {
     await d
         .appDir(
           pubspec: {
-            'environment': {
-              'sdk': '^$testVersion',
-              'flutter': '>=0.5.0 <1.0.0',
-            },
+            'environment': {'sdk': '^3.8.0', 'flutter': '>=0.5.0 <1.0.0'},
+          },
+        )
+        .create();
+
+    await pubGet(
+      environment: {
+        'FLUTTER_ROOT': fakeFlutterRoot.io.path,
+        '_PUB_TEST_SDK_VERSION': '3.9.0',
+      },
+    );
+  });
+
+  test('pub get respects the bound of the root package after 3.9', () async {
+    final fakeFlutterRoot = d.dir('fake_flutter_root', [
+      d.flutterVersion('1.23.0'),
+    ]);
+    await fakeFlutterRoot.create();
+
+    await d
+        .appDir(
+          pubspec: {
+            'environment': {'sdk': '^3.9.0', 'flutter': '>=0.5.0 <1.0.0'},
           },
         )
         .create();
 
     await pubGet(
       exitCode: 1,
-      environment: {'FLUTTER_ROOT': fakeFlutterRoot.io.path},
+      environment: {
+        'FLUTTER_ROOT': fakeFlutterRoot.io.path,
+        '_PUB_TEST_SDK_VERSION': '3.9.0',
+      },
       error: contains(
         'Because myapp requires '
         'Flutter SDK version >=0.5.0 <1.0.0, version solving failed',
       ),
     );
   });
-
-  test(
-    'pub get ignores the bound of the root package if env-var is set',
-    () async {
-      final fakeFlutterRoot = d.dir('fake_flutter_root', [
-        d.flutterVersion('1.23.0'),
-      ]);
-      await fakeFlutterRoot.create();
-
-      await d
-          .appDir(
-            pubspec: {
-              'environment': {
-                'sdk': '^$testVersion',
-                'flutter': '>=0.5.0 <1.0.0',
-              },
-            },
-          )
-          .create();
-
-      await pubGet(
-        exitCode: 0,
-        environment: {
-          'FLUTTER_ROOT': fakeFlutterRoot.io.path,
-          'PUB_IGNORE_FLUTTER_UPPER_BOUND': 'true',
-        },
-      );
-    },
-  );
 
   test('pub get respects the bound of a workspace root package', () async {
     final fakeFlutterRoot = d.dir('fake_flutter_root', [
@@ -100,7 +93,7 @@ void main() {
     await d.dir(appPath, [
       d.appPubspec(
         extras: {
-          'environment': {'sdk': '^3.5.0'},
+          'environment': {'sdk': '^3.9.0'},
           'workspace': ['app'],
         },
       ),
@@ -110,7 +103,7 @@ void main() {
           '1.0.0',
           resolutionWorkspace: true,
           extras: {
-            'environment': {'sdk': '^3.5.0', 'flutter': '>=0.5.0 <1.0.0'},
+            'environment': {'sdk': '^3.9.0', 'flutter': '>=0.5.0 <1.0.0'},
           },
         ),
       ]),
@@ -119,7 +112,7 @@ void main() {
     await pubGet(
       exitCode: 1,
       environment: {
-        '_PUB_TEST_SDK_VERSION': '3.5.0',
+        '_PUB_TEST_SDK_VERSION': '3.9.0',
         'FLUTTER_ROOT': fakeFlutterRoot.io.path,
       },
       error: contains(

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -793,7 +793,7 @@ dependencies:
         final pubspec = Pubspec.parse(
           '''
 environment:
-  sdk: ">=1.2.3 <2.3.4"
+  sdk: ">=3.10.3 <3.11.4"
   flutter: ^0.1.2
   fuchsia: ^5.6.7
 ''',
@@ -804,7 +804,7 @@ environment:
           pubspec.sdkConstraints,
           containsPair(
             'dart',
-            SdkConstraint(VersionConstraint.parse('>=1.2.3 <2.3.4')),
+            SdkConstraint(VersionConstraint.parse('>=3.10.3 <3.11.4')),
           ),
         );
         expect(

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -812,8 +812,7 @@ environment:
           containsPair(
             'flutter',
             SdkConstraint(
-              VersionConstraint.parse('>=0.1.2'),
-              originalConstraint: VersionConstraint.parse('^0.1.2'),
+              VersionConstraint.parse('^0.1.2'),
             ),
           ),
         );

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -811,9 +811,7 @@ environment:
           pubspec.sdkConstraints,
           containsPair(
             'flutter',
-            SdkConstraint(
-              VersionConstraint.parse('^0.1.2'),
-            ),
+            SdkConstraint(VersionConstraint.parse('^0.1.2')),
           ),
         );
         expect(


### PR DESCRIPTION
Solves https://github.com/flutter/flutter/issues/95472 (at least partially)

By making this depend on language version we avoid a breaking change
