### PR TITLE
Pass LOCALAPPDATA to test pub process

### DIFF
--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -525,6 +525,7 @@ Future<PubProcess> startPub({
   final mergedEnvironment = {
     if (includeParentHomeAndPath) ...{
       'HOME': Platform.environment['HOME'] ?? '',
+      'LOCALAPPDATA': Platform.environment['LOCALAPPDATA'] ?? '',
       'PATH': Platform.environment['PATH'] ?? '',
     },
     // These seem to be needed for networking to work.


### PR DESCRIPTION
`dart analyze` started relying on this being present on windows.