### PR TITLE
Replace pub run with dart run

### DIFF
--- a/lib/src/command/run.dart
+++ b/lib/src/command/run.dart
@@ -86,7 +86,7 @@ class RunCommand extends PubCommand {
         );
       }
     } else if (onlyIdentifierRegExp.hasMatch(executable)) {
-      // "pub run foo" means the same thing as "pub run foo:foo" as long as
+      // "dart run foo" means the same thing as "dart run foo:foo" as long as
       // "foo" is a valid Dart identifier (and thus package name).
       package = executable;
     }

--- a/lib/src/log.dart
+++ b/lib/src/log.dart
@@ -363,7 +363,7 @@ String limitLength(String input, int limit) {
 void dumpTranscriptToFile(String path, String command, Entrypoint? entrypoint) {
   final buffer = StringBuffer();
   buffer.writeln('''
-Information about the latest pub run.
+Information about the latest dart run.
 
 If you believe something is not working right, you can go to
 https://github.com/dart-lang/pub/issues/new to post a new issue and attach this file.

--- a/test/run/forwards_signal_posix_test.dart
+++ b/test/run/forwards_signal_posix_test.dart
@@ -5,7 +5,7 @@
 // Windows doesn't support sending signals.
 // TODO(sigurdm): Test this when vm-args are provided.
 // This test doesn't work when we subprocess instead of an isolate
-// in `pub run`. Now signals only work as expected when sent to the process
+// in `dart run`. Now signals only work as expected when sent to the process
 // group. And this seems hard to emulate in a test.
 @TestOn('!windows')
 library;

--- a/test/run/precompile_test.dart
+++ b/test/run/precompile_test.dart
@@ -35,7 +35,7 @@ void main() {
     await pubGet(args: ['--no-precompile']);
   }
 
-  test('`pub run` precompiles script', () async {
+  test('`dart run` precompiles script', () async {
     await setupForPubRunToPrecompile();
     final pub = await pubRun(args: ['test']);
     await pub.shouldExit(0);
@@ -44,7 +44,7 @@ void main() {
     expect(lines, contains('hello'));
   });
 
-  test("`pub run` doesn't write about precompilation "
+  test("`dart run` doesn't write about precompilation "
       'when a terminal is not attached', () async {
     await setupForPubRunToPrecompile();
 
@@ -56,7 +56,7 @@ void main() {
   });
 
   // Regression test of https://github.com/dart-lang/pub/issues/2483
-  test('`pub run` precompiles script with relative PUB_CACHE', () async {
+  test('`dart run` precompiles script with relative PUB_CACHE', () async {
     await d.dir(appPath, [
       d.appPubspec(dependencies: {'test': '1.0.0'}),
     ]).create();

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -298,9 +298,9 @@ Future<void> pubRemove({
 /// expected startup output.
 ///
 /// If [global] is `true`, this invokes "pub global run", otherwise it does
-/// "pub run".
+/// "dart run".
 ///
-/// Returns the `pub run` process.
+/// Returns the `dart run` process.
 Future<PubProcess> pubRun({
   bool global = false,
   required Iterable<String> args,

--- a/tool/test.dart
+++ b/tool/test.dart
@@ -8,7 +8,7 @@
 /// invocation requires the dart compiler to load all the sources. This script
 /// will create a `pub.XXX.dart.snapshot.dart2` which the tests can utilize.
 /// After creating the snapshot this script will forward arguments to
-/// `pub run test`, and ensure that the snapshot is deleted after tests have
+/// `dart run test`, and ensure that the snapshot is deleted after tests have
 /// been run.
 library;
 


### PR DESCRIPTION
Following up on https://github.com/dart-lang/pub/issues/4737, this PR replaces deprecated `pub run` commands with `dart run`.