### PR TITLE
Give sdk tagging action write permissions

### DIFF
--- a/.github/workflows/tag_from_sdk.yml
+++ b/.github/workflows/tag_from_sdk.yml
@@ -3,6 +3,7 @@ on:
   schedule:
     # Run every day at 00:00
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   tag_from_sdk:


### PR DESCRIPTION
Seems to be missing according to https://github.com/dart-lang/pub/actions/runs/18266389503/job/52001322342

Also allow manual triggering of the action