### PR TITLE
Fix detection of root packages in PackageGraph.transitiveDependencies

### DIFF
--- a/lib/src/command/deps.dart
+++ b/lib/src/command/deps.dart
@@ -420,7 +420,7 @@ class DepsCommand extends PubCommand {
         .expand(
           (p) => graph.transitiveDependencies(
             p,
-            followDevDependenciesFromRoot: false,
+            followDevDependenciesFromRoots: false,
           ),
         )
         .map((package) => package.name)

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -124,7 +124,7 @@ class UpgradeCommand extends PubCommand {
             (package) => graph
                 .transitiveDependencies(
                   package,
-                  followDevDependenciesFromRoot: true,
+                  followDevDependenciesFromRoots: true,
                 )
                 .map((p) => p.name),
           )

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -212,7 +212,7 @@ Follow progress in https://github.com/dart-lang/sdk/issues/60889.
     final activatedPackage = entrypoint.workPackage;
     final name = activatedPackage.name;
     for (final package in (await entrypoint.packageGraph)
-        .transitiveDependencies(name, followDevDependenciesFromRoot: false)) {
+        .transitiveDependencies(name, followDevDependenciesFromRoots: false)) {
       _testForHooks(package, name);
     }
     _describeActive(name, cache);

--- a/lib/src/package_graph.dart
+++ b/lib/src/package_graph.dart
@@ -46,12 +46,11 @@ class PackageGraph {
 
   /// Returns all transitive dependencies of [package].
   ///
-  /// For the entrypoint this returns all packages in [packages], which includes
-  /// dev and override. For any other package, it ignores dev and override
-  /// dependencies.
+  /// For the root packages, this will explore the dev_dependencies if
+  /// [followDevDependenciesFromRoots] is true.
   Set<Package> transitiveDependencies(
     String package, {
-    required bool followDevDependenciesFromRoot,
+    required bool followDevDependenciesFromRoots,
   }) {
     final result = <Package>{};
 
@@ -63,7 +62,10 @@ class PackageGraph {
       final currentPackage = packages[current]!;
       result.add(currentPackage);
       stack.addAll(currentPackage.dependencies.keys);
-      if (followDevDependenciesFromRoot && current == package) {
+      if (followDevDependenciesFromRoots &&
+          entrypoint.workspaceRoot.transitiveWorkspace.any(
+            (p) => p.name == current,
+          )) {
         stack.addAll(currentPackage.devDependencies.keys);
       }
     }
@@ -89,7 +91,7 @@ class PackageGraph {
 
     return transitiveDependencies(
       package,
-      followDevDependenciesFromRoot: true,
+      followDevDependenciesFromRoots: true,
     ).any((dep) => !_isPackageFromImmutableSource(dep.name));
   }
 }

--- a/test/package_graph_test.dart
+++ b/test/package_graph_test.dart
@@ -1,0 +1,94 @@
+// Copyright (c) 2025, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:path/path.dart' as p;
+import 'package:pub/src/entrypoint.dart';
+import 'package:pub/src/system_cache.dart';
+import 'package:test/test.dart';
+
+import 'descriptor.dart' as d;
+import 'test_pub.dart';
+
+void main() {
+  test('transitiveDependencies', () async {
+    final server = await servePackages();
+    server.serve(
+      'foo',
+      '1.0.0',
+      deps: {
+        'transitive': {'hosted': globalServer.url},
+      },
+      pubspec: {
+        'dev_dependencies': {
+          'transitive_dev_dep': {'hosted': globalServer.url},
+        }, // This should **not** be included.
+      },
+    );
+    server.serve(
+      'dev_dep',
+      '1.0.0',
+      deps: {
+        'dev_dep_transitive': {'hosted': globalServer.url},
+      },
+      pubspec: {
+        'dev_dependencies': {
+          'transitive_dev_dep': {
+            'hosted': globalServer.url,
+          }, // This should **not** be included.
+        },
+      },
+    );
+    server.serve('dev_dep_transitive', '1.0.0');
+    server.serve('transitive', '1.0.0');
+    await d
+        .appDir(
+          dependencies: {
+            'foo': {'hosted': globalServer.url},
+          },
+          pubspec: {
+            'dev_dependencies': {
+              'dev_dep': {'hosted': globalServer.url},
+            },
+          },
+        )
+        .create();
+    await pubGet();
+    final entrypoint = Entrypoint(
+      p.join(d.sandbox, appPath),
+      SystemCache(rootDir: p.join(d.sandbox, cachePath)),
+    );
+    final graph = await entrypoint.packageGraph;
+
+    expect(
+      graph
+          .transitiveDependencies('foo', followDevDependenciesFromRoots: true)
+          .map((p) => p.name),
+      {'foo', 'transitive'},
+    );
+
+    expect(
+      graph
+          .transitiveDependencies('foo', followDevDependenciesFromRoots: false)
+          .map((p) => p.name),
+      {'foo', 'transitive'},
+    );
+
+    expect(
+      graph
+          .transitiveDependencies('myapp', followDevDependenciesFromRoots: true)
+          .map((p) => p.name),
+      {'myapp', 'foo', 'dev_dep', 'dev_dep_transitive', 'transitive'},
+    );
+
+    expect(
+      graph
+          .transitiveDependencies(
+            'myapp',
+            followDevDependenciesFromRoots: false,
+          )
+          .map((p) => p.name),
+      {'myapp', 'foo', 'transitive'},
+    );
+  });
+}


### PR DESCRIPTION
The current behavior is broken. It looks at the wrong package, and does not consider the entire workspace.