### PR TITLE
Introduce `getPackageNameFromGitRepo` in package API

### DIFF
--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -78,8 +78,8 @@ class ResolutionFailedException implements Exception {
 /// [url] points to the git repository. If it is a relative url, it is resolved
 /// as a file url relative to the path [relativeTo].
 ///
-/// [ref] is the commit-hash where the package should be looked up when fetching
-/// the name. If omitted, 'HEAD' is used.
+/// [ref] is the commit, tag, or branch name where the package should be looked
+/// up when fetching the name. If omitted, 'HEAD' is used.
 ///
 /// [tagPattern] is a string containing `'{{version}}'` as a substring, the
 /// latest tag matching the pattern will be used for fetching the name.

--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -74,6 +74,16 @@ class ResolutionFailedException implements Exception {
 ///
 /// Will download the repo to the system cache under the assumption that the
 /// package will be downloaded afterwards.
+///
+/// [url] points to the git repository. If it is a relative url it is resolved as a file url relative to the path [relativeTo].
+///
+/// [ref] is the commit-ish where the package should be looked up when fetching the name. If omitted 'HEAD' is used.
+///
+/// [tagPattern] is a string containing `'{{version}}'` as a substring, the latest tag matching the pattern will be used for fetching the name.
+///
+/// Only one of [ref] and [tagPattern] can be used.
+///
+/// If [isOffline] only the already cached versions of the repo is used.
 Future<String> getPackageNameFromGitRepo(
   String url, {
   String? ref,

--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -8,6 +8,7 @@ import 'src/entrypoint.dart';
 import 'src/exceptions.dart';
 import 'src/http.dart';
 import 'src/pub_embeddable_command.dart';
+import 'src/source/git.dart';
 import 'src/system_cache.dart';
 
 export 'src/executable.dart'
@@ -66,4 +67,27 @@ Future<void> ensurePubspecResolved(
 class ResolutionFailedException implements Exception {
   String message;
   ResolutionFailedException._(this.message);
+}
+
+/// Given a Git repo that contains a pub package, gets the name of the pub
+/// package.
+///
+/// Will download the repo to the system cache under the assumption that the
+/// package will be downloaded afterwards.
+Future<String> getPackageNameFromGitRepo(
+  String url, {
+  String? ref,
+  String? path,
+  String? tagPattern,
+  String? relativeTo,
+  bool isOffline = false,
+}) async {
+  return await GitSource.instance.getPackageNameFromRepo(
+    url,
+    ref,
+    path,
+    SystemCache(isOffline: isOffline),
+    relativeTo: relativeTo,
+    tagPattern: tagPattern,
+  );
 }

--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -75,11 +75,14 @@ class ResolutionFailedException implements Exception {
 /// Will download the repo to the system cache under the assumption that the
 /// package will be downloaded afterwards.
 ///
-/// [url] points to the git repository. If it is a relative url it is resolved as a file url relative to the path [relativeTo].
+/// [url] points to the git repository. If it is a relative url it is resolved
+/// as a file url relative to the path [relativeTo].
 ///
-/// [ref] is the commit-ish where the package should be looked up when fetching the name. If omitted 'HEAD' is used.
+/// [ref] is the commit-ish where the package should be looked up when fetching
+/// the name. If omitted 'HEAD' is used.
 ///
-/// [tagPattern] is a string containing `'{{version}}'` as a substring, the latest tag matching the pattern will be used for fetching the name.
+/// [tagPattern] is a string containing `'{{version}}'` as a substring, the
+/// latest tag matching the pattern will be used for fetching the name.
 ///
 /// Only one of [ref] and [tagPattern] can be used.
 ///

--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -75,18 +75,18 @@ class ResolutionFailedException implements Exception {
 /// Will download the repo to the system cache under the assumption that the
 /// package will be downloaded afterwards.
 ///
-/// [url] points to the git repository. If it is a relative url it is resolved
+/// [url] points to the git repository. If it is a relative url, it is resolved
 /// as a file url relative to the path [relativeTo].
 ///
-/// [ref] is the commit-ish where the package should be looked up when fetching
-/// the name. If omitted 'HEAD' is used.
+/// [ref] is the commit-hash where the package should be looked up when fetching
+/// the name. If omitted, 'HEAD' is used.
 ///
 /// [tagPattern] is a string containing `'{{version}}'` as a substring, the
 /// latest tag matching the pattern will be used for fetching the name.
 ///
 /// Only one of [ref] and [tagPattern] can be used.
 ///
-/// If [isOffline] only the already cached versions of the repo is used.
+/// If [isOffline], only the already cached versions of the repo is used.
 Future<String> getPackageNameFromGitRepo(
   String url, {
   String? ref,

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -290,7 +290,7 @@ class GitSource extends CachedSource {
     String? ref,
     String? path,
     SystemCache cache, {
-    required String relativeTo,
+    required String? relativeTo,
     required String? tagPattern,
   }) async {
     assert(


### PR DESCRIPTION
For https://github.com/dart-lang/sdk/issues/60889, `dartdev` needs a way to get the package name from a git repo.

The package name is used for the following steps in `dart install` and friends:

1. Creating a temporary pubspec to fetch all dependencies.
2. Finding the package path on disk via the package_config.json.
3. Finding the resolved git ref in the pubspec lock.
4. Selecting a directory to install in.
5. Displaying the name in dart installed.

@sigurdm and I discussed that step 1 should be possible without knowing the package name if we massage the `pubspec.yaml` format. However, that makes step 2 and 3 impossible, because the package name is the unique key after resolution to lookup information in pub's formats.

Rather than duplicating logic in dartdev to check out a git repo, we'd pub's API and check out the git repo in the pub cache and reuse that cache.

This PR makes that API available in the library exports.

For reference the code that does a `src/` import without this PR:

```dart
import 'package:pub/src/source/git.dart';
import 'package:pub/src/system_cache.dart';

// ...

        return await GitSource.instance.getPackageNameFromRepo(
          parsedArgs.source,
          parsedArgs.gitRef,
          parsedArgs.gitPath,
          SystemCache(),
          relativeTo: Directory.current.path,
          tagPattern: null,
        );
```

https://dart-review.googlesource.com/c/sdk/+/441581/15/pkg/dartdev/lib/src/commands/install.dart

Open question:

* Can a git url be relative, do we need the `relativeTo` parameter?
* What do we document on the parameters? The internal function had no dartdoc comments on the parameters.