### PR TITLE
Add test case for server that returns content-type: application/json

### DIFF
--- a/test/hosted/content_type_test.dart
+++ b/test/hosted/content_type_test.dart
@@ -10,7 +10,8 @@ import '../test_pub.dart';
 void main() {
   test('gets a package from a server that returns application/json', () async {
     final server = await servePackages();
-    server.serve('foo', '1.2.3', contentType: 'application/json');
+    server.contentType = 'application/json';
+    server.serve('foo', '1.2.3');
 
     await d.appDir(dependencies: {'foo': '1.2.3'}).create();
 
@@ -23,11 +24,8 @@ void main() {
     'gets a package from a server that returns application/json with charset',
     () async {
       final server = await servePackages();
-      server.serve(
-        'foo',
-        '1.2.3',
-        contentType: 'application/json; charset=utf-8',
-      );
+      server.contentType = 'application/json; charset=utf-8';
+      server.serve('foo', '1.2.3');
 
       await d.appDir(dependencies: {'foo': '1.2.3'}).create();
 
@@ -41,8 +39,9 @@ void main() {
     'gets multiple versions from a server that returns application/json',
     () async {
       final server = await servePackages();
-      server.serve('foo', '1.0.0', contentType: 'application/json');
-      server.serve('foo', '1.2.3', contentType: 'application/json');
+      server.contentType = 'application/json';
+      server.serve('foo', '1.0.0');
+      server.serve('foo', '1.2.3');
 
       await d.appDir(dependencies: {'foo': '1.2.3'}).create();
 
@@ -56,13 +55,9 @@ void main() {
     'gets a package with dependencies from a server returning application/json',
     () async {
       final server = await servePackages();
-      server.serve(
-        'foo',
-        '1.0.0',
-        deps: {'bar': '^1.0.0'},
-        contentType: 'application/json',
-      );
-      server.serve('bar', '1.0.0', contentType: 'application/json');
+      server.contentType = 'application/json';
+      server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
+      server.serve('bar', '1.0.0');
 
       await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
 

--- a/test/package_server.dart
+++ b/test/package_server.dart
@@ -44,6 +44,9 @@ class PackageServer {
   // Setting this to false will disable automatic calculation of checksums.
   bool serveChecksums = true;
 
+  /// The Content-Type header to use for API responses.
+  String contentType = 'application/vnd.pub.v2+json';
+
   PackageServer._(this._inner) {
     final outerZone = Zone.current;
     _inner.mount((request) {
@@ -119,10 +122,7 @@ class PackageServer {
           if (package.discontinuedReplacementText != null)
             'replacedBy': package.discontinuedReplacementText,
         }),
-        headers: {
-          HttpHeaders.contentTypeHeader:
-              package.contentType ?? 'application/vnd.pub.v2+json',
-        },
+        headers: {HttpHeaders.contentTypeHeader: server.contentType},
       );
     });
 
@@ -165,10 +165,7 @@ class PackageServer {
               },
           ],
         }),
-        headers: {
-          HttpHeaders.contentTypeHeader:
-              package.contentType ?? 'application/vnd.pub.v2+json',
-        },
+        headers: {HttpHeaders.contentTypeHeader: server.contentType},
       );
     });
 
@@ -275,11 +272,6 @@ class PackageServer {
   ///
   /// If [contents] is passed, it's used as the contents of the package. By
   /// default, a package just contains a dummy lib directory.
-  ///
-  /// If [contentType] is passed, it sets the Content-Type header for API
-  /// responses for this package. A null value does not modify any previously
-  /// configured content type (last non-null wins). Defaults to
-  /// 'application/vnd.pub.v2+json'.
   void serve(
     String name,
     String version, {
@@ -288,7 +280,6 @@ class PackageServer {
     List<d.Descriptor>? contents,
     String? sdk,
     Map<String, List<String>>? headers,
-    String? contentType,
   }) {
     final pubspecFields = <String, dynamic>{
       'name': name,
@@ -302,9 +293,6 @@ class PackageServer {
     contents = [d.file('pubspec.yaml', yaml(pubspecFields)), ...contents];
 
     final package = _packages.putIfAbsent(name, _ServedPackage.new);
-    if (contentType != null) {
-      package.contentType = contentType;
-    }
     package.versions[version] = _ServedPackageVersion(
       pubspecFields,
       headers: headers,
@@ -406,7 +394,6 @@ class _ServedPackage {
   String? discontinuedReplacementText;
   DateTime? advisoriesUpdated;
   final advisories = <String, _ServedAdvisory>{};
-  String? contentType;
 }
 
 /// A package that's intended to be served.


### PR DESCRIPTION
This change allows tests to simulate servers that return `Content-Type: application/json` instead of the default `application/vnd.pub.v2+json`.

## Changes
- Add field for `contentType` to `PackageServer`
- Add test cases for servers returning `application/json`

Fixes #3580