### PR TITLE
Initial support for experiments

### DIFF
--- a/lib/src/command/global_activate.dart
+++ b/lib/src/command/global_activate.dart
@@ -52,6 +52,8 @@ class GlobalActivateCommand extends PubCommand {
       hide: true,
     );
 
+    argParser.addMultiOption('experiments', help: 'Experiments(s) to enable.');
+
     argParser.addFlag(
       'no-executables',
       negatable: false,
@@ -131,6 +133,7 @@ class GlobalActivateCommand extends PubCommand {
           overwriteBinStubs: overwrite,
           path: argResults.option('git-path'),
           ref: argResults.option('git-ref'),
+          allowedExperiments: argResults.multiOption('experiments'),
         );
 
       case 'hosted':
@@ -171,6 +174,7 @@ class GlobalActivateCommand extends PubCommand {
           ref.withConstraint(constraint),
           executables,
           overwriteBinStubs: overwrite,
+          allowedExperiments: argResults.multiOption('experiments'),
         );
 
       case 'path':

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -404,7 +404,9 @@ See $workspacesDocUrl for more information.''',
   /// package dir.
   ///
   /// Also marks the package active in `PUB_CACHE/active_roots/`.
-  Future<void> writePackageConfigFiles() async {
+  Future<void> writePackageConfigFiles({
+    required List<String> experiments,
+  }) async {
     ensureDir(p.dirname(packageConfigPath));
 
     writeTextFileIfDifferent(
@@ -416,6 +418,7 @@ See $workspacesDocUrl for more information.''',
                 .pubspec
                 .sdkConstraints[sdk.identifier]
                 ?.effectiveConstraint,
+        experiments: experiments,
       ),
     );
     writeTextFileIfDifferent(packageGraphPath, await _packageGraphFile(cache));
@@ -471,6 +474,7 @@ See $workspacesDocUrl for more information.''',
   Future<String> _packageConfigFile(
     SystemCache cache, {
     VersionConstraint? entrypointSdkConstraint,
+    required List<String> experiments,
   }) async {
     final entries = <PackageConfigEntry>[];
     if (lockFile.packages.isNotEmpty) {
@@ -515,6 +519,7 @@ See $workspacesDocUrl for more information.''',
       packages: entries,
       generator: 'pub',
       generatorVersion: sdk.version,
+      experiments: experiments,
       additionalProperties: {
         if (FlutterSdk().isAvailable) ...{
           'flutterRoot':
@@ -616,6 +621,7 @@ Try running `$topLevelProgram pub get` to create `$lockFilePath`.''');
       lockFile,
       newLockFile,
       result.availableVersions,
+      result.experiments,
       cache,
       dryRun: dryRun,
       enforceLockfile: enforceLockfile,
@@ -644,7 +650,7 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       /// have to reload and reparse all the pubspecs.
       _packageGraph = Future.value(PackageGraph.fromSolveResult(this, result));
 
-      await writePackageConfigFiles();
+      await writePackageConfigFiles(experiments: result.experiments);
 
       try {
         if (precompile) {

--- a/lib/src/experiment.dart
+++ b/lib/src/experiment.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// An experiment as described by an sdk_experiments file
+class Experiment {
+  final String name;
+
+  /// A description of the experiment
+  final String description;
+
+  /// Where you can read more about the experiment
+  final String docUrl;
+
+  Experiment(this.name, this.description, this.docUrl);
+}

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -87,6 +87,11 @@ class Package {
       ...package.pubspec.dependencyOverrides,
   };
 
+  /// A collection of the union of all experiments used in the workspace.
+  late final Set<String> allExperimentsInWorkspace = {
+    for (final package in transitiveWorkspace) ...package.pubspec.experiments,
+  };
+
   /// The immediate dependencies this package specifies in its pubspec.
   Map<String, PackageRange> get dependencies => pubspec.dependencies;
 

--- a/lib/src/package_config.dart
+++ b/lib/src/package_config.dart
@@ -38,11 +38,14 @@ class PackageConfig {
   /// `.dart_tool/package_config.json` file.
   Map<String, dynamic> additionalProperties;
 
+  List<String> experiments;
+
   PackageConfig({
     required this.configVersion,
     required this.packages,
     this.generator,
     this.generatorVersion,
+    required this.experiments,
     Map<String, dynamic>? additionalProperties,
   }) : additionalProperties = additionalProperties ?? {} {
     final names = <String>{};
@@ -100,6 +103,21 @@ class PackageConfig {
       );
     }
 
+    // Read the 'experiments' property
+    final experiments = root['experiments'] ?? <String>[];
+    if (experiments is! List) {
+      throw const FormatException(
+        '"experiments" in package_config.json must be a list, if given',
+      );
+    }
+    for (final experiment in experiments) {
+      if (experiment is! String) {
+        throw const FormatException(
+          '"experiments" in package_config.json must all be strings',
+        );
+      }
+    }
+
     // Read the 'generatorVersion' property
     Version? generatorVersion;
     final generatorVersionRaw = root['generatorVersion'];
@@ -122,6 +140,7 @@ class PackageConfig {
       packages: packages,
       generator: generator,
       generatorVersion: generatorVersion,
+      experiments: experiments.cast<String>(),
       additionalProperties: Map.fromEntries(
         root.entries.where(
           (e) =>
@@ -131,6 +150,7 @@ class PackageConfig {
                 'generated',
                 'generator',
                 'generatorVersion',
+                'experiments',
               }.contains(e.key),
         ),
       ),
@@ -141,6 +161,7 @@ class PackageConfig {
   Map<String, Object?> toJson() => {
     'configVersion': configVersion,
     'packages': packages.map((p) => p.toJson()).toList(),
+    'experiments': experiments,
     'generator': generator,
     'generatorVersion': generatorVersion?.toString(),
   }..addAll(additionalProperties);

--- a/lib/src/sdk/dart.dart
+++ b/lib/src/sdk/dart.dart
@@ -40,6 +40,9 @@ class DartSdk extends Sdk {
     return aboveExecutable;
   }();
 
+  @override
+  String get experimentsPath => p.join(_rootDirectory, '.sdk_experiments.json');
+
   /// The loaded `sdk_packages.yaml` file if present.
   static final SdkPackageConfig? _sdkPackages = () {
     final path = p.join(_rootDirectory, 'sdk_packages.yaml');

--- a/lib/src/sdk/flutter.dart
+++ b/lib/src/sdk/flutter.dart
@@ -116,4 +116,7 @@ class FlutterSdk extends Sdk {
 
     return null;
   }
+
+  @override
+  String get experimentsPath => p.join(rootDirectory!, '.sdk_experiments.json');
 }

--- a/lib/src/sdk/fuchsia.dart
+++ b/lib/src/sdk/fuchsia.dart
@@ -23,6 +23,10 @@ class FuchsiaSdk extends Sdk {
       Platform.environment['FUCHSIA_DART_SDK_ROOT'];
 
   @override
+  String get experimentsPath =>
+      p.join(_rootDirectory!, '.sdk_experiments.json');
+
+  @override
   String get installMessage =>
       'Please set the FUCHSIA_DART_SDK_ROOT environment variable to point to '
       'the root of the Fuchsia SDK for Dart.';

--- a/lib/src/solver/incompatibility_cause.dart
+++ b/lib/src/solver/incompatibility_cause.dart
@@ -68,6 +68,52 @@ class NoVersionsIncompatibilityCause extends IncompatibilityCause {
   const NoVersionsIncompatibilityCause._();
 }
 
+/// The incompatibility indicates that the uses an experiment not allowed by the
+/// roots.
+class ExperimentIncompatibilityCause extends IncompatibilityCause {
+  final String experiment;
+  final Iterable<String> allowedExperiments;
+
+  ExperimentIncompatibilityCause(this.experiment, this.allowedExperiments);
+
+  @override
+  String? get hint {
+    if (!availableExperiments.containsKey(experiment)) {
+      final availableExperimentsDescription =
+          availableExperiments.isEmpty
+              ? '''There are no available experiments.'''
+              : '''
+Available experiments are:
+${availableExperiments.values.map((experiment) => '* ${experiment.name}: ${experiment.description}, ${experiment.docUrl}').join('\n')}''';
+      return '''
+$experiment is not a known experiment.
+
+$availableExperimentsDescription
+
+Read more about experiments at https://dart.dev/go/experiments.''';
+    } else {
+      final enabledExperimentsDescription =
+          allowedExperiments.isEmpty
+              ? 'Currently no experiments are enabled.'
+              : 'Currently the following experiments are enabled: '
+                  '${allowedExperiments.join(', ')}';
+      return '''
+The experiment `$experiment` has not been enabled.
+
+$enabledExperimentsDescription
+
+To enable it add to your pubspec.yaml:
+
+```
+experiments:
+  - $experiment
+```
+
+Read more about experiments at https://dart.dev/go/experiments.''';
+    }
+  }
+}
+
 /// The incompatibility indicates that the package has an unknown source.
 class UnknownSourceIncompatibilityCause extends IncompatibilityCause {
   factory UnknownSourceIncompatibilityCause() =>

--- a/lib/src/solver/report.dart
+++ b/lib/src/solver/report.dart
@@ -11,6 +11,7 @@ import '../lock_file.dart';
 import '../log.dart' as log;
 import '../package_name.dart';
 import '../pubspec.dart';
+import '../sdk.dart';
 import '../source/hosted.dart';
 import '../source/root.dart';
 import '../system_cache.dart';
@@ -50,6 +51,8 @@ class SolveReport {
   static const maxAdvisoryFootnotesPerLine = 5;
   final advisoryDisplayHandles = <String>[];
 
+  final List<String> experiments;
+
   SolveReport(
     this._type,
     this._location,
@@ -58,6 +61,7 @@ class SolveReport {
     this._previousLockFile,
     this._newLockFile,
     this._availableVersions,
+    this.experiments,
     this._cache, {
     required bool dryRun,
     required bool enforceLockfile,
@@ -76,6 +80,7 @@ class SolveReport {
     final changes = await _reportChanges();
     _checkContentHashesMatchOldLockfile();
     if (summary) await summarize(changes);
+    reportExperiments();
   }
 
   void _checkContentHashesMatchOldLockfile() {
@@ -305,6 +310,19 @@ $contentHashesDocumentationUrl
       ) {
         message('  [^$footnote]: ${advisoryDisplayHandles[footnote]}');
       }
+    }
+  }
+
+  void reportExperiments() {
+    if (experiments.isNotEmpty) {
+      message('The following experiments have been enabled:');
+
+      for (final experimentName in experiments) {
+        final experiment = availableExperiments[experimentName]!;
+        message('* ${experiment.name} (see ${experiment.docUrl})');
+      }
+
+      message('See (https://dart.dev/go/experiments for more information).');
     }
   }
 

--- a/lib/src/solver/result.dart
+++ b/lib/src/solver/result.dart
@@ -48,6 +48,9 @@ class SolveResult {
   /// The wall clock time the resolution took.
   final Duration resolutionTime;
 
+  /// The experiments enabled for this solve.
+  List<String> get experiments => _root.allExperimentsInWorkspace.toList();
+
   /// Downloads all the cached packages selected by this version resolution.
   ///
   /// If some already cached package differs from what is provided by the server

--- a/lib/src/solver/version_solver.dart
+++ b/lib/src/solver/version_solver.dart
@@ -93,6 +93,8 @@ class VersionSolver {
 
   final _stopwatch = Stopwatch();
 
+  final Set<String> _allowedExperiments;
+
   VersionSolver(
     this._type,
     this._systemCache,
@@ -102,7 +104,8 @@ class VersionSolver {
     Map<String, Version> sdkOverrides = const {},
   }) : _sdkOverrides = sdkOverrides,
        _dependencyOverrides = _root.allOverridesInWorkspace,
-       _unlock = {...unlock};
+       _unlock = {...unlock},
+       _allowedExperiments = _root.allExperimentsInWorkspace;
 
   /// Prime the solver with [constraints].
   void addConstraints(Iterable<ConstraintAndCause> constraints) {
@@ -541,6 +544,7 @@ class VersionSolver {
           _systemCache,
           overriddenPackages: _overriddenPackages,
           sdkOverrides: _sdkOverrides,
+          allowedExperiments: _root.allExperimentsInWorkspace,
         );
       }
 
@@ -566,6 +570,7 @@ class VersionSolver {
         _getAllowedRetracted(ref.name),
         downgrade: _type == SolveType.downgrade,
         sdkOverrides: _sdkOverrides,
+        allowedExperiments: _allowedExperiments,
       );
     });
   }

--- a/lib/src/validator/pubspec_typo.dart
+++ b/lib/src/validator/pubspec_typo.dart
@@ -57,6 +57,7 @@ const _validPubspecKeys = [
   'name',
   'version',
   'description',
+  'experiments',
   'homepage',
   'repository',
   'issue_tracker',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -474,4 +474,4 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
+  dart: ">=3.8.0 <4.0.0"

--- a/test/descriptor/package_config.dart
+++ b/test/descriptor/package_config.dart
@@ -18,6 +18,7 @@ class PackageConfigFileDescriptor extends Descriptor {
   final String _pubCache;
   final String? _flutterRoot;
   final String? _flutterVersion;
+  final List<String> experiments;
 
   /// A map describing the packages in this `package_config.json` file.
   final List<PackageConfigEntry> _packages;
@@ -28,6 +29,7 @@ class PackageConfigFileDescriptor extends Descriptor {
       packages: _packages,
       generatorVersion: Version.parse(_generatorVersion),
       generator: 'pub',
+      experiments: experiments,
       additionalProperties: {
         'pubCache': p.toUri(_pubCache).toString(),
         if (_flutterRoot != null)
@@ -45,8 +47,9 @@ class PackageConfigFileDescriptor extends Descriptor {
     this._generatorVersion,
     this._pubCache,
     this._flutterRoot,
-    this._flutterVersion,
-  ) : super('.dart_tool/package_config.json');
+    this._flutterVersion, {
+    this.experiments = const [],
+  }) : super('.dart_tool/package_config.json');
 
   @override
   Future<void> create([String? parent]) async {

--- a/test/experiments_test.dart
+++ b/test/experiments_test.dart
@@ -1,0 +1,188 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:pub/src/exit_codes.dart';
+import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart';
+
+import 'descriptor.dart' as d;
+import 'test_pub.dart';
+
+Future<void> main() async {
+  test('allows experiments that are enabled in the root', () async {
+    final server = await servePackages();
+    await _setupFlutterRootWithExperiment();
+
+    server.serve(
+      'foo',
+      '1.0.0',
+      pubspec: {
+        'experiments': ['abc'],
+      },
+    );
+    await d
+        .appDir(
+          dependencies: {'foo': '^1.0.0'},
+          pubspec: {
+            'experiments': ['abc'],
+          },
+        )
+        .create();
+
+    await pubGet(
+      output: contains('''
+The following experiments have been enabled:
+* abc (see https://dart.dev/experiments/abc)
+'''),
+      environment: {'FLUTTER_ROOT': p.join(sandbox, 'flutter')},
+    );
+
+    final packageConfig =
+        json.decode(
+              File(
+                p.join(sandbox, appPath, '.dart_tool', 'package_config.json'),
+              ).readAsStringSync(),
+            )
+            as Map<String, Object?>;
+    expect(packageConfig['experiments'], ['abc']);
+  });
+
+  test('Finds the version with the right experiments enabled', () async {
+    final server = await servePackages();
+    await _setupFlutterRootWithExperiment();
+    server.serve(
+      'foo',
+      '1.0.0-dev',
+      pubspec: {
+        'experiments': ['abc'],
+      },
+    );
+    server.serve(
+      'foo',
+      '1.0.1-dev', // This version is newer, but uses a disabled experiment.
+      pubspec: {
+        'experiments': ['abcd'],
+      },
+    );
+    await d
+        .appDir(
+          dependencies: {'foo': '^1.0.0-dev'},
+          pubspec: {
+            'experiments': ['abc'],
+          },
+        )
+        .create();
+
+    await pubGet(
+      output: contains('+ foo 1.0.0-dev'),
+      environment: {'FLUTTER_ROOT': p.join(sandbox, 'flutter')},
+    );
+  });
+
+  test('disallows experiments that are not enabled in the root', () async {
+    final server = await servePackages();
+    await _setupFlutterRootWithExperiment();
+    server.serve(
+      'foo',
+      '1.1.0-dev',
+      pubspec: {
+        'experiments': ['abc'],
+      },
+    );
+    await d.appDir(dependencies: {'foo': '^1.0.0-dev'}).create();
+
+    await pubGet(
+      error: '''
+Because myapp depends on foo any which requires enabling the experiment `abc`, version solving failed.
+
+The experiment `abc` has not been enabled.
+
+Currently no experiments are enabled.
+
+To enable it add to your pubspec.yaml:
+
+```
+experiments:
+  - abc
+```
+
+Read more about experiments at https://dart.dev/go/experiments.''',
+      environment: {'FLUTTER_ROOT': p.join(sandbox, 'flutter')},
+    );
+  });
+
+  test('disallows experiments that are not enabled in the sdk', () async {
+    await servePackages();
+    await _setupFlutterRootWithExperiment();
+    await d
+        .appDir(
+          pubspec: {
+            'experiments': <String>['abcd'],
+          },
+        )
+        .create();
+
+    await pubGet(
+      error: contains('''
+abcd is not a known experiment.
+
+Available experiments are:
+* abc: New alphabetical feature, https://dart.dev/experiments/abc
+
+Read more about experiments at https://dart.dev/go/experiments.'''),
+      environment: {'FLUTTER_ROOT': p.join(sandbox, 'flutter')},
+      exitCode: DATA,
+    );
+  });
+
+  test('Can global activate a package using experiments', () async {
+    final server = await servePackages();
+    server.serve(
+      'foo',
+      '1.0.0',
+      pubspec: {
+        'experiments': ['abc'],
+      },
+    );
+    await _setupFlutterRootWithExperiment();
+    await d
+        .appDir(
+          pubspec: {
+            'experiments': <String>['abcd'],
+          },
+        )
+        .create();
+
+    await runPub(
+      args: ['global', 'activate', 'foo', '--experiments', 'abc'],
+      output: contains('''
+The following experiments have been enabled:
+* abc (see https://dart.dev/experiments/abc)
+'''),
+      environment: {'FLUTTER_ROOT': p.join(sandbox, 'flutter')},
+    );
+  });
+}
+
+Future<void> _setupFlutterRootWithExperiment() async {
+  await d.dir('flutter', [
+    d.flutterVersion('1.2.3'),
+    d.file(
+      '.sdk_experiments.json',
+      jsonEncode({
+        'experiments': [
+          {
+            'name': 'abc',
+            'description': 'New alphabetical feature',
+            'docUrl': 'https://dart.dev/experiments/abc',
+          },
+        ],
+      }),
+    ),
+  ]).create();
+}

--- a/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
+++ b/test/testdata/goldens/embedding/embedding_test/logfile is written with --verbose and on unexpected exceptions.txt
@@ -122,6 +122,7 @@ MSG : Logs written to $SANDBOX/cache/log/pub_log.txt.
 [E]    |   "languageVersion": "3.0"
 [E]    |   }
 [E]    |   ],
+[E]    |   "experiments": [],
 [E]    |   "generator": "pub",
 [E]    |   "generatorVersion": "3.1.2+3",
 [E]    |   "pubCache": "file://$SANDBOX/cache"
@@ -311,6 +312,7 @@ FINE: Contents:
    |   "languageVersion": "3.0"
    |   }
    |   ],
+   |   "experiments": [],
    |   "generator": "pub",
    |   "generatorVersion": "3.1.2+3",
    |   "pubCache": "file://$SANDBOX/cache"

--- a/test/testdata/goldens/help_test/pub global activate --help.txt
+++ b/test/testdata/goldens/help_test/pub global activate --help.txt
@@ -10,6 +10,7 @@ Usage: pub global activate <package> [version-constraint]
                         [git, hosted (default), path]
     --git-path          Path of git package in repository
     --git-ref           Git branch or commit to be retrieved
+    --experiments       Experiments(s) to enable.
     --no-executables    Do not put executables on PATH.
 -x, --executable        Executable(s) to place on PATH.
     --overwrite         Overwrite executables from other packages with the same name.


### PR DESCRIPTION
An sdk can describe currently available experiments in a .sdk_experiments file
A package can declare use of an experiment in pubspec.yaml
A resolution cannot include packages that use experiments not declared in the root pubspec
Experiments get written to .dart_tool/package_config.json for the sdk tools (vm, flutter_tool etc) to pick up.

Internal design doc: [go/align-dart-flutter-experiments](http://goto.google.com/align-dart-flutter-experiments)
