### PR TITLE
Remove unintended `-v` flag from binstub template

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -1031,10 +1031,8 @@ ${header}if [ -f $snapshot ]; then
   if [ \$exit_code != 253 ]; then
     exit \$exit_code
   fi
-  dart $pubInvocation -v global run $runPubGlobal "\$@"
-else
-  dart $pubInvocation global run $runPubGlobal "\$@"
 fi
+dart $pubInvocation global run $runPubGlobal "\$@"
 ''';
       } else {
         binstub = '''

--- a/tool/test.dart
+++ b/tool/test.dart
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S dart run -r
+
 // Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.


### PR DESCRIPTION
In PR #4192 (cf9ba6c), binstub generation was updated to invoke the local `pub` binary during testing. While troubleshooting CI failures in that PR, a `-v` flag was added to the snapshot invalidation fallback branch (`if [ $exit_code != 253 ]`) in the Linux/macOS binstub template to inspect verbose subprocess logs in CI.

This `-v` flag was accidentally included in the merged PR, causing globally activated packages to produce verbose pub logs whenever a Dart SDK upgrade invalidated pre-compiled snapshots.

This commit removes the leftover `-v` flag and simplifies the binstub template by removing a redundant `else` branch.
