### PR TITLE
fix: repair no-op resolution timestamps

### DIFF
--- a/lib/src/command/dependency_services.dart
+++ b/lib/src/command/dependency_services.dart
@@ -575,7 +575,11 @@ class DependencyServicesApplyCommand extends PubCommand {
           overriddenDependencies: entrypoint.lockFile.overriddenDependencies,
         );
 
-        newLockFile.writeToFile(entrypoint.lockFilePath, cache);
+        newLockFile.writeToFile(
+          entrypoint.lockFilePath,
+          cache,
+          dependencies: const [],
+        );
       }
     });
     // Dummy message.

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -458,6 +458,37 @@ See $workspacesDocUrl for more information.''',
     }
   }
 
+  /// touches unchanged generated resolution files if their inputs are newer.
+  Future<void> _updateResolutionFileTimestamps() async {
+    final lockFileStat = tryStatFile(lockFilePath);
+    if (lockFileStat == null) return;
+    var lockFileModified = lockFileStat.modified;
+
+    final graph = await packageGraph;
+    for (final package in graph.packages.values) {
+      if (!graph.isPackageMutable(package.name)) continue;
+
+      final pubspecModified = tryStatFile(package.pubspecPath)?.modified;
+      final pubspecOverridesModified = tryStatFile(
+        package.pubspecOverridesPath,
+      )?.modified;
+      if ((pubspecModified != null &&
+              pubspecModified.isAfter(lockFileModified)) ||
+          (pubspecOverridesModified != null &&
+              pubspecOverridesModified.isAfter(lockFileModified))) {
+        touch(lockFilePath);
+        lockFileModified = tryStatFile(lockFilePath)!.modified;
+        break;
+      }
+    }
+
+    final packageConfigModified = tryStatFile(packageConfigPath)?.modified;
+    if (packageConfigModified != null &&
+        lockFileModified.isAfter(packageConfigModified)) {
+      touch(packageConfigPath);
+    }
+  }
+
   Future<String> _packageGraphFile(SystemCache cache) async {
     return const JsonEncoder.withIndent('  ').convert({
       'roots':
@@ -663,6 +694,10 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       _packageGraph = Future.value(PackageGraph.fromSolveResult(this, result));
 
       await writePackageConfigFiles();
+
+      if (!enforceLockfile) {
+        await _updateResolutionFileTimestamps();
+      }
 
       try {
         if (precompile) {

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -459,9 +459,8 @@ See $workspacesDocUrl for more information.''',
     }
   }
 
-  Iterable<String> _resolutionFileDependencies(PackageGraph graph) sync* {
-    for (final package in graph.packages.values) {
-      if (!graph.isPackageMutable(package.name)) continue;
+  Iterable<String> _resolutionFileDependencies() sync* {
+    for (final package in workspaceRoot.transitiveWorkspace) {
       yield package.pubspecPath;
       yield package.pubspecOverridesPath;
     }
@@ -665,7 +664,7 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       newLockFile.writeToFile(
         lockFilePath,
         cache,
-        dependencies: _resolutionFileDependencies(packageGraph),
+        dependencies: _resolutionFileDependencies(),
       );
     }
 

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -469,9 +469,8 @@ See $workspacesDocUrl for more information.''',
       if (!graph.isPackageMutable(package.name)) continue;
 
       final pubspecModified = tryStatFile(package.pubspecPath)?.modified;
-      final pubspecOverridesModified = tryStatFile(
-        package.pubspecOverridesPath,
-      )?.modified;
+      final pubspecOverridesModified =
+          tryStatFile(package.pubspecOverridesPath)?.modified;
       if ((pubspecModified != null &&
               pubspecModified.isAfter(lockFileModified)) ||
           (pubspecOverridesModified != null &&

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -435,6 +435,7 @@ See $workspacesDocUrl for more information.''',
                 .sdkConstraints[sdk.identifier]
                 ?.effectiveConstraint,
       ),
+      dependencies: [lockFilePath],
     );
     writeTextFileIfDifferent(packageGraphPath, await _packageGraphFile(cache));
 
@@ -458,33 +459,11 @@ See $workspacesDocUrl for more information.''',
     }
   }
 
-  /// touches unchanged generated resolution files if their inputs are newer.
-  Future<void> _updateResolutionFileTimestamps() async {
-    final lockFileStat = tryStatFile(lockFilePath);
-    if (lockFileStat == null) return;
-    var lockFileModified = lockFileStat.modified;
-
-    final graph = await packageGraph;
+  Iterable<String> _resolutionFileDependencies(PackageGraph graph) sync* {
     for (final package in graph.packages.values) {
       if (!graph.isPackageMutable(package.name)) continue;
-
-      final pubspecModified = tryStatFile(package.pubspecPath)?.modified;
-      final pubspecOverridesModified =
-          tryStatFile(package.pubspecOverridesPath)?.modified;
-      if ((pubspecModified != null &&
-              pubspecModified.isAfter(lockFileModified)) ||
-          (pubspecOverridesModified != null &&
-              pubspecOverridesModified.isAfter(lockFileModified))) {
-        touch(lockFilePath);
-        lockFileModified = tryStatFile(lockFilePath)!.modified;
-        break;
-      }
-    }
-
-    final packageConfigModified = tryStatFile(packageConfigPath)?.modified;
-    if (packageConfigModified != null &&
-        lockFileModified.isAfter(packageConfigModified)) {
-      touch(packageConfigPath);
+      yield package.pubspecPath;
+      yield package.pubspecOverridesPath;
     }
   }
 
@@ -679,24 +658,25 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
 `--enforce-lockfile`.''');
     }
 
-    if (!(dryRun || enforceLockfile)) {
-      newLockFile.writeToFile(lockFilePath, cache);
-    }
-
     _lockFile = newLockFile;
+    late final packageGraph = PackageGraph.fromSolveResult(this, result);
+
+    if (!(dryRun || enforceLockfile)) {
+      newLockFile.writeToFile(
+        lockFilePath,
+        cache,
+        dependencies: _resolutionFileDependencies(packageGraph),
+      );
+    }
 
     if (!dryRun) {
       _removeStrayLockAndConfigFiles();
 
       /// Build a package graph from the version solver results so we don't
       /// have to reload and reparse all the pubspecs.
-      _packageGraph = Future.value(PackageGraph.fromSolveResult(this, result));
+      _packageGraph = Future.value(packageGraph);
 
       await writePackageConfigFiles();
-
-      if (!enforceLockfile) {
-        await _updateResolutionFileTimestamps();
-      }
 
       try {
         if (precompile) {

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -233,10 +233,11 @@ Follow progress in https://github.com/dart-lang/sdk/issues/60889.
     final tempDir = cache.createTempDir();
     // TODO(rnystrom): Look in "bin" and display list of binaries that
     // user can run.
-    LockFile(
-      [id],
-      mainDependencies: {id.name},
-    ).writeToFile(p.join(tempDir, 'pubspec.lock'), cache);
+    LockFile([id], mainDependencies: {id.name}).writeToFile(
+      p.join(tempDir, 'pubspec.lock'),
+      cache,
+      dependencies: const [],
+    );
 
     tryDeleteEntry(_packageDir(name));
     tryRenameDir(tempDir, _packageDir(name));
@@ -333,7 +334,11 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
         ).show(summary: false);
       }
 
-      lockFile.writeToFile(p.join(tempDir, 'pubspec.lock'), cache);
+      lockFile.writeToFile(
+        p.join(tempDir, 'pubspec.lock'),
+        cache,
+        dependencies: const [],
+      );
 
       final packageDir = _packageDir(name);
       tryDeleteEntry(packageDir);

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -265,17 +265,31 @@ void writeTextFile(
 }
 
 /// Reads the file at [path] and writes [newContent] to it, if it is different
-/// from [newContent].
+/// from the existing content.
 ///
 /// If the file doesn't exist it is always written.
-void writeTextFileIfDifferent(String path, String newContent) {
-  // Compare to the present package_config.json
-  // For purposes of equality we don't care about the `generated` timestamp.
+///
+/// If the content is unchanged but any [dependencies] are newer than [path],
+/// [path] is touched.
+void writeTextFileIfDifferent(
+  String path,
+  String newContent, {
+  Iterable<String> dependencies = const [],
+}) {
   final originalText = tryReadTextFile(path);
   if (originalText != newContent) {
     writeTextFile(path, newContent);
   } else {
     log.fine('`$path` is unchanged. Not rewriting.');
+    final modified = tryStatFile(path)?.modified;
+    if (modified == null) return;
+    for (final dependency in dependencies) {
+      final dependencyModified = tryStatFile(dependency)?.modified;
+      if (dependencyModified != null && dependencyModified.isAfter(modified)) {
+        touch(path);
+        break;
+      }
+    }
   }
 }
 

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -280,16 +280,21 @@ void writeTextFileIfDifferent(
   if (originalText != newContent) {
     writeTextFile(path, newContent);
   } else {
-    log.fine('`$path` is unchanged. Not rewriting.');
     final modified = tryStatFile(path)?.modified;
-    if (modified == null) return;
-    for (final dependency in dependencies) {
-      final dependencyModified = tryStatFile(dependency)?.modified;
-      if (dependencyModified != null && dependencyModified.isAfter(modified)) {
-        touch(path);
-        break;
+    if (modified != null) {
+      for (final dependency in dependencies) {
+        final dependencyModified = tryStatFile(dependency)?.modified;
+        if (dependencyModified != null &&
+            dependencyModified.isAfter(modified)) {
+          log.fine(
+            '`$path` is unchanged. Touching because `$dependency` is newer.',
+          );
+          touch(path);
+          return;
+        }
       }
     }
+    log.fine('`$path` is unchanged. Not rewriting.');
   }
 }
 

--- a/lib/src/lock_file.dart
+++ b/lib/src/lock_file.dart
@@ -389,10 +389,13 @@ ${yamlToString(data)}
   /// uses that.
   ///
   /// Relative paths will be resolved relative to [lockFilePath]
+  ///
+  /// If the serialized lockfile is unchanged, but any [dependencies] are newer
+  /// than [lockFilePath], the lockfile is touched.
   void writeToFile(
     String lockFilePath,
     SystemCache cache, {
-    Iterable<String> dependencies = const [],
+    required Iterable<String> dependencies,
   }) {
     final windowsLineEndings =
         fileExists(lockFilePath) &&

--- a/lib/src/lock_file.dart
+++ b/lib/src/lock_file.dart
@@ -389,7 +389,11 @@ ${yamlToString(data)}
   /// uses that.
   ///
   /// Relative paths will be resolved relative to [lockFilePath]
-  void writeToFile(String lockFilePath, SystemCache cache) {
+  void writeToFile(
+    String lockFilePath,
+    SystemCache cache, {
+    Iterable<String> dependencies = const [],
+  }) {
     final windowsLineEndings =
         fileExists(lockFilePath) &&
         detectWindowsLineEndings(readTextFile(lockFilePath));
@@ -398,6 +402,7 @@ ${yamlToString(data)}
     writeTextFileIfDifferent(
       lockFilePath,
       windowsLineEndings ? serialized.replaceAll('\n', '\r\n') : serialized,
+      dependencies: dependencies,
     );
   }
 

--- a/test/package_config_file_test.dart
+++ b/test/package_config_file_test.dart
@@ -379,4 +379,69 @@ void main() {
     expect(lockFile.lastModifiedSync(), lockfileTimestamp);
     expect(workspaceRefFile.lastModifiedSync(), workspaceRefTimestamp);
   });
+
+  test(
+    'pub get touches unchanged resolution files after pubspec edits',
+    () async {
+      final server = await servePackages();
+      server.serve('foo', '1.0.0');
+
+      await d.dir(appPath, [
+        d.appPubspec(
+          dependencies: {'foo': 'any'},
+          extras: {
+            'workspace': ['foo'],
+            'environment': {'sdk': '^3.5.0'},
+          },
+        ),
+        d.dir('foo', [d.libPubspec('foo', '1.0.0', resolutionWorkspace: true)]),
+      ]).create();
+
+      await pubGet(environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'});
+      final rootPubspec = File(p.join(sandbox, appPath, 'pubspec.yaml'));
+      final workspacePubspec = File(
+        p.join(sandbox, appPath, 'foo', 'pubspec.yaml'),
+      );
+      final lockFile = File(p.join(sandbox, appPath, 'pubspec.lock'));
+      final packageConfigFile = File(
+        p.join(sandbox, appPath, '.dart_tool', 'package_config.json'),
+      );
+      final lockfileContents = lockFile.readAsStringSync();
+      final packageConfig = jsonDecode(packageConfigFile.readAsStringSync());
+
+      // timestamp resolution is rather poor especially on windows.
+      await Future<void>.delayed(const Duration(seconds: 1));
+      rootPubspec.writeAsStringSync(
+        '${rootPubspec.readAsStringSync()}\n# hi\n',
+      );
+      workspacePubspec.writeAsStringSync(
+        '${workspacePubspec.readAsStringSync()}\n# hi\n',
+      );
+
+      expect(
+        rootPubspec.lastModifiedSync().isAfter(lockFile.lastModifiedSync()),
+        isTrue,
+      );
+      expect(
+        workspacePubspec.lastModifiedSync().isAfter(
+          lockFile.lastModifiedSync(),
+        ),
+        isTrue,
+      );
+
+      await pubGet(environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'});
+
+      expect(lockFile.readAsStringSync(), lockfileContents);
+      expect(jsonDecode(packageConfigFile.readAsStringSync()), packageConfig);
+
+      final lockFileModified = lockFile.lastModifiedSync();
+      final packageConfigModified = packageConfigFile.lastModifiedSync();
+      expect(rootPubspec.lastModifiedSync().isAfter(lockFileModified), isFalse);
+      expect(
+        workspacePubspec.lastModifiedSync().isAfter(lockFileModified),
+        isFalse,
+      );
+      expect(lockFileModified.isAfter(packageConfigModified), isFalse);
+    },
+  );
 }

--- a/tool/test.dart
+++ b/tool/test.dart
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S dart run -r
+
 // Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.


### PR DESCRIPTION
touch unchanged generated resolution files after a successful no-op resolution so timestamp-based clients can keep using the existing package resolution.

this keeps file contents stable, but repairs mtimes when mutable pubspec inputs are newer than the generated lockfile/package config.

fixes dart-lang/pub#4672
relates to dart-lang/pub#4699