### PR TITLE
Workspaces glob support

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -122,7 +122,7 @@ packages:
     source: hosted
     version: "4.0.0"
   glob:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: glob
       sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
@@ -474,4 +474,4 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   convert: ^3.1.2
   crypto: ^3.0.6
   frontend_server_client: ^4.0.0
+  glob: ^2.1.3
   graphs: ^2.3.2
   http: ^1.5.0
   http_multi_server: ^3.2.2


### PR DESCRIPTION
Attempt to fix #4391 

This is very slightly backwards incompatible. If users had directories containing `{` or `*`.

Not sure if it is worth the effort to handle the difference, but one way would be to base it on language version