### PR TITLE
feat: `pub deps -s mermaid`

### DIFF
--- a/test/deps_test.dart
+++ b/test/deps_test.dart
@@ -142,6 +142,65 @@ void main() {
           ''',
       );
     });
+
+    test('in mermaid form', () async {
+      await pubGet();
+      await runPub(
+        args: ['deps', '-s', 'mermaid'],
+        output: '''
+          %% Dart SDK 3.1.2+3
+          graph LR
+            %% Root
+            myapp["myapp 0.0.0"]
+
+            %% Direct dependencies
+            from_path["from_path 1.2.3"]
+            normal["normal 1.2.3"]
+            overridden["overridden 2.0.0"]
+
+            myapp --> from_path
+            myapp --> normal
+            myapp --> overridden
+
+            %% Dev dependencies
+            unittest["unittest 1.2.3"]
+          
+            myapp -. dev .-> unittest
+
+            %% Dependency overrides
+            override_only["override_only 1.2.3"]
+          
+            myapp -. override .-> overridden
+            myapp -. override .-> override_only
+
+            %% Transitive dependencies
+            circular_a["circular_a 1.2.3"]
+            circular_b["circular_b 1.2.3"]
+            dev_only["dev_only 1.2.3"]
+            other["other 1.0.0"]
+            shared["shared 1.2.3"]
+            transitive["transitive 1.2.3"]
+
+            %% Normal dependency chain
+            normal --> circular_a
+            normal --> transitive
+
+            %% Dev dependency chain
+            unittest --> dev_only
+            unittest --> shared
+          
+            %% Circular dependencies
+            circular_a --> circular_b
+            circular_b --> circular_a
+          
+            %% Transitive chains
+            transitive --> shared
+            shared --> other
+            other --> myapp
+          ''',
+      );
+    });
+
     test('in json form', () async {
       await pubGet();
       await runPub(
@@ -407,6 +466,54 @@ void main() {
           ├── overridden 2.0.0
           └── override_only 1.2.3
           ''',
+      );
+    });
+
+    test('in mermaid form', () async {
+      await pubGet();
+      await runPub(
+        args: ['deps', '-s', 'mermaid', '--no-dev'],
+        output: '''
+          %% Dart SDK 3.1.2+3
+          graph LR
+            %% Root
+            myapp["myapp 0.0.0"]
+
+            %% Direct dependencies
+            from_path["from_path 1.2.3"]
+            normal["normal 1.2.3"]
+            overridden["overridden 2.0.0"]
+
+            myapp --> from_path
+            myapp --> normal
+            myapp --> overridden
+
+            %% Dependency overrides
+            override_only["override_only 1.2.3"]
+
+            myapp -. override .-> overridden
+            myapp -. override .-> override_only
+
+            %% Transitive dependencies
+            circular_a["circular_a 1.2.3"]
+            circular_b["circular_b 1.2.3"]
+            other["other 1.0.0"]
+            shared["shared 1.2.3"]
+            transitive["transitive 1.2.3"]
+
+            %% Transitive chains from direct deps
+            normal --> circular_a
+            normal --> transitive
+
+            %% Circular dependencies
+            circular_a --> circular_b
+            circular_b --> circular_a
+
+            %% Transitive dependency chains
+            transitive --> shared
+            shared --> other
+            other --> myapp
+        ''',
       );
     });
   });

--- a/test/testdata/goldens/help_test/pub deps --help.txt
+++ b/test/testdata/goldens/help_test/pub deps --help.txt
@@ -7,7 +7,7 @@ Print package dependencies.
 Usage: pub deps [arguments...]
 -h, --help               Print this usage information.
 -s, --style              How output should be displayed.
-                         [compact, tree (default), list]
+                         [compact, tree (default), list, mermaid]
     --[no-]dev           Whether to include dev dependencies.
                          (defaults to on)
     --executables        List all available executables.


### PR DESCRIPTION
#4732 

mermaid version of deps command
`pub deps -s mermaid`

below are the expected outputs from deps_test.dart

1. `deps -s mermaid`
```mermaid
          %% Dart SDK 3.1.2+3
          graph LR
            %% Root
            myapp["myapp 0.0.0"]

            %% Direct dependencies
            from_path["from_path 1.2.3"]
            normal["normal 1.2.3"]
            overridden["overridden 2.0.0"]

            myapp --> from_path
            myapp --> normal
            myapp --> overridden

            %% Dev dependencies
            unittest["unittest 1.2.3"]
          
            myapp -. dev .-> unittest

            %% Dependency overrides
            override_only["override_only 1.2.3"]
          
            myapp -. override .-> overridden
            myapp -. override .-> override_only

            %% Transitive dependencies
            circular_a["circular_a 1.2.3"]
            circular_b["circular_b 1.2.3"]
            dev_only["dev_only 1.2.3"]
            other["other 1.0.0"]
            shared["shared 1.2.3"]
            transitive["transitive 1.2.3"]

            %% Normal dependency chain
            normal --> circular_a
            normal --> transitive

            %% Dev dependency chain
            unittest --> dev_only
            unittest --> shared
          
            %% Circular dependencies
            circular_a --> circular_b
            circular_b --> circular_a
          
            %% Transitive chains
            transitive --> shared
            shared --> other
            other --> myapp
```

3. `deps -s mermaid --no-dev`
```mermaid
          %% Dart SDK 3.1.2+3
          graph LR
            %% Root
            myapp["myapp 0.0.0"]

            %% Direct dependencies
            from_path["from_path 1.2.3"]
            normal["normal 1.2.3"]
            overridden["overridden 2.0.0"]

            myapp --> from_path
            myapp --> normal
            myapp --> overridden

            %% Dependency overrides
            override_only["override_only 1.2.3"]

            myapp -. override .-> overridden
            myapp -. override .-> override_only

            %% Transitive dependencies
            circular_a["circular_a 1.2.3"]
            circular_b["circular_b 1.2.3"]
            other["other 1.0.0"]
            shared["shared 1.2.3"]
            transitive["transitive 1.2.3"]

            %% Transitive chains from direct deps
            normal --> circular_a
            normal --> transitive

            %% Circular dependencies
            circular_a --> circular_b
            circular_b --> circular_a

            %% Transitive dependency chains
            transitive --> shared
            shared --> other
            other --> myapp
```



---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
