### PR TITLE
Add customizable `category` to pub `Command`

### DIFF
--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -22,8 +22,10 @@ export 'src/executable.dart'
 ///
 /// [isVerbose] should return `true` (after argument resolution) if the
 /// embedding top-level is in verbose mode.
-Command<int> pubCommand({required bool Function() isVerbose}) =>
-    PubEmbeddableCommand(isVerbose);
+Command<int> pubCommand({
+  required bool Function() isVerbose,
+  String category = '',
+}) => PubEmbeddableCommand(isVerbose, category);
 
 /// Makes sure that [dir]/pubspec.yaml is resolved such that pubspec.lock and
 /// .dart_tool/package_config.json are up-to-date and all packages are

--- a/lib/src/pub_embeddable_command.dart
+++ b/lib/src/pub_embeddable_command.dart
@@ -45,7 +45,10 @@ class PubEmbeddableCommand extends PubCommand implements PubTopLevel {
 
   final bool Function() isVerbose;
 
-  PubEmbeddableCommand(this.isVerbose) : super() {
+  @override
+  final String category;
+
+  PubEmbeddableCommand(this.isVerbose, this.category) : super() {
     // This flag was never honored in the embedding but since it was accepted we
     // leave it as a hidden flag to avoid breaking clients that pass it.
     argParser.addFlag('trace', hide: true);


### PR DESCRIPTION
We'd like to add categories to the commands in `dartdev`:

```
$ dart --help
A command-line utility for Dart development.

Usage: dart <command|dart-file> [arguments]

Global options:
-v, --verbose               Show additional command output.
    --version               Print the Dart SDK version.
    --enable-analytics      Enable analytics.
    --disable-analytics     Disable analytics.
    --suppress-analytics    Disallow analytics for this `dart *` run without changing the analytics configuration.
-h, --help                  Print this usage information.

Available commands:

Dart SDK
  info       Show diagnostic information about the installed tooling.

Project
  analyze    Analyze Dart code in a directory.
  build      Build a Dart application including native assets.
  compile    Compile Dart to various formats.
  create     Create a new Dart project.
  doc        Generate API documentation for Dart projects.
  fix        Apply automated fixes to Dart source code.
  format     Idiomatically format Dart source code.
  pub        Work with packages.
  run        Run a Dart program.
  test       Run tests for a project.

Tools
  devtools   Open DevTools (optionally connecting to an existing application).

Run "dart help <command>" for more information about a command.
See https://dart.dev/tools/dart-tool for detailed documentation.
```

For that we need to be able to customize the `categories` getter.

Workaround without this PR is a src/ import with the following:

```dart
class PubEmbeddableCommand2 extends PubEmbeddableCommand {
  PubEmbeddableCommand2(super.isVerbose);

  @override
  String get category => 'Project';
}
```

I didn't find a `lib/src/pub_embeddable_command_test.dart`, where and how is this tested?