### PR TITLE
Fix FormatException when advisoriesUpdated is null

### DIFF
--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -647,7 +647,8 @@ class HostedSource extends CachedSource {
     }
 
     final advisoriesUpdated = body['advisoriesUpdated'];
-    if (advisoriesUpdated is! String) {
+
+    if (advisoriesUpdated != null && advisoriesUpdated is! String) {
       throw const FormatException('advisoriesUpdated must be a String');
     }
 


### PR DESCRIPTION
## Description
Fixes dart-lang/pub-dev#9372.

When attempting to resolve dependencies or add a new package (e.g. `dart pub add http`), the pub client would sometimes crash with a `FormatException: advisoriesUpdated must be a String`.

This occurs because the `advisoriesUpdated` JSON key returned by the server can be `null` (e.g. `{"advisories":[],"advisoriesUpdated":null}`). The existing code strictly checked `if (advisoriesUpdated is! String)`, which evaluates to `true` for `null` and threw an error. 

This PR updates `_extractAdvisoryDetailsForPackage` to check if `advisoriesUpdated != null` before asserting its type, similar to how it is handled elsewhere in `hosted.dart`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
