### PR TITLE
Only push single tag

### DIFF
--- a/tool/create_version_tags_from_sdk.dart
+++ b/tool/create_version_tags_from_sdk.dart
@@ -168,6 +168,7 @@ Usage: create_version_tags_from_sdk [--create] [--push] [--sdk-dir <path>]
             'origin',
             // Don't run any hooks before pushing.
             '--no-verify',
+            'tag',
             'SDK-$sdkTag',
           ], workingDirectory: Directory.current.path);
           if (pushResult.exitCode != 0) {


### PR DESCRIPTION
https://git-scm.com/book/en/v2/Git-Basics-Tagging#:~:text=0700%0A%0A%20%20%20%20Update%20rakefile%0A...-,Sharing%20Tags,-By%20default%2C%20the

Says the invocation is `git push origin <tagname>` but in practice that seems to push all tags.
`git push origin tag <tagname>` seems to work. Inspired by https://stackoverflow.com/a/5195913/4809566