### PR TITLE
Check out all of pub when adding sdk tags

### DIFF
--- a/.github/workflows/tag_from_sdk.yml
+++ b/.github/workflows/tag_from_sdk.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      with:
+        fetch-depth: 0 # Check out everything to be able to tag.
     - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
       with:
         sdk: stable


### PR DESCRIPTION
https://github.com/dart-lang/pub/actions/runs/17660660465/job/50193260481 indicates that the script cannot tag the local checkout.

actions/checkout makes a shallow checkout by default.