### PR TITLE
Use kernel to compile tests

### DIFF
--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,11 +1,11 @@
 platforms:
-  - chrome
   - vm
+  - chrome
 # TODO: Consider testing on Firefox
 
 compilers:
+ - kernel
  - dart2wasm
- - source
  - dart2js
 
 presets:


### PR DESCRIPTION
This is the default, and it makes the tests run many times faster.

https://github.com/dart-lang/test/blob/master/pkgs/test_api/lib/src/backend/compiler.dart#L18C21-L18C27