### PR TITLE
Add dependency constraints natively to `pub deps --json`

### DIFF
--- a/lib/src/command/deps.dart
+++ b/lib/src/command/deps.dart
@@ -148,6 +148,10 @@ class DepsCommand extends PubCommand {
           'directDependencies': currentPackage.dependencies.keys.toList(),
           if (isRoot)
             'devDependencies': currentPackage.devDependencies.keys.toList(),
+          'dependencyConstraints': (isRoot
+                  ? currentPackage.immediateDependencies
+                  : currentPackage.dependencies)
+              .map((k, v) => MapEntry(k, v.constraint.toString())),
         });
         toVisit.addAll(next);
       }

--- a/test/deps_test.dart
+++ b/test/deps_test.dart
@@ -172,7 +172,14 @@ void main() {
       ],
       "devDependencies": [
         "unittest"
-      ]
+      ],
+      "dependencyConstraints": {
+        "normal": "any",
+        "overridden": "2.0.0",
+        "from_path": "any",
+        "unittest": "any",
+        "override_only": "any"
+      }
     },
     {
       "name": "override_only",
@@ -180,7 +187,8 @@ void main() {
       "kind": "transitive",
       "source": "hosted",
       "dependencies": [],
-      "directDependencies": []
+      "directDependencies": [],
+      "dependencyConstraints": {}
     },
     {
       "name": "unittest",
@@ -194,7 +202,11 @@ void main() {
       "directDependencies": [
         "shared",
         "dev_only"
-      ]
+      ],
+      "dependencyConstraints": {
+        "shared": "any",
+        "dev_only": "any"
+      }
     },
     {
       "name": "dev_only",
@@ -202,7 +214,8 @@ void main() {
       "kind": "transitive",
       "source": "hosted",
       "dependencies": [],
-      "directDependencies": []
+      "directDependencies": [],
+      "dependencyConstraints": {}
     },
     {
       "name": "shared",
@@ -214,7 +227,10 @@ void main() {
       ],
       "directDependencies": [
         "other"
-      ]
+      ],
+      "dependencyConstraints": {
+        "other": "any"
+      }
     },
     {
       "name": "other",
@@ -226,7 +242,10 @@ void main() {
       ],
       "directDependencies": [
         "myapp"
-      ]
+      ],
+      "dependencyConstraints": {
+        "myapp": "any"
+      }
     },
     {
       "name": "from_path",
@@ -234,7 +253,8 @@ void main() {
       "kind": "direct",
       "source": "path",
       "dependencies": [],
-      "directDependencies": []
+      "directDependencies": [],
+      "dependencyConstraints": {}
     },
     {
       "name": "overridden",
@@ -242,7 +262,8 @@ void main() {
       "kind": "direct",
       "source": "hosted",
       "dependencies": [],
-      "directDependencies": []
+      "directDependencies": [],
+      "dependencyConstraints": {}
     },
     {
       "name": "normal",
@@ -256,7 +277,11 @@ void main() {
       "directDependencies": [
         "transitive",
         "circular_a"
-      ]
+      ],
+      "dependencyConstraints": {
+        "transitive": "any",
+        "circular_a": "any"
+      }
     },
     {
       "name": "circular_a",
@@ -268,7 +293,10 @@ void main() {
       ],
       "directDependencies": [
         "circular_b"
-      ]
+      ],
+      "dependencyConstraints": {
+        "circular_b": "any"
+      }
     },
     {
       "name": "circular_b",
@@ -280,7 +308,10 @@ void main() {
       ],
       "directDependencies": [
         "circular_a"
-      ]
+      ],
+      "dependencyConstraints": {
+        "circular_a": "any"
+      }
     },
     {
       "name": "transitive",
@@ -292,7 +323,10 @@ void main() {
       ],
       "directDependencies": [
         "shared"
-      ]
+      ],
+      "dependencyConstraints": {
+        "shared": "any"
+      }
     }
   ],
   "sdks": [

--- a/test/testdata/goldens/deps/executables_test/applies formatting before printing executables.txt
+++ b/test/testdata/goldens/deps/executables_test/applies formatting before printing executables.txt
@@ -82,10 +82,6 @@ $ pub deps --json
     {
       "name": "Dart",
       "version": "3.1.2+3"
-    },
-    {
-      "name": "Flutter",
-      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/applies formatting before printing executables.txt
+++ b/test/testdata/goldens/deps/executables_test/applies formatting before printing executables.txt
@@ -53,7 +53,11 @@ $ pub deps --json
         "foo",
         "bar"
       ],
-      "devDependencies": []
+      "devDependencies": [],
+      "dependencyConstraints": {
+        "foo": "any",
+        "bar": "any"
+      }
     },
     {
       "name": "bar",
@@ -61,7 +65,8 @@ $ pub deps --json
       "kind": "direct",
       "source": "path",
       "dependencies": [],
-      "directDependencies": []
+      "directDependencies": [],
+      "dependencyConstraints": {}
     },
     {
       "name": "foo",
@@ -69,13 +74,18 @@ $ pub deps --json
       "kind": "direct",
       "source": "path",
       "dependencies": [],
-      "directDependencies": []
+      "directDependencies": [],
+      "dependencyConstraints": {}
     }
   ],
   "sdks": [
     {
       "name": "Dart",
       "version": "3.1.2+3"
+    },
+    {
+      "name": "Flutter",
+      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/dev dependencies.txt
+++ b/test/testdata/goldens/deps/executables_test/dev dependencies.txt
@@ -40,7 +40,10 @@ $ pub deps --json
       "directDependencies": [],
       "devDependencies": [
         "foo"
-      ]
+      ],
+      "dependencyConstraints": {
+        "foo": "any"
+      }
     },
     {
       "name": "foo",
@@ -48,13 +51,18 @@ $ pub deps --json
       "kind": "dev",
       "source": "path",
       "dependencies": [],
-      "directDependencies": []
+      "directDependencies": [],
+      "dependencyConstraints": {}
     }
   ],
   "sdks": [
     {
       "name": "Dart",
       "version": "3.1.2+3"
+    },
+    {
+      "name": "Flutter",
+      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/dev dependencies.txt
+++ b/test/testdata/goldens/deps/executables_test/dev dependencies.txt
@@ -59,10 +59,6 @@ $ pub deps --json
     {
       "name": "Dart",
       "version": "3.1.2+3"
-    },
-    {
-      "name": "Flutter",
-      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/lists Dart executables, without entrypoints.txt
+++ b/test/testdata/goldens/deps/executables_test/lists Dart executables, without entrypoints.txt
@@ -43,10 +43,6 @@ $ pub deps --json
     {
       "name": "Dart",
       "version": "3.1.2+3"
-    },
-    {
-      "name": "Flutter",
-      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/lists Dart executables, without entrypoints.txt
+++ b/test/testdata/goldens/deps/executables_test/lists Dart executables, without entrypoints.txt
@@ -35,13 +35,18 @@ $ pub deps --json
       "source": "root",
       "dependencies": [],
       "directDependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "dependencyConstraints": {}
     }
   ],
   "sdks": [
     {
       "name": "Dart",
       "version": "3.1.2+3"
+    },
+    {
+      "name": "Flutter",
+      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/lists executables from a dependency.txt
+++ b/test/testdata/goldens/deps/executables_test/lists executables from a dependency.txt
@@ -59,10 +59,6 @@ $ pub deps --json
     {
       "name": "Dart",
       "version": "3.1.2+3"
-    },
-    {
-      "name": "Flutter",
-      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/lists executables from a dependency.txt
+++ b/test/testdata/goldens/deps/executables_test/lists executables from a dependency.txt
@@ -40,7 +40,10 @@ $ pub deps --json
       "directDependencies": [
         "foo"
       ],
-      "devDependencies": []
+      "devDependencies": [],
+      "dependencyConstraints": {
+        "foo": "any"
+      }
     },
     {
       "name": "foo",
@@ -48,13 +51,18 @@ $ pub deps --json
       "kind": "direct",
       "source": "path",
       "dependencies": [],
-      "directDependencies": []
+      "directDependencies": [],
+      "dependencyConstraints": {}
     }
   ],
   "sdks": [
     {
       "name": "Dart",
       "version": "3.1.2+3"
+    },
+    {
+      "name": "Flutter",
+      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/lists executables only from immediate dependencies.txt
+++ b/test/testdata/goldens/deps/executables_test/lists executables only from immediate dependencies.txt
@@ -44,7 +44,10 @@ $ pub deps --json
       "directDependencies": [
         "foo"
       ],
-      "devDependencies": []
+      "devDependencies": [],
+      "dependencyConstraints": {
+        "foo": "any"
+      }
     },
     {
       "name": "foo",
@@ -56,7 +59,10 @@ $ pub deps --json
       ],
       "directDependencies": [
         "baz"
-      ]
+      ],
+      "dependencyConstraints": {
+        "baz": "any"
+      }
     },
     {
       "name": "baz",
@@ -64,13 +70,18 @@ $ pub deps --json
       "kind": "transitive",
       "source": "path",
       "dependencies": [],
-      "directDependencies": []
+      "directDependencies": [],
+      "dependencyConstraints": {}
     }
   ],
   "sdks": [
     {
       "name": "Dart",
       "version": "3.1.2+3"
+    },
+    {
+      "name": "Flutter",
+      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/lists executables only from immediate dependencies.txt
+++ b/test/testdata/goldens/deps/executables_test/lists executables only from immediate dependencies.txt
@@ -78,10 +78,6 @@ $ pub deps --json
     {
       "name": "Dart",
       "version": "3.1.2+3"
-    },
-    {
-      "name": "Flutter",
-      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/overriden dependencies executables.txt
+++ b/test/testdata/goldens/deps/executables_test/overriden dependencies executables.txt
@@ -64,10 +64,6 @@ $ pub deps --json
     {
       "name": "Dart",
       "version": "3.1.2+3"
-    },
-    {
-      "name": "Flutter",
-      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/overriden dependencies executables.txt
+++ b/test/testdata/goldens/deps/executables_test/overriden dependencies executables.txt
@@ -45,7 +45,10 @@ $ pub deps --json
       "directDependencies": [
         "foo"
       ],
-      "devDependencies": []
+      "devDependencies": [],
+      "dependencyConstraints": {
+        "foo": "any"
+      }
     },
     {
       "name": "foo",
@@ -53,13 +56,18 @@ $ pub deps --json
       "kind": "direct",
       "source": "path",
       "dependencies": [],
-      "directDependencies": []
+      "directDependencies": [],
+      "dependencyConstraints": {}
     }
   ],
   "sdks": [
     {
       "name": "Dart",
       "version": "3.1.2+3"
+    },
+    {
+      "name": "Flutter",
+      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/skips executables in sub directories.txt
+++ b/test/testdata/goldens/deps/executables_test/skips executables in sub directories.txt
@@ -44,10 +44,6 @@ $ pub deps --json
     {
       "name": "Dart",
       "version": "3.1.2+3"
-    },
-    {
-      "name": "Flutter",
-      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/skips executables in sub directories.txt
+++ b/test/testdata/goldens/deps/executables_test/skips executables in sub directories.txt
@@ -36,13 +36,18 @@ $ pub deps --json
       "source": "root",
       "dependencies": [],
       "directDependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "dependencyConstraints": {}
     }
   ],
   "sdks": [
     {
       "name": "Dart",
       "version": "3.1.2+3"
+    },
+    {
+      "name": "Flutter",
+      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": [

--- a/test/testdata/goldens/deps/executables_test/skips non-Dart executables.txt
+++ b/test/testdata/goldens/deps/executables_test/skips non-Dart executables.txt
@@ -33,13 +33,18 @@ $ pub deps --json
       "source": "root",
       "dependencies": [],
       "directDependencies": [],
-      "devDependencies": []
+      "devDependencies": [],
+      "dependencyConstraints": {}
     }
   ],
   "sdks": [
     {
       "name": "Dart",
       "version": "3.1.2+3"
+    },
+    {
+      "name": "Flutter",
+      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": []

--- a/test/testdata/goldens/deps/executables_test/skips non-Dart executables.txt
+++ b/test/testdata/goldens/deps/executables_test/skips non-Dart executables.txt
@@ -41,10 +41,6 @@ $ pub deps --json
     {
       "name": "Dart",
       "version": "3.1.2+3"
-    },
-    {
-      "name": "Flutter",
-      "version": "3.43.0-1.0.pre-199"
     }
   ],
   "executables": []

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -538,7 +538,11 @@ transitive dependencies:
         "myapp",
         "both"
       ],
-      "devDependencies": []
+      "devDependencies": [],
+      "dependencyConstraints": {
+        "myapp": "any",
+        "both": "^1.0.0"
+      }
     },
     {
       "name": "both",
@@ -546,7 +550,8 @@ transitive dependencies:
       "kind": "direct",
       "source": "hosted",
       "dependencies": [],
-      "directDependencies": []
+      "directDependencies": [],
+      "dependencyConstraints": {}
     },
     {
       "name": "myapp",
@@ -561,7 +566,11 @@ transitive dependencies:
         "both",
         "b"
       ],
-      "devDependencies": []
+      "devDependencies": [],
+      "dependencyConstraints": {
+        "both": "^1.0.0",
+        "b": "any"
+      }
     },
     {
       "name": "a",
@@ -579,7 +588,12 @@ transitive dependencies:
       ],
       "devDependencies": [
         "both"
-      ]
+      ],
+      "dependencyConstraints": {
+        "myapp": "any",
+        "foo": "^1.0.0",
+        "both": "^1.0.0"
+      }
     },
     {
       "name": "foo",
@@ -591,7 +605,10 @@ transitive dependencies:
       ],
       "directDependencies": [
         "transitive"
-      ]
+      ],
+      "dependencyConstraints": {
+        "transitive": "^1.0.0"
+      }
     },
     {
       "name": "transitive",
@@ -599,7 +616,8 @@ transitive dependencies:
       "kind": "transitive",
       "source": "hosted",
       "dependencies": [],
-      "directDependencies": []
+      "directDependencies": [],
+      "dependencyConstraints": {}
     }
   ],
   "sdks": [


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub/issues/4796

This implicitly injects a `dependencyConstraints` map directly into the package nodes within the JSON graph payload. We rely on the robustness of typical JSON parsers to ignore unrecognized keys allowing advanced tooling like `pubviz` to access strict version constraints exactly as defined in `pubspec.yaml` without requiring any new CLI flags.
