### PR TITLE
Introduce platform-agnostic gzipDecoder abstraction

### DIFF
--- a/lib/src/gzip/gzip.dart
+++ b/lib/src/gzip/gzip.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'gzip_stub.dart'
+    if (dart.library.io) 'gzip_io.dart'
+    if (dart.library.js_util) 'gzip_js.dart'
+    as impl;
+
+/// A [Converter] that decompresses gzip-compressed data.
+Converter<List<int>, List<int>> get gzipDecoder => impl.gzipDecoder;

--- a/lib/src/gzip/gzip_io.dart
+++ b/lib/src/gzip/gzip_io.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+/// Native implementation of gzipDecoder using `dart:io`.
+Converter<List<int>, List<int>> get gzipDecoder => gzip.decoder;

--- a/lib/src/gzip/gzip_js.dart
+++ b/lib/src/gzip/gzip_js.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:web/web.dart' as web;
+
+/// Web implementation of gzipDecoder using the browser's `DecompressionStream`.
+Converter<List<int>, List<int>> get gzipDecoder => const BrowserGZipDecoder();
+
+/// A [Converter] that decompresses gzip-compressed data using the browser's
+/// `DecompressionStream` API.
+class BrowserGZipDecoder extends Converter<List<int>, List<int>> {
+  const BrowserGZipDecoder();
+
+  @override
+  List<int> convert(List<int> input) {
+    // The browser's DecompressionStream API is asynchronous, so we cannot
+    // implement this synchronously.
+    throw UnsupportedError(
+      'Synchronous gzip decoding is not supported on the web.',
+    );
+  }
+
+  @override
+  Stream<List<int>> bind(Stream<List<int>> stream) {
+    final controller = StreamController<List<int>>();
+    unawaited(_pipe(stream, controller));
+    return controller.stream;
+  }
+
+  Future<void> _pipe(
+    Stream<List<int>> stream,
+    StreamController<List<int>> controller,
+  ) async {
+    try {
+      final decompressionStream = web.DecompressionStream('gzip');
+      final writer = decompressionStream.writable.getWriter();
+      final reader =
+          decompressionStream.readable.getReader()
+              as web.ReadableStreamDefaultReader;
+
+      final readFuture = () async {
+        try {
+          while (true) {
+            final result = await reader.read().toDart;
+            if (result.done) break;
+            final value = result.value as JSUint8Array;
+            controller.add(value.toDart);
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      }();
+
+      await for (final chunk in stream) {
+        final bytes = chunk is Uint8List ? chunk : Uint8List.fromList(chunk);
+        await writer.write(bytes.toJS).toDart;
+      }
+      await writer.close().toDart;
+      await readFuture;
+      await controller.close();
+    } catch (e, st) {
+      controller.addError(e, st);
+      await controller.close();
+    }
+  }
+}

--- a/lib/src/gzip/gzip_stub.dart
+++ b/lib/src/gzip/gzip_stub.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+/// Default stub implementation of gzipDecoder.
+Converter<List<int>, List<int>> get gzipDecoder =>
+    throw UnsupportedError('gzipDecoder is not supported on this platform.');

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -26,6 +26,7 @@ import 'package:tar/tar.dart';
 import 'error_group.dart';
 import 'exceptions.dart';
 import 'exit_codes.dart' as exit_codes;
+import 'gzip/gzip.dart';
 import 'log.dart' as log;
 import 'utils.dart';
 
@@ -1135,7 +1136,7 @@ Future<Uint8List> extractFileFromTarGz(
   Stream<List<int>> stream,
   String filename,
 ) async {
-  final reader = TarReader(stream.transform(gzip.decoder));
+  final reader = TarReader(stream.transform(gzipDecoder));
   filename = p.posix.normalize(filename);
   while (await reader.moveNext()) {
     final entry = reader.current;
@@ -1154,7 +1155,7 @@ Future<void> extractTarGz(Stream<List<int>> stream, String destination) async {
   log.fine('Extracting .tar.gz stream to $destination.');
 
   destination = p.absolute(destination);
-  final reader = TarReader(stream.transform(gzip.decoder));
+  final reader = TarReader(stream.transform(gzipDecoder));
   final paths = <String>{};
   while (await reader.moveNext()) {
     final entry = reader.current;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -418,7 +418,7 @@ packages:
     source: hosted
     version: "1.1.3"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   stack_trace: ^1.12.1
   tar: ^2.0.0
   typed_data: ^1.4.0
+  web: ^1.1.1
   yaml: ^3.1.3
   yaml_edit: ^2.2.2
 


### PR DESCRIPTION
I'm not sure if we should add tests, maybe when we have it all working we can make some minimal in-memory tests.