### PR TITLE
upgrade: explain targeted transitive upgrades

### DIFF
--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -17,6 +17,7 @@ import '../package_name.dart';
 import '../pubspec.dart';
 import '../pubspec_utils.dart';
 import '../solver.dart';
+import '../solver/version_solver.dart';
 import '../utils.dart';
 
 /// Handles the `upgrade` pub command.
@@ -27,7 +28,7 @@ class UpgradeCommand extends PubCommand {
   String get description =>
       "Upgrade the current package's dependencies to latest versions.";
   @override
-  String get argumentsDescription => '[dependencies...]';
+  String get argumentsDescription => '[dependencies[:latest|:resolvable]...]';
   @override
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-upgrade';
 
@@ -111,6 +112,15 @@ class UpgradeCommand extends PubCommand {
   late final Future<List<String>> _packagesToUpgrade =
       _computePackagesToUpgrade();
 
+  late final List<_UpgradeTarget> _upgradeTargets =
+      argResults.rest.map(_parseUpgradeTarget).toList();
+
+  late final Future<List<ConstraintAndCause>?> _additionalConstraints =
+      _upgradeTargetConstraints();
+
+  late final Future<Map<String, PackageId>> _latestResolvablePackages =
+      _computeLatestResolvablePackages();
+
   /// List of package names to upgrade, if empty then upgrade all packages.
   ///
   /// This allows the user to specify list of names that they want the
@@ -118,11 +128,11 @@ class UpgradeCommand extends PubCommand {
   Future<List<String>> _computePackagesToUpgrade() async {
     if (argResults.flag('unlock-transitive')) {
       final graph = await entrypoint.packageGraph;
-      return argResults.rest
+      return _upgradeTargets
           .expand(
-            (package) => graph
+            (target) => graph
                 .transitiveDependencies(
-                  package,
+                  target.name,
                   followDevDependenciesFromPackage: true,
                 )
                 .map((p) => p.name),
@@ -130,7 +140,7 @@ class UpgradeCommand extends PubCommand {
           .toSet()
           .toList();
     } else {
-      return argResults.rest;
+      return _upgradeTargets.map((target) => target.name).toList();
     }
   }
 
@@ -151,6 +161,18 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
           'The --packages-dir flag is no longer used and does nothing.',
         ),
       );
+    }
+    if (_upgradeTargets.any((target) => target.kind != null)) {
+      if (_upgradeMajorVersions) {
+        usageException(
+          'Cannot use `:latest` or `:resolvable` with `--major-versions`.',
+        );
+      }
+      if (_tighten) {
+        usageException(
+          'Cannot use `:latest` or `:resolvable` with `--tighten`.',
+        );
+      }
     }
 
     if (_upgradeMajorVersions) {
@@ -196,12 +218,122 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
     await e.acquireDependencies(
       SolveType.upgrade,
       unlock: await _packagesToUpgrade,
+      additionalConstraints: await _additionalConstraints,
       dryRun: _dryRun,
       precompile: _precompile,
       summaryOnly: onlySummary,
     );
 
     _showOfflineWarning();
+  }
+
+  Future<List<ConstraintAndCause>?> _upgradeTargetConstraints() async {
+    final constraintFutures = <Future<ConstraintAndCause>>[];
+    for (final target in _upgradeTargets) {
+      final kind = target.kind;
+      if (kind == null) continue;
+
+      constraintFutures.add(
+        (() async {
+          final targetPackage = switch (kind) {
+            _UpgradeTargetKind.latest => await _latest(target.name),
+            _UpgradeTargetKind.resolvable => await _latestResolvable(
+              target.name,
+            ),
+          };
+          return ConstraintAndCause(
+            targetPackage.toRange(),
+            '${targetPackage.name} ${targetPackage.version} was requested by '
+            '`$topLevelProgram pub upgrade ${target.argument}`.',
+          );
+        })(),
+      );
+    }
+    final constraints = await Future.wait(constraintFutures);
+    return constraints.isEmpty ? null : constraints;
+  }
+
+  Future<Map<String, PackageId>> _computeLatestResolvablePackages() async {
+    final solveResult = await log.spinner('Resolving dependencies', () async {
+      return await resolveVersions(
+        SolveType.upgrade,
+        cache,
+        entrypoint.workspaceRoot.transformWorkspace(
+          (package) => stripVersionBounds(package.pubspec),
+        ),
+      );
+    }, condition: _shouldShowSpinner);
+    return {for (final package in solveResult.packages) package.name: package};
+  }
+
+  Future<PackageId> _latestResolvable(String package) async {
+    if (_packageRef(package) == null) {
+      dataError('Package `$package` is not in the current resolution.');
+    }
+    final latestResolvable = (await _latestResolvablePackages)[package];
+    if (latestResolvable == null) {
+      dataError(
+        'Package `$package` is not in the latest resolvable resolution.',
+      );
+    }
+    return latestResolvable;
+  }
+
+  Future<PackageId> _latest(String package) async {
+    final ref = _packageRef(package);
+    if (ref == null) {
+      dataError('Package `$package` is not in the current resolution.');
+    }
+    final current = entrypoint.lockFile.packages[package];
+    final latest = await cache.getLatest(ref, version: current?.version);
+    if (latest == null) {
+      dataError('Could not find package `$package`.');
+    }
+    return latest;
+  }
+
+  PackageRef? _packageRef(String package) {
+    final current = entrypoint.lockFile.packages[package];
+    if (current != null) return current.toRef();
+
+    for (final workspacePackage
+        in entrypoint.workspaceRoot.transitiveWorkspace) {
+      final dependency = workspacePackage.dependencies[package];
+      if (dependency != null) return dependency.toRef();
+      final devDependency = workspacePackage.devDependencies[package];
+      if (devDependency != null) return devDependency.toRef();
+    }
+    return null;
+  }
+
+  _UpgradeTarget _parseUpgradeTarget(String argument) {
+    final parts = argument.split(':');
+    if (parts.length > 2) {
+      usageException('Could not parse `$argument`.');
+    }
+
+    final package = parts.first;
+    if (!packageNameRegExp.hasMatch(package)) {
+      usageException('Not a valid package name: "$package"');
+    }
+
+    if (parts.length == 1) {
+      return _UpgradeTarget(argument, package, null);
+    }
+
+    final suffix = parts.last;
+    final kind = switch (suffix) {
+      'latest' => _UpgradeTargetKind.latest,
+      'resolvable' => _UpgradeTargetKind.resolvable,
+      _ => null,
+    };
+    if (kind == null) {
+      usageException(
+        'Unknown upgrade target `$argument`. Use `<package>`, '
+        '`<package>:latest`, or `<package>:resolvable`.',
+      );
+    }
+    return _UpgradeTarget(argument, package, kind);
   }
 
   /// Return names of packages to be upgraded, and throws [UsageException] if
@@ -240,21 +372,7 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
 
   Future<void> _runUpgradeMajorVersions() async {
     final toUpgrade = await _directDependenciesToUpgrade();
-    // Solve [resolvablePubspec] in-memory and consolidate the resolved
-    // versions of the packages into a map for quick searching.
-    final resolvedPackages = <String, PackageId>{};
-    final solveResult = await log.spinner('Resolving dependencies', () async {
-      return await resolveVersions(
-        SolveType.upgrade,
-        cache,
-        entrypoint.workspaceRoot.transformWorkspace(
-          (package) => stripVersionBounds(package.pubspec),
-        ),
-      );
-    }, condition: _shouldShowSpinner);
-    for (final resolvedPackage in solveResult.packages) {
-      resolvedPackages[resolvedPackage.name] = resolvedPackage;
-    }
+    final resolvedPackages = await _latestResolvablePackages;
     final dependencyOverriddenDeps = <String>[];
     // Changes to be made to `pubspec.yaml` of each package.
     // Mapping from original to changed value.
@@ -376,4 +494,14 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
       );
     }
   }
+}
+
+enum _UpgradeTargetKind { latest, resolvable }
+
+class _UpgradeTarget {
+  final String argument;
+  final String name;
+  final _UpgradeTargetKind? kind;
+
+  _UpgradeTarget(this.argument, this.name, this.kind);
 }

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -327,6 +327,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
   String _suggestedMajorVersionsCommand(Entrypoint e, _UpgradeTarget target) {
     final directoryOption =
         identical(e, entrypoint) ? directory : e.workspaceRoot.dir;
+    final disableExamples = e.examples.isNotEmpty;
     return [
       topLevelProgram,
       'pub',
@@ -334,6 +335,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
       '--major-versions',
       if (_tighten) '--tighten',
       if (argResults.flag('unlock-transitive')) '--unlock-transitive',
+      if (disableExamples) '--no-example',
       if (directoryOption != '.') ...['--directory', directoryOption],
       target.argument,
     ].map(escapeShellArgument).join(' ');

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -26,7 +26,14 @@ class UpgradeCommand extends PubCommand {
   String get name => 'upgrade';
   @override
   String get description =>
-      "Upgrade the current package's dependencies to latest versions.";
+      "Upgrade the current package's dependencies to latest versions.\n"
+      '\n'
+      'Append `:latest` to a dependency to require the latest available '
+      'version.\n'
+      '\n'
+      'Append `:resolvable` to require the newest version resolvable with the '
+      'rest of\n'
+      'the dependency graph.';
   @override
   String get argumentsDescription => '[dependencies[:latest|:resolvable]...]';
   @override
@@ -309,7 +316,10 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
   _UpgradeTarget _parseUpgradeTarget(String argument) {
     final parts = argument.split(':');
     if (parts.length > 2) {
-      usageException('Could not parse `$argument`.');
+      usageException(
+        'Could not parse upgrade target `$argument`. Use `<package>`, '
+        '`<package>:latest`, or `<package>:resolvable`.',
+      );
     }
 
     final package = parts.first;

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -183,20 +183,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
     final hasUpgradeTargetConstraints = _upgradeTargets.any(
       (target) => target.kind != null,
     );
-    if (hasUpgradeTargetConstraints) {
-      if (_upgradeMajorVersions) {
-        usageException(
-          'Cannot use `@<constraint>`, `@latest`, or `@resolvable` with '
-          '`--major-versions`.',
-        );
-      }
-      if (_tighten) {
-        usageException(
-          'Cannot use `@<constraint>`, `@latest`, or `@resolvable` with '
-          '`--tighten`.',
-        );
-      }
-    }
+
     if (hasUpgradeTargetConstraints ||
         (argResults.flag('unlock-transitive') && _upgradeTargets.isNotEmpty)) {
       _validateUpgradeTargetEntrypoints(
@@ -339,8 +326,9 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
   }
 
   Future<Map<String, PackageId>> _computeLatestResolvablePackages(
-    Entrypoint e,
-  ) async {
+    Entrypoint e, {
+    Iterable<ConstraintAndCause>? additionalConstraints,
+  }) async {
     final solveResult = await log.spinner('Resolving dependencies', () async {
       return await resolveVersions(
         SolveType.upgrade,
@@ -348,6 +336,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
         e.workspaceRoot.transformWorkspace(
           (package) => stripVersionBounds(package.pubspec),
         ),
+        additionalConstraints: additionalConstraints,
       );
     }, condition: _shouldShowSpinner);
     return {for (final package in solveResult.packages) package.name: package};
@@ -475,7 +464,10 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
 
   Future<void> _runUpgradeMajorVersions() async {
     final toUpgrade = await _directDependenciesToUpgrade();
-    final resolvedPackages = await _computeLatestResolvablePackages(entrypoint);
+    final resolvedPackages = await _computeLatestResolvablePackages(
+      entrypoint,
+      additionalConstraints: await _upgradeTargetConstraints(entrypoint),
+    );
     final dependencyOverriddenDeps = <String>[];
     // Changes to be made to `pubspec.yaml` of each package.
     // Mapping from original to changed value.

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -189,6 +189,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
       _validateUpgradeTargetEntrypoints(
         validatePlainTargets: argResults.flag('unlock-transitive'),
       );
+      _validateUpgradeTargetConstraintsOverlap();
     }
 
     if (_upgradeMajorVersions) {
@@ -265,6 +266,77 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
         'It was not found in $entrypoints.',
       );
     }
+  }
+
+  void _validateUpgradeTargetConstraintsOverlap() {
+    if (_upgradeMajorVersions) return;
+
+    for (final target in _upgradeTargets) {
+      if (target.kind != _UpgradeTargetKind.constraint) continue;
+      for (final entrypoint in _entrypointsToUpgrade) {
+        _validateUpgradeTargetConstraintOverlap(entrypoint, target);
+      }
+    }
+  }
+
+  void _validateUpgradeTargetConstraintOverlap(
+    Entrypoint e,
+    _UpgradeTarget target,
+  ) {
+    final targetConstraint = target.constraint!;
+    var hasOverride = false;
+    for (final workspacePackage in e.workspaceRoot.transitiveWorkspace) {
+      final override =
+          workspacePackage.pubspec.dependencyOverrides[target.name];
+      if (override == null) continue;
+      hasOverride = true;
+      if (!override.constraint.allowsAny(targetConstraint)) {
+        final pubspecPath =
+            workspacePackage.pubspec.dependencyOverridesFromOverridesFile
+                ? workspacePackage.pubspecOverridesPath
+                : workspacePackage.pubspecPath;
+        dataError(
+          'The requested constraint `$targetConstraint` for `${target.name}` '
+          'does not overlap with the dependency override constraint '
+          '`${override.constraint}` in `$pubspecPath`.\n'
+          'Update or remove the dependency override before retrying.',
+        );
+      }
+    }
+    if (hasOverride) return;
+
+    for (final workspacePackage in e.workspaceRoot.transitiveWorkspace) {
+      final dependency = workspacePackage.dependencies[target.name];
+      final devDependency = workspacePackage.devDependencies[target.name];
+      final declaredConstraint =
+          dependency?.constraint ?? devDependency?.constraint;
+      if (declaredConstraint == null ||
+          declaredConstraint.allowsAny(targetConstraint)) {
+        continue;
+      }
+      dataError(
+        'The requested constraint `$targetConstraint` for `${target.name}` '
+        'does not overlap with the current constraint `$declaredConstraint` '
+        'in `${workspacePackage.pubspecPath}`.\n'
+        'To update the constraint, run '
+        '`${_suggestedMajorVersionsCommand(e, target)}`.',
+      );
+    }
+  }
+
+  String _suggestedMajorVersionsCommand(Entrypoint e, _UpgradeTarget target) {
+    final directoryOption =
+        identical(e, entrypoint) ? directory : e.workspaceRoot.dir;
+    return [
+      topLevelProgram,
+      'pub',
+      'upgrade',
+      '--major-versions',
+      if (_tighten) '--tighten',
+      if (argResults.flag('unlock-transitive')) '--unlock-transitive',
+      if (directoryOption != '.') ...['--directory', directoryOption],
+      target.argument,
+    ].map(escapeShellArgument).join(' ');
   }
 
   Future<List<ConstraintAndCause>?> _upgradeTargetConstraints(

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -28,14 +28,17 @@ class UpgradeCommand extends PubCommand {
   String get description =>
       "Upgrade the current package's dependencies to latest versions.\n"
       '\n'
-      'Append `:latest` to a dependency to require the latest available '
+      'Append `@<version>` to a dependency to require a specific version.\n'
+      '\n'
+      'Append `@latest` to a dependency to require the latest available '
       'version.\n'
       '\n'
-      'Append `:resolvable` to require the newest version resolvable with the '
+      'Append `@resolvable` to require the newest version resolvable with the '
       'rest of\n'
       'the dependency graph.';
   @override
-  String get argumentsDescription => '[dependencies[:latest|:resolvable]...]';
+  String get argumentsDescription =>
+      '[dependencies[@<version>|@latest|@resolvable]...]';
   @override
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-upgrade';
 
@@ -176,18 +179,28 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
         ),
       );
     }
-    if (_upgradeTargets.any((target) => target.kind != null)) {
+    final hasUpgradeTargetConstraints = _upgradeTargets.any(
+      (target) => target.kind != null,
+    );
+    if (hasUpgradeTargetConstraints) {
       if (_upgradeMajorVersions) {
         usageException(
-          'Cannot use `:latest` or `:resolvable` with `--major-versions`.',
+          'Cannot use `@<version>`, `@latest`, or `@resolvable` with '
+          '`--major-versions`.',
         );
       }
       if (_tighten) {
         usageException(
-          'Cannot use `:latest` or `:resolvable` with `--tighten`.',
+          'Cannot use `@<version>`, `@latest`, or `@resolvable` with '
+          '`--tighten`.',
         );
       }
-      _validateUpgradeTargetEntrypoints();
+    }
+    if (hasUpgradeTargetConstraints ||
+        (argResults.flag('unlock-transitive') && _upgradeTargets.isNotEmpty)) {
+      _validateUpgradeTargetEntrypoints(
+        validatePlainTargets: argResults.flag('unlock-transitive'),
+      );
     }
 
     if (_upgradeMajorVersions) {
@@ -247,9 +260,9 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
     if (argResults.flag('example')) ...entrypoint.examples,
   ];
 
-  void _validateUpgradeTargetEntrypoints() {
+  void _validateUpgradeTargetEntrypoints({required bool validatePlainTargets}) {
     for (final target in _upgradeTargets) {
-      if (target.kind == null) continue;
+      if (target.kind == null && !validatePlainTargets) continue;
       if (_entrypointsToUpgrade.any(
         (e) => _packageRef(e, target.name) != null,
       )) {
@@ -297,15 +310,24 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
 
       constraintFutures.add(
         (() async {
-          final targetPackage = switch (kind) {
-            _UpgradeTargetKind.latest => await _latest(e, target.name, ref),
-            _UpgradeTargetKind.resolvable => await latestResolvable(
-              target.name,
-            ),
-          };
+          late final PackageRange targetRange;
+          late final Version targetVersion;
+          switch (kind) {
+            case _UpgradeTargetKind.latest:
+              final targetPackage = await _latest(e, target.name, ref);
+              targetRange = targetPackage.toRange();
+              targetVersion = targetPackage.version;
+            case _UpgradeTargetKind.resolvable:
+              final targetPackage = await latestResolvable(target.name);
+              targetRange = targetPackage.toRange();
+              targetVersion = targetPackage.version;
+            case _UpgradeTargetKind.version:
+              targetVersion = target.version!;
+              targetRange = ref.withConstraint(targetVersion);
+          }
           return ConstraintAndCause(
-            targetPackage.toRange(),
-            '${targetPackage.name} ${targetPackage.version} was requested by '
+            targetRange,
+            '${targetRange.name} $targetVersion was requested by '
             '`$topLevelProgram pub upgrade ${target.argument}`.',
           );
         })(),
@@ -361,11 +383,24 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
   }
 
   _UpgradeTarget _parseUpgradeTarget(String argument) {
-    final parts = argument.split(':');
+    final oldStyleParts = argument.split(':');
+    if (oldStyleParts.length == 2 &&
+        packageNameRegExp.hasMatch(oldStyleParts.first) &&
+        (oldStyleParts.last == 'latest' ||
+            oldStyleParts.last == 'resolvable')) {
+      usageException(
+        'Unknown upgrade target `$argument`. Use `<package>`, '
+        '`<package>@<version>`, `<package>@latest`, or '
+        '`<package>@resolvable`.',
+      );
+    }
+
+    final parts = argument.split('@');
     if (parts.length > 2) {
       usageException(
         'Could not parse upgrade target `$argument`. Use `<package>`, '
-        '`<package>:latest`, or `<package>:resolvable`.',
+        '`<package>@<version>`, `<package>@latest`, or '
+        '`<package>@resolvable`.',
       );
     }
 
@@ -385,10 +420,20 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
       _ => null,
     };
     if (kind == null) {
-      usageException(
-        'Unknown upgrade target `$argument`. Use `<package>`, '
-        '`<package>:latest`, or `<package>:resolvable`.',
-      );
+      try {
+        return _UpgradeTarget(
+          argument,
+          package,
+          _UpgradeTargetKind.version,
+          Version.parse(suffix),
+        );
+      } on FormatException catch (_) {
+        usageException(
+          'Unknown upgrade target `$argument`. Use `<package>`, '
+          '`<package>@<version>`, `<package>@latest`, or '
+          '`<package>@resolvable`.',
+        );
+      }
     }
     return _UpgradeTarget(argument, package, kind);
   }
@@ -555,12 +600,13 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
   }
 }
 
-enum _UpgradeTargetKind { latest, resolvable }
+enum _UpgradeTargetKind { latest, resolvable, version }
 
 class _UpgradeTarget {
   final String argument;
   final String name;
   final _UpgradeTargetKind? kind;
+  final Version? version;
 
-  _UpgradeTarget(this.argument, this.name, this.kind);
+  _UpgradeTarget(this.argument, this.name, this.kind, [this.version]);
 }

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -28,7 +28,8 @@ class UpgradeCommand extends PubCommand {
   String get description =>
       "Upgrade the current package's dependencies to latest versions.\n"
       '\n'
-      'Append `@<version>` to a dependency to require a specific version.\n'
+      'Append `@<constraint>` to a dependency to require a specific version '
+      'constraint.\n'
       '\n'
       'Append `@latest` to a dependency to require the latest available '
       'version.\n'
@@ -38,7 +39,7 @@ class UpgradeCommand extends PubCommand {
       'the dependencies.';
   @override
   String get argumentsDescription =>
-      '[dependencies[@<version>|@latest|@resolvable]...]';
+      '[dependencies[@<constraint>|@latest|@resolvable]...]';
   @override
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-upgrade';
 
@@ -185,13 +186,13 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
     if (hasUpgradeTargetConstraints) {
       if (_upgradeMajorVersions) {
         usageException(
-          'Cannot use `@<version>`, `@latest`, or `@resolvable` with '
+          'Cannot use `@<constraint>`, `@latest`, or `@resolvable` with '
           '`--major-versions`.',
         );
       }
       if (_tighten) {
         usageException(
-          'Cannot use `@<version>`, `@latest`, or `@resolvable` with '
+          'Cannot use `@<constraint>`, `@latest`, or `@resolvable` with '
           '`--tighten`.',
         );
       }
@@ -311,23 +312,23 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
       constraintFutures.add(
         (() async {
           late final PackageRange targetRange;
-          late final Version targetVersion;
+          late final VersionConstraint targetConstraint;
           switch (kind) {
             case _UpgradeTargetKind.latest:
               final targetPackage = await _latest(e, target.name, ref);
               targetRange = targetPackage.toRange();
-              targetVersion = targetPackage.version;
+              targetConstraint = targetPackage.version;
             case _UpgradeTargetKind.resolvable:
               final targetPackage = await latestResolvable(target.name);
               targetRange = targetPackage.toRange();
-              targetVersion = targetPackage.version;
-            case _UpgradeTargetKind.version:
-              targetVersion = target.version!;
-              targetRange = ref.withConstraint(targetVersion);
+              targetConstraint = targetPackage.version;
+            case _UpgradeTargetKind.constraint:
+              targetConstraint = target.constraint!;
+              targetRange = ref.withConstraint(targetConstraint);
           }
           return ConstraintAndCause(
             targetRange,
-            '${targetRange.name} $targetVersion was requested by '
+            '${targetRange.name} $targetConstraint was requested by '
             '`$topLevelProgram pub upgrade ${target.argument}`.',
           );
         })(),
@@ -390,7 +391,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
             oldStyleParts.last == 'resolvable')) {
       usageException(
         'Unknown upgrade target `$argument`. Use `<package>`, '
-        '`<package>@<version>`, `<package>@latest`, or '
+        '`<package>@<constraint>`, `<package>@latest`, or '
         '`<package>@resolvable`.',
       );
     }
@@ -399,7 +400,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
     if (parts.length > 2) {
       usageException(
         'Could not parse upgrade target `$argument`. Use `<package>`, '
-        '`<package>@<version>`, `<package>@latest`, or '
+        '`<package>@<constraint>`, `<package>@latest`, or '
         '`<package>@resolvable`.',
       );
     }
@@ -424,13 +425,13 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
         return _UpgradeTarget(
           argument,
           package,
-          _UpgradeTargetKind.version,
-          Version.parse(suffix),
+          _UpgradeTargetKind.constraint,
+          VersionConstraint.parse(suffix),
         );
       } on FormatException catch (_) {
         usageException(
           'Unknown upgrade target `$argument`. Use `<package>`, '
-          '`<package>@<version>`, `<package>@latest`, or '
+          '`<package>@<constraint>`, `<package>@latest`, or '
           '`<package>@resolvable`.',
         );
       }
@@ -600,13 +601,13 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
   }
 }
 
-enum _UpgradeTargetKind { latest, resolvable, version }
+enum _UpgradeTargetKind { latest, resolvable, constraint }
 
 class _UpgradeTarget {
   final String argument;
   final String name;
   final _UpgradeTargetKind? kind;
-  final Version? version;
+  final VersionConstraint? constraint;
 
-  _UpgradeTarget(this.argument, this.name, this.kind, [this.version]);
+  _UpgradeTarget(this.argument, this.name, this.kind, [this.constraint]);
 }

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -464,9 +464,12 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
 
   Future<void> _runUpgradeMajorVersions() async {
     final toUpgrade = await _directDependenciesToUpgrade();
+    final upgradeTargetConstraints = await _upgradeTargetConstraints(
+      entrypoint,
+    );
     final resolvedPackages = await _computeLatestResolvablePackages(
       entrypoint,
-      additionalConstraints: await _upgradeTargetConstraints(entrypoint),
+      additionalConstraints: upgradeTargetConstraints,
     );
     final dependencyOverriddenDeps = <String>[];
     // Changes to be made to `pubspec.yaml` of each package.
@@ -516,6 +519,7 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
         entrypoint.workspaceRoot.transformWorkspace((package) {
           return applyChanges(package.pubspec, changes[package] ?? {});
         }),
+        additionalConstraints: upgradeTargetConstraints,
       );
       changes = entrypoint.tighten(
         packagesToUpgrade: await _rootPackagesToUpgrade,
@@ -546,6 +550,7 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
           dryRun: _dryRun,
           precompile: !_dryRun && _precompile,
           unlock: await _rootPackagesToUpgrade,
+          additionalConstraints: upgradeTargetConstraints,
         );
 
     // If any of the packages to upgrade are dependency overrides, then we

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -116,36 +116,43 @@ class UpgradeCommand extends PubCommand {
 
   bool get _precompile => argResults.flag('precompile');
 
-  late final Future<List<String>> _packagesToUpgrade =
-      _computePackagesToUpgrade();
+  late final Future<List<String>> _rootPackagesToUpgrade =
+      _computePackagesToUpgrade(entrypoint);
 
   late final List<_UpgradeTarget> _upgradeTargets =
       argResults.rest.map(_parseUpgradeTarget).toList();
-
-  late final Future<List<ConstraintAndCause>?> _additionalConstraints =
-      _upgradeTargetConstraints();
-
-  late final Future<Map<String, PackageId>> _latestResolvablePackages =
-      _computeLatestResolvablePackages();
 
   /// List of package names to upgrade, if empty then upgrade all packages.
   ///
   /// This allows the user to specify list of names that they want the
   /// upgrade command to affect.
-  Future<List<String>> _computePackagesToUpgrade() async {
+  Future<List<String>> _packagesToUpgrade(Entrypoint e) {
+    if (identical(e, entrypoint)) return _rootPackagesToUpgrade;
+    return _computePackagesToUpgrade(e);
+  }
+
+  Future<List<String>> _computePackagesToUpgrade(Entrypoint e) async {
     if (argResults.flag('unlock-transitive')) {
-      final graph = await entrypoint.packageGraph;
-      return _upgradeTargets
-          .expand(
-            (target) => graph
-                .transitiveDependencies(
-                  target.name,
-                  followDevDependenciesFromPackage: true,
-                )
-                .map((p) => p.name),
-          )
-          .toSet()
-          .toList();
+      final graph = await e.packageGraph;
+      final packagesToUnlock =
+          _upgradeTargets
+              .expand(
+                (target) =>
+                    graph.packages.containsKey(target.name)
+                        ? graph
+                            .transitiveDependencies(
+                              target.name,
+                              followDevDependenciesFromPackage: true,
+                            )
+                            .map((p) => p.name)
+                        : const <String>[],
+              )
+              .toSet()
+              .toList();
+      if (_upgradeTargets.isNotEmpty && packagesToUnlock.isEmpty) {
+        return _upgradeTargets.map((target) => target.name).toList();
+      }
+      return packagesToUnlock;
     } else {
       return _upgradeTargets.map((target) => target.name).toList();
     }
@@ -180,6 +187,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
           'Cannot use `:latest` or `:resolvable` with `--tighten`.',
         );
       }
+      _validateUpgradeTargetEntrypoints();
     }
 
     if (_upgradeMajorVersions) {
@@ -209,7 +217,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
           }
         }
         final changes = entrypoint.tighten(
-          packagesToUpgrade: await _packagesToUpgrade,
+          packagesToUpgrade: await _rootPackagesToUpgrade,
         );
         entrypoint.applyChanges(changes, _dryRun);
       }
@@ -224,8 +232,8 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
   Future<void> _runUpgrade(Entrypoint e, {bool onlySummary = false}) async {
     await e.acquireDependencies(
       SolveType.upgrade,
-      unlock: await _packagesToUpgrade,
-      additionalConstraints: await _additionalConstraints,
+      unlock: await _packagesToUpgrade(e),
+      additionalConstraints: await _upgradeTargetConstraints(e),
       dryRun: _dryRun,
       precompile: _precompile,
       summaryOnly: onlySummary,
@@ -234,17 +242,64 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
     _showOfflineWarning();
   }
 
-  Future<List<ConstraintAndCause>?> _upgradeTargetConstraints() async {
+  List<Entrypoint> get _entrypointsToUpgrade => [
+    entrypoint,
+    if (argResults.flag('example')) ...entrypoint.examples,
+  ];
+
+  void _validateUpgradeTargetEntrypoints() {
+    for (final target in _upgradeTargets) {
+      if (target.kind == null) continue;
+      if (_entrypointsToUpgrade.any(
+        (e) => _packageRef(e, target.name) != null,
+      )) {
+        continue;
+      }
+      final entrypoints =
+          argResults.flag('example')
+              ? 'the root package or any examples'
+              : 'the root package';
+      dataError(
+        'Package `${target.name}` is not in the current resolution. '
+        'It was not found in $entrypoints.',
+      );
+    }
+  }
+
+  Future<List<ConstraintAndCause>?> _upgradeTargetConstraints(
+    Entrypoint e,
+  ) async {
     final constraintFutures = <Future<ConstraintAndCause>>[];
+    Future<Map<String, PackageId>>? latestResolvablePackages;
+
+    Future<PackageId> latestResolvable(String package) async {
+      if (_packageRef(e, package) == null) {
+        dataError('Package `$package` is not in the current resolution.');
+      }
+      final packages =
+          await (latestResolvablePackages ??= _computeLatestResolvablePackages(
+            e,
+          ));
+      final latestResolvable = packages[package];
+      if (latestResolvable == null) {
+        dataError(
+          'Package `$package` is not in the latest resolvable resolution.',
+        );
+      }
+      return latestResolvable;
+    }
+
     for (final target in _upgradeTargets) {
       final kind = target.kind;
       if (kind == null) continue;
+      final ref = _packageRef(e, target.name);
+      if (ref == null) continue;
 
       constraintFutures.add(
         (() async {
           final targetPackage = switch (kind) {
-            _UpgradeTargetKind.latest => await _latest(target.name),
-            _UpgradeTargetKind.resolvable => await _latestResolvable(
+            _UpgradeTargetKind.latest => await _latest(e, target.name, ref),
+            _UpgradeTargetKind.resolvable => await latestResolvable(
               target.name,
             ),
           };
@@ -260,12 +315,14 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
     return constraints.isEmpty ? null : constraints;
   }
 
-  Future<Map<String, PackageId>> _computeLatestResolvablePackages() async {
+  Future<Map<String, PackageId>> _computeLatestResolvablePackages(
+    Entrypoint e,
+  ) async {
     final solveResult = await log.spinner('Resolving dependencies', () async {
       return await resolveVersions(
         SolveType.upgrade,
         cache,
-        entrypoint.workspaceRoot.transformWorkspace(
+        e.workspaceRoot.transformWorkspace(
           (package) => stripVersionBounds(package.pubspec),
         ),
       );
@@ -273,43 +330,33 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
     return {for (final package in solveResult.packages) package.name: package};
   }
 
-  Future<PackageId> _latestResolvable(String package) async {
-    if (_packageRef(package) == null) {
-      dataError('Package `$package` is not in the current resolution.');
-    }
-    final latestResolvable = (await _latestResolvablePackages)[package];
-    if (latestResolvable == null) {
-      dataError(
-        'Package `$package` is not in the latest resolvable resolution.',
-      );
-    }
-    return latestResolvable;
-  }
-
-  Future<PackageId> _latest(String package) async {
-    final ref = _packageRef(package);
-    if (ref == null) {
-      dataError('Package `$package` is not in the current resolution.');
-    }
-    final current = entrypoint.lockFile.packages[package];
-    final latest = await cache.getLatest(ref, version: current?.version);
+  Future<PackageId> _latest(
+    Entrypoint e,
+    String package,
+    PackageRef ref,
+  ) async {
+    final current = e.lockFile.packages[package];
+    final currentVersionForRef =
+        current?.toRef() == ref ? current?.version : null;
+    final latest = await cache.getLatest(ref, version: currentVersionForRef);
     if (latest == null) {
       dataError('Could not find package `$package`.');
     }
     return latest;
   }
 
-  PackageRef? _packageRef(String package) {
-    final current = entrypoint.lockFile.packages[package];
-    if (current != null) return current.toRef();
+  PackageRef? _packageRef(Entrypoint e, String package) {
+    final override = e.workspaceRoot.allOverridesInWorkspace[package];
+    if (override != null) return override.toRef();
 
-    for (final workspacePackage
-        in entrypoint.workspaceRoot.transitiveWorkspace) {
+    for (final workspacePackage in e.workspaceRoot.transitiveWorkspace) {
       final dependency = workspacePackage.dependencies[package];
       if (dependency != null) return dependency.toRef();
       final devDependency = workspacePackage.devDependencies[package];
       if (devDependency != null) return devDependency.toRef();
     }
+    final current = e.lockFile.packages[package];
+    if (current != null) return current.toRef();
     return null;
   }
 
@@ -362,7 +409,7 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
             ...package.devDependencies.keys,
           ],
         }.toList();
-    final packagesToUpgrade = await _packagesToUpgrade;
+    final packagesToUpgrade = await _rootPackagesToUpgrade;
     final toUpgrade =
         packagesToUpgrade.isEmpty ? directDeps : packagesToUpgrade;
 
@@ -382,7 +429,7 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
 
   Future<void> _runUpgradeMajorVersions() async {
     final toUpgrade = await _directDependenciesToUpgrade();
-    final resolvedPackages = await _latestResolvablePackages;
+    final resolvedPackages = await _computeLatestResolvablePackages(entrypoint);
     final dependencyOverriddenDeps = <String>[];
     // Changes to be made to `pubspec.yaml` of each package.
     // Mapping from original to changed value.
@@ -433,7 +480,7 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
         }),
       );
       changes = entrypoint.tighten(
-        packagesToUpgrade: await _packagesToUpgrade,
+        packagesToUpgrade: await _rootPackagesToUpgrade,
         existingChanges: changes,
         packageVersions: solveResult.packages,
       );
@@ -445,7 +492,9 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
     // But without a specific package we want to get as many non-major updates
     // as possible (SolveType.upgrade).
     final solveType =
-        (await _packagesToUpgrade).isEmpty ? SolveType.upgrade : SolveType.get;
+        (await _rootPackagesToUpgrade).isEmpty
+            ? SolveType.upgrade
+            : SolveType.get;
 
     entrypoint.applyChanges(changes, _dryRun);
     await entrypoint
@@ -458,7 +507,7 @@ be direct 'dependencies' or 'dev_dependencies', following packages are not:
           solveType,
           dryRun: _dryRun,
           precompile: !_dryRun && _precompile,
-          unlock: await _packagesToUpgrade,
+          unlock: await _rootPackagesToUpgrade,
         );
 
     // If any of the packages to upgrade are dependency overrides, then we

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -28,7 +28,7 @@ class UpgradeCommand extends PubCommand {
   String get description =>
       "Upgrade the current package's dependencies to latest versions.\n"
       '\n'
-      'Append `@<constraint>` to a dependency to require a specific version '
+      'Append `@<constraint>` to a dependency to require a version '
       'constraint.\n'
       '\n'
       'Append `@latest` to a dependency to require the latest available '
@@ -270,24 +270,19 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
   Future<List<ConstraintAndCause>?> _upgradeTargetConstraints(
     Entrypoint e,
   ) async {
-    final constraintFutures = <Future<ConstraintAndCause>>[];
-    Future<Map<String, PackageId>>? latestResolvablePackages;
+    final constraints = <ConstraintAndCause>[];
+    final resolvableTargets = <_UpgradeTarget>[];
 
-    Future<PackageId> latestResolvable(String package) async {
-      if (_packageRef(e, package) == null) {
-        dataError('Package `$package` is not in the current resolution.');
-      }
-      final packages =
-          await (latestResolvablePackages ??= _computeLatestResolvablePackages(
-            e,
-          ));
-      final latestResolvable = packages[package];
-      if (latestResolvable == null) {
-        dataError(
-          'Package `$package` is not in the latest resolvable resolution.',
-        );
-      }
-      return latestResolvable;
+    ConstraintAndCause constraintAndCause(
+      PackageRange targetRange,
+      VersionConstraint targetConstraint,
+      String argument,
+    ) {
+      return ConstraintAndCause(
+        targetRange,
+        '${targetRange.name} $targetConstraint was requested by '
+        '`$topLevelProgram pub upgrade $argument`.',
+      );
     }
 
     for (final target in _upgradeTargets) {
@@ -296,32 +291,56 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
       final ref = _packageRef(e, target.name);
       if (ref == null) continue;
 
-      constraintFutures.add(
-        (() async {
-          late final PackageRange targetRange;
-          late final VersionConstraint targetConstraint;
-          switch (kind) {
-            case _UpgradeTargetKind.latest:
-              final targetPackage = await _latest(e, target.name, ref);
-              targetRange = targetPackage.toRange();
-              targetConstraint = targetPackage.version;
-            case _UpgradeTargetKind.resolvable:
-              final targetPackage = await latestResolvable(target.name);
-              targetRange = targetPackage.toRange();
-              targetConstraint = targetPackage.version;
-            case _UpgradeTargetKind.constraint:
-              targetConstraint = target.constraint!;
-              targetRange = ref.withConstraint(targetConstraint);
-          }
-          return ConstraintAndCause(
-            targetRange,
-            '${targetRange.name} $targetConstraint was requested by '
-            '`$topLevelProgram pub upgrade ${target.argument}`.',
+      switch (kind) {
+        case _UpgradeTargetKind.latest:
+          final targetPackage = await _latest(e, target.name, ref);
+          constraints.add(
+            constraintAndCause(
+              targetPackage.toRange(),
+              targetPackage.version,
+              target.argument,
+            ),
           );
-        })(),
-      );
+        case _UpgradeTargetKind.resolvable:
+          resolvableTargets.add(target);
+        case _UpgradeTargetKind.constraint:
+          final targetConstraint = target.constraint!;
+          constraints.add(
+            constraintAndCause(
+              ref.withConstraint(targetConstraint),
+              targetConstraint,
+              target.argument,
+            ),
+          );
+      }
     }
-    final constraints = await Future.wait(constraintFutures);
+
+    if (resolvableTargets.isNotEmpty) {
+      final packages = await _computeLatestResolvablePackages(
+        e,
+        additionalConstraints:
+            constraints.isEmpty
+                ? null
+                : List<ConstraintAndCause>.of(constraints),
+      );
+      for (final target in resolvableTargets) {
+        final targetPackage = packages[target.name];
+        if (targetPackage == null) {
+          dataError(
+            'Package `${target.name}` is not in the latest resolvable '
+            'resolution.',
+          );
+        }
+        constraints.add(
+          constraintAndCause(
+            targetPackage.toRange(),
+            targetPackage.version,
+            target.argument,
+          ),
+        );
+      }
+    }
+
     return constraints.isEmpty ? null : constraints;
   }
 
@@ -449,8 +468,10 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
         packagesToUpgrade.isEmpty ? directDeps : packagesToUpgrade;
 
     // Check that all package names in upgradeOnly are direct-dependencies
-    final notInDeps = toUpgrade.where((n) => !directDeps.contains(n));
-    if (argResults.rest.any(notInDeps.contains)) {
+    final notInDeps = _upgradeTargets
+        .map((target) => target.name)
+        .where((n) => !directDeps.contains(n));
+    if (notInDeps.isNotEmpty) {
       usageException('''
 Dependencies specified in `$topLevelProgram pub upgrade --major-versions <dependencies>` must
 be direct 'dependencies' or 'dev_dependencies', following packages are not:

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -35,7 +35,7 @@ class UpgradeCommand extends PubCommand {
       '\n'
       'Append `@resolvable` to require the newest version resolvable with the '
       'rest of\n'
-      'the dependency graph.';
+      'the dependencies.';
   @override
   String get argumentsDescription =>
       '[dependencies[@<version>|@latest|@resolvable]...]';

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -35,6 +35,7 @@ import 'sdk/flutter.dart';
 import 'solver.dart';
 import 'solver/report.dart';
 import 'solver/solve_suggestions.dart';
+import 'solver/version_solver.dart';
 import 'source/cached.dart';
 import 'source/hosted.dart';
 import 'source/root.dart';
@@ -575,6 +576,7 @@ See $workspacesDocUrl for more information.''',
   Future<void> acquireDependencies(
     SolveType type, {
     Iterable<String> unlock = const [],
+    Iterable<ConstraintAndCause>? additionalConstraints,
     bool dryRun = false,
     bool precompile = false,
     bool summaryOnly = false,
@@ -608,6 +610,7 @@ Try running `$topLevelProgram pub get` to create `$lockFilePath`.''');
           workspaceRoot,
           lockFile: lockFile,
           unlock: unlock,
+          additionalConstraints: additionalConstraints,
         );
       });
     } on SolveFailure catch (e) {

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -557,6 +557,10 @@ See $workspacesDocUrl for more information.''',
   /// The iterable [unlock] specifies the list of packages whose versions can be
   /// changed even if they are locked in the pubspec.lock file.
   ///
+  /// The iterable [additionalConstraints] specifies extra constraints the
+  /// version solver must satisfy. When omitted, no extra constraints are
+  /// applied.
+  ///
   /// Shows a report of the changes made relative to the previous lockfile. If
   /// this is an upgrade or downgrade, all transitive dependencies are shown in
   /// the report. Otherwise, only dependencies that were changed are shown. If

--- a/test/testdata/goldens/help_test/pub upgrade --help.txt
+++ b/test/testdata/goldens/help_test/pub upgrade --help.txt
@@ -4,7 +4,7 @@
 $ pub upgrade --help
 Upgrade the current package's dependencies to latest versions.
 
-Usage: pub upgrade [dependencies...]
+Usage: pub upgrade [dependencies[:latest|:resolvable]...]
 -h, --help                 Print this usage information.
     --[no-]offline         Use cached packages instead of accessing the network.
 -n, --dry-run              Report what dependencies would change but don't change any.

--- a/test/testdata/goldens/help_test/pub upgrade --help.txt
+++ b/test/testdata/goldens/help_test/pub upgrade --help.txt
@@ -9,7 +9,7 @@ Append `@<version>` to a dependency to require a specific version.
 Append `@latest` to a dependency to require the latest available version.
 
 Append `@resolvable` to require the newest version resolvable with the rest of
-the dependency graph.
+the dependencies.
 
 Usage: pub upgrade [dependencies[@<version>|@latest|@resolvable]...]
 -h, --help                 Print this usage information.

--- a/test/testdata/goldens/help_test/pub upgrade --help.txt
+++ b/test/testdata/goldens/help_test/pub upgrade --help.txt
@@ -4,14 +4,14 @@
 $ pub upgrade --help
 Upgrade the current package's dependencies to latest versions.
 
-Append `@<version>` to a dependency to require a specific version.
+Append `@<constraint>` to a dependency to require a specific version constraint.
 
 Append `@latest` to a dependency to require the latest available version.
 
 Append `@resolvable` to require the newest version resolvable with the rest of
 the dependencies.
 
-Usage: pub upgrade [dependencies[@<version>|@latest|@resolvable]...]
+Usage: pub upgrade [dependencies[@<constraint>|@latest|@resolvable]...]
 -h, --help                 Print this usage information.
     --[no-]offline         Use cached packages instead of accessing the network.
 -n, --dry-run              Report what dependencies would change but don't change any.

--- a/test/testdata/goldens/help_test/pub upgrade --help.txt
+++ b/test/testdata/goldens/help_test/pub upgrade --help.txt
@@ -4,6 +4,11 @@
 $ pub upgrade --help
 Upgrade the current package's dependencies to latest versions.
 
+Append `:latest` to a dependency to require the latest available version.
+
+Append `:resolvable` to require the newest version resolvable with the rest of
+the dependency graph.
+
 Usage: pub upgrade [dependencies[:latest|:resolvable]...]
 -h, --help                 Print this usage information.
     --[no-]offline         Use cached packages instead of accessing the network.

--- a/test/testdata/goldens/help_test/pub upgrade --help.txt
+++ b/test/testdata/goldens/help_test/pub upgrade --help.txt
@@ -4,12 +4,14 @@
 $ pub upgrade --help
 Upgrade the current package's dependencies to latest versions.
 
-Append `:latest` to a dependency to require the latest available version.
+Append `@<version>` to a dependency to require a specific version.
 
-Append `:resolvable` to require the newest version resolvable with the rest of
+Append `@latest` to a dependency to require the latest available version.
+
+Append `@resolvable` to require the newest version resolvable with the rest of
 the dependency graph.
 
-Usage: pub upgrade [dependencies[:latest|:resolvable]...]
+Usage: pub upgrade [dependencies[@<version>|@latest|@resolvable]...]
 -h, --help                 Print this usage information.
     --[no-]offline         Use cached packages instead of accessing the network.
 -n, --dry-run              Report what dependencies would change but don't change any.

--- a/test/testdata/goldens/help_test/pub upgrade --help.txt
+++ b/test/testdata/goldens/help_test/pub upgrade --help.txt
@@ -4,7 +4,7 @@
 $ pub upgrade --help
 Upgrade the current package's dependencies to latest versions.
 
-Append `@<constraint>` to a dependency to require a specific version constraint.
+Append `@<constraint>` to a dependency to require a version constraint.
 
 Append `@latest` to a dependency to require the latest available version.
 

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -5,6 +5,7 @@
 @TestOn('vm')
 library;
 
+import 'package:pub/src/exit_codes.dart' as exit_codes;
 import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
@@ -104,4 +105,146 @@ void main() {
       ),
     );
   });
+
+  test('`dependency:latest` explains why latest cannot be selected', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
+    server.serve('bar', '1.0.0');
+
+    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+    await pubGet(output: contains('+ foo 1.0.0'));
+
+    server.serve('bar', '2.0.0');
+
+    await pubUpgrade(
+      args: ['bar:latest'],
+      error: allOf(
+        contains('bar 2.0.0'),
+        contains('bar:latest'),
+        contains('foo'),
+        contains('bar ^1.0.0'),
+        contains('version solving failed'),
+      ),
+    );
+  });
+
+  test(
+    '`dependency:latest` upgrades a transitive dependency to latest',
+    () async {
+      final server = await servePackages();
+      server.serve('foo', '1.0.0', deps: {'bar': 'any'});
+      server.serve('bar', '1.0.0');
+
+      await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+      await pubGet(output: contains('+ foo 1.0.0'));
+
+      server.serve('bar', '2.0.0');
+
+      await pubUpgrade(args: ['bar:latest'], output: contains('> bar 2.0.0'));
+    },
+  );
+
+  test('`dependency:resolvable` upgrades a transitive dependency to latest '
+      'resolvable', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
+    server.serve('bar', '1.0.0');
+
+    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+    await pubGet(output: contains('+ foo 1.0.0'));
+
+    server.serve('bar', '1.5.0');
+    server.serve('bar', '2.0.0');
+
+    await pubUpgrade(
+      args: ['bar:resolvable'],
+      output: allOf(contains('> bar 1.5.0'), isNot(contains('bar 2.0.0'))),
+    );
+  });
+
+  test(
+    '`dependency:resolvable` explains why resolvable cannot be selected',
+    () async {
+      final server = await servePackages();
+      server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
+      server.serve('foo', '2.0.0', deps: {'bar': '^2.0.0'});
+      server.serve('bar', '1.0.0');
+
+      await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+      await pubGet(output: contains('+ foo 1.0.0'));
+
+      server.serve('bar', '2.0.0');
+
+      await pubUpgrade(
+        args: ['bar:resolvable'],
+        error: allOf(
+          contains('bar 2.0.0'),
+          contains('bar:resolvable'),
+          contains('foo'),
+          contains('bar ^1.0.0'),
+          contains('version solving failed'),
+        ),
+      );
+    },
+  );
+
+  test('multiple dependency targets resolve together', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0', deps: {'bar': 'any', 'baz': '^1.0.0'});
+    server.serve('bar', '1.0.0');
+    server.serve('baz', '1.0.0');
+
+    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+    await pubGet(output: contains('+ foo 1.0.0'));
+
+    server.serve('foo', '1.5.0', deps: {'bar': 'any', 'baz': '^1.0.0'});
+    server.serve('bar', '2.0.0');
+    server.serve('baz', '1.5.0');
+    server.serve('baz', '2.0.0');
+
+    await pubUpgrade(
+      args: ['foo', 'bar:latest', 'baz:resolvable'],
+      output: allOf(
+        contains('> foo 1.5.0'),
+        contains('> bar 2.0.0'),
+        contains('> baz 1.5.0'),
+        isNot(contains('baz 2.0.0')),
+      ),
+    );
+  });
+
+  test(
+    '`dependency:latest` requires a package from the current resolution',
+    () async {
+      await servePackages();
+      await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+      await pubUpgrade(
+        args: ['missing:latest'],
+        error: contains('Package `missing` is not in the current resolution.'),
+        exitCode: exit_codes.DATA,
+      );
+    },
+  );
+
+  test(
+    '`dependency:latest` cannot be combined with --major-versions',
+    () async {
+      await servePackages();
+      await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+      await pubUpgrade(
+        args: ['--major-versions', 'foo:latest'],
+        error: contains(
+          'Cannot use `:latest` or `:resolvable` with `--major-versions`.',
+        ),
+        exitCode: exit_codes.USAGE,
+      );
+    },
+  );
 }

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -106,7 +106,7 @@ void main() {
     );
   });
 
-  test('`dependency:latest` explains why latest cannot be selected', () async {
+  test('`dependency@latest` explains why latest cannot be selected', () async {
     final server = await servePackages();
     server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
     server.serve('bar', '1.0.0');
@@ -118,10 +118,10 @@ void main() {
     server.serve('bar', '2.0.0');
 
     await pubUpgrade(
-      args: ['bar:latest'],
+      args: ['bar@latest'],
       error: allOf(
         contains('bar 2.0.0'),
-        contains('bar:latest'),
+        contains('bar@latest'),
         contains('foo'),
         contains('bar ^1.0.0'),
         contains('version solving failed'),
@@ -130,7 +130,7 @@ void main() {
   });
 
   test(
-    '`dependency:latest` upgrades a transitive dependency to latest',
+    '`dependency@latest` upgrades a transitive dependency to latest',
     () async {
       final server = await servePackages();
       server.serve('foo', '1.0.0', deps: {'bar': 'any'});
@@ -142,11 +142,11 @@ void main() {
 
       server.serve('bar', '2.0.0');
 
-      await pubUpgrade(args: ['bar:latest'], output: contains('> bar 2.0.0'));
+      await pubUpgrade(args: ['bar@latest'], output: contains('> bar 2.0.0'));
     },
   );
 
-  test('`dependency:resolvable` upgrades a transitive dependency to latest '
+  test('`dependency@resolvable` upgrades a transitive dependency to latest '
       'resolvable', () async {
     final server = await servePackages();
     server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
@@ -160,13 +160,78 @@ void main() {
     server.serve('bar', '2.0.0');
 
     await pubUpgrade(
-      args: ['bar:resolvable'],
+      args: ['bar@resolvable'],
       output: allOf(contains('> bar 1.5.0'), isNot(contains('bar 2.0.0'))),
     );
   });
 
   test(
-    '`dependency:resolvable` explains why resolvable cannot be selected',
+    '`dependency@version` upgrades a transitive dependency to that version',
+    () async {
+      final server = await servePackages();
+      server.serve('foo', '1.0.0', deps: {'bar': 'any'});
+      server.serve('bar', '1.0.0');
+
+      await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+      await pubGet(output: contains('+ foo 1.0.0'));
+
+      server.serve('bar', '1.5.0');
+      server.serve('bar', '2.0.0');
+
+      await pubUpgrade(
+        args: ['bar@1.5.0'],
+        output: allOf(contains('> bar 1.5.0'), isNot(contains('bar 2.0.0'))),
+      );
+    },
+  );
+
+  test('`dependency@version` can target a pre-release version', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0', deps: {'bar': 'any'});
+    server.serve('bar', '1.0.0');
+
+    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+    await pubGet(output: contains('+ foo 1.0.0'));
+
+    server.serve('bar', '1.5.0-beta');
+    server.serve('bar', '2.0.0');
+
+    await pubUpgrade(
+      args: ['bar@1.5.0-beta'],
+      output: allOf(contains('> bar 1.5.0-beta'), isNot(contains('bar 2.0.0'))),
+    );
+  });
+
+  test(
+    '`dependency@version` explains why that version cannot be selected',
+    () async {
+      final server = await servePackages();
+      server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
+      server.serve('bar', '1.0.0');
+
+      await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+      await pubGet(output: contains('+ foo 1.0.0'));
+
+      server.serve('bar', '2.0.0');
+
+      await pubUpgrade(
+        args: ['bar@2.0.0'],
+        error: allOf(
+          contains('bar 2.0.0'),
+          contains('bar@2.0.0'),
+          contains('foo'),
+          contains('bar ^1.0.0'),
+          contains('version solving failed'),
+        ),
+      );
+    },
+  );
+
+  test(
+    '`dependency@resolvable` explains why resolvable cannot be selected',
     () async {
       final server = await servePackages();
       server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
@@ -180,10 +245,10 @@ void main() {
       server.serve('bar', '2.0.0');
 
       await pubUpgrade(
-        args: ['bar:resolvable'],
+        args: ['bar@resolvable'],
         error: allOf(
           contains('bar 2.0.0'),
-          contains('bar:resolvable'),
+          contains('bar@resolvable'),
           contains('foo'),
           contains('bar ^1.0.0'),
           contains('version solving failed'),
@@ -208,7 +273,7 @@ void main() {
     server.serve('baz', '2.0.0');
 
     await pubUpgrade(
-      args: ['foo', 'bar:latest', 'baz:resolvable'],
+      args: ['foo', 'bar@latest', 'baz@resolvable'],
       output: allOf(
         contains('> foo 1.5.0'),
         contains('> bar 2.0.0'),
@@ -218,7 +283,7 @@ void main() {
     );
   });
 
-  test('`dependency:latest` is resolved separately for examples', () async {
+  test('`dependency@latest` is resolved separately for examples', () async {
     final server = await servePackages();
     server.serve('bar', '1.0.0');
 
@@ -240,7 +305,7 @@ void main() {
     server.serve('bar', '1.5.0');
 
     await pubUpgrade(
-      args: ['--example', 'bar:latest'],
+      args: ['--example', 'bar@latest'],
       output: contains('> bar 1.5.0'),
     );
 
@@ -254,7 +319,7 @@ void main() {
     ]).validate();
   });
 
-  test('`dependency:latest` can target an example-only dependency', () async {
+  test('`dependency@latest` can target an example-only dependency', () async {
     final server = await servePackages();
     server.serve('bar', '1.0.0');
 
@@ -273,7 +338,7 @@ void main() {
     server.serve('bar', '2.0.0');
 
     await pubUpgrade(
-      args: ['--example', 'bar:latest'],
+      args: ['--example', 'bar@latest'],
       output: contains('Got dependencies in'),
     );
 
@@ -310,7 +375,7 @@ void main() {
     server.serve('bar', '1.5.0');
 
     await pubUpgrade(
-      args: ['--example', '--unlock-transitive', 'foo:latest'],
+      args: ['--example', '--unlock-transitive', 'foo@latest'],
       output: contains('Got dependencies in'),
     );
 
@@ -352,7 +417,7 @@ void main() {
     server.serve('example_dep', '2.0.0');
 
     await pubUpgrade(
-      args: ['--example', '--unlock-transitive', 'foo:latest'],
+      args: ['--example', '--unlock-transitive', 'foo@latest'],
       output: allOf(contains('> foo 1.5.0'), contains('Got dependencies in')),
     );
 
@@ -366,7 +431,29 @@ void main() {
     ]).validate();
   });
 
-  test('`dependency:latest` uses the dependency source from pubspec', () async {
+  test(
+    '`--unlock-transitive` rejects unknown packages in mixed targets',
+    () async {
+      final server = await servePackages();
+      server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
+      server.serve('bar', '1.0.0');
+
+      await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+      await pubGet(output: contains('+ foo 1.0.0'));
+
+      await pubUpgrade(
+        args: ['--no-example', '--unlock-transitive', 'foo', 'missing'],
+        error: allOf(
+          contains('Package `missing` is not in the current resolution.'),
+          contains('It was not found in the root package.'),
+        ),
+        exitCode: exit_codes.DATA,
+      );
+    },
+  );
+
+  test('`dependency@latest` uses the dependency source from pubspec', () async {
     final server = await servePackages();
     server.serve('bar', '1.0.0');
     server.serve('bar', '1.5.0');
@@ -389,7 +476,7 @@ void main() {
         .create();
 
     await pubUpgrade(
-      args: ['bar:latest'],
+      args: ['bar@latest'],
       output: contains('* bar 2.0.0 from path'),
     );
 
@@ -401,7 +488,7 @@ void main() {
     ]).validate();
   });
 
-  test('`dependency:latest` uses the dependency override source', () async {
+  test('`dependency@latest` uses the dependency override source', () async {
     final server = await servePackages();
     server.serve('bar', '1.0.0');
     server.serve('bar', '2.0.0');
@@ -425,7 +512,7 @@ void main() {
     await pubGet();
 
     await pubUpgrade(
-      args: ['bar:latest'],
+      args: ['bar@latest'],
       output: contains('No dependencies changed.'),
     );
 
@@ -438,20 +525,20 @@ void main() {
   });
 
   test(
-    '`dependency:latest` requires a package from the current resolution',
+    '`dependency@latest` requires a package from the current resolution',
     () async {
       await servePackages();
       await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
 
       await pubUpgrade(
-        args: ['missing:latest'],
+        args: ['missing@latest'],
         error: contains('Package `missing` is not in the current resolution.'),
         exitCode: exit_codes.DATA,
       );
     },
   );
 
-  test('`dependency:latest` requires a package from the current resolution '
+  test('`dependency@latest` requires a package from the current resolution '
       'with examples', () async {
     await servePackages();
     await d.dir(appPath, [
@@ -462,7 +549,7 @@ void main() {
     ]).create();
 
     await pubUpgrade(
-      args: ['--example', 'missing:latest'],
+      args: ['--example', 'missing@latest'],
       error: allOf(
         contains('Package `missing` is not in the current resolution.'),
         contains('It was not found in the root package or any examples.'),
@@ -472,32 +559,96 @@ void main() {
   });
 
   test(
-    '`dependency:latest` cannot be combined with --major-versions',
+    '`dependency@latest` cannot be combined with --major-versions',
     () async {
       await servePackages();
       await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
 
       await pubUpgrade(
-        args: ['--major-versions', 'foo:latest'],
+        args: ['--major-versions', 'foo@latest'],
         error: contains(
-          'Cannot use `:latest` or `:resolvable` with `--major-versions`.',
+          'Cannot use `@<version>`, `@latest`, or `@resolvable` with '
+          '`--major-versions`.',
         ),
         exitCode: exit_codes.USAGE,
       );
     },
   );
 
-  test('dependency target cannot contain multiple colons', () async {
+  test('`dependency@version` cannot be combined with --tighten', () async {
     await servePackages();
     await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
 
     await pubUpgrade(
-      args: ['foo:bar:latest'],
+      args: ['--tighten', 'foo@1.0.0'],
+      error: contains(
+        'Cannot use `@<version>`, `@latest`, or `@resolvable` with '
+        '`--tighten`.',
+      ),
+      exitCode: exit_codes.USAGE,
+    );
+  });
+
+  test('dependency target uses @ instead of colon', () async {
+    await servePackages();
+    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+    for (final target in [
+      'foo:latest',
+      'foo:resolvable',
+      'foo_bar:latest',
+      'foo_bar:resolvable',
+    ]) {
+      await pubUpgrade(
+        args: [target],
+        error: allOf(
+          contains('Unknown upgrade target `$target`.'),
+          contains('Use `<package>`'),
+          contains('`<package>@<version>`'),
+          contains('`<package>@latest`'),
+          contains('`<package>@resolvable`.'),
+        ),
+        exitCode: exit_codes.USAGE,
+      );
+    }
+  });
+
+  test('dependency target requires a valid suffix after @', () async {
+    await servePackages();
+    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+    for (final target in [
+      'foo@',
+      'foo@Latest',
+      'foo@not-a-version',
+      'foo@^1.0.0',
+    ]) {
+      await pubUpgrade(
+        args: [target],
+        error: allOf(
+          contains('Unknown upgrade target `$target`.'),
+          contains('Use `<package>`'),
+          contains('`<package>@<version>`'),
+          contains('`<package>@latest`'),
+          contains('`<package>@resolvable`.'),
+        ),
+        exitCode: exit_codes.USAGE,
+      );
+    }
+  });
+
+  test('dependency target cannot contain multiple @ separators', () async {
+    await servePackages();
+    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+    await pubUpgrade(
+      args: ['foo@bar@latest'],
       error: allOf(
-        contains('Could not parse upgrade target `foo:bar:latest`.'),
+        contains('Could not parse upgrade target `foo@bar@latest`.'),
         contains('Use `<package>`'),
-        contains('`<package>:latest`'),
-        contains('`<package>:resolvable`.'),
+        contains('`<package>@<version>`'),
+        contains('`<package>@latest`'),
+        contains('`<package>@resolvable`.'),
       ),
       exitCode: exit_codes.USAGE,
     );

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -558,7 +558,29 @@ void main() {
     );
   });
 
-  test('`dependency@constraint` can be combined with --major-versions', () async {
+  test(
+    '`dependency@constraint` can be combined with --major-versions',
+    () async {
+      final server = await servePackages();
+      server.serve('bar', '1.0.0');
+
+      await d.appDir(dependencies: {'bar': '^1.0.0'}).create();
+
+      await pubGet();
+
+      server.serve('bar', '2.0.0');
+      server.serve('bar', '3.0.0');
+
+      await pubUpgrade(
+        args: ['--major-versions', 'bar@^2.0.0'],
+        output: contains('> bar 2.0.0'),
+      );
+
+      await d.appDir(dependencies: {'bar': '^2.0.0'}).validate();
+    },
+  );
+
+  test('`dependency@latest` can be combined with --major-versions', () async {
     final server = await servePackages();
     server.serve('bar', '1.0.0');
 
@@ -566,22 +588,50 @@ void main() {
 
     await pubGet();
 
+    server.serve('bar', '1.5.0');
     server.serve('bar', '2.0.0');
     server.serve('bar', '3.0.0');
 
     await pubUpgrade(
-      args: ['--major-versions', 'bar@^2.0.0'],
-      output: contains('> bar 2.0.0'),
+      args: ['--major-versions', 'bar@latest'],
+      output: contains('> bar 3.0.0'),
     );
 
-    await d.appDir(dependencies: {'bar': '^2.0.0'}).validate();
+    await d.appDir(dependencies: {'bar': '^3.0.0'}).validate();
   });
+
+  test(
+    '`dependency@resolvable` can be combined with --major-versions',
+    () async {
+      final server = await servePackages();
+      server.serve('bar', '1.0.0', deps: {'baz': '^1.0.0'});
+      server.serve('baz', '1.0.0');
+      server.serve('qux', '1.0.0', deps: {'baz': '^1.0.0'});
+
+      await d.appDir(dependencies: {'bar': '^1.0.0', 'qux': '^1.0.0'}).create();
+
+      await pubGet();
+
+      server.serve('bar', '2.0.0', deps: {'baz': '^1.0.0'});
+      server.serve('bar', '3.0.0', deps: {'baz': '^2.0.0'});
+      server.serve('baz', '2.0.0');
+
+      await pubUpgrade(
+        args: ['--major-versions', 'bar@resolvable'],
+        output: allOf(contains('> bar 2.0.0'), isNot(contains('bar 3.0.0'))),
+      );
+
+      await d
+          .appDir(dependencies: {'bar': '^2.0.0', 'qux': '^1.0.0'})
+          .validate();
+    },
+  );
 
   test('`dependency@constraint` can be combined with --tighten', () async {
     final server = await servePackages();
     server.serve('foo', '1.0.0');
 
-    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+    await d.appDir(dependencies: {'foo': 'any'}).create();
 
     await pubGet();
 
@@ -590,10 +640,53 @@ void main() {
 
     await pubUpgrade(
       args: ['--tighten', 'foo@<2.0.0'],
-      output: contains('> foo 1.5.0'),
+      output: allOf(contains('> foo 1.5.0'), isNot(contains('foo 2.0.0'))),
     );
 
     await d.appDir(dependencies: {'foo': '^1.5.0'}).validate();
+  });
+
+  test('`dependency@latest` can be combined with --tighten', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0');
+
+    await d.appDir(dependencies: {'foo': '>=1.0.0 <3.0.0'}).create();
+
+    await pubGet();
+
+    server.serve('foo', '1.5.0');
+    server.serve('foo', '2.0.0');
+
+    await pubUpgrade(
+      args: ['--tighten', 'foo@latest'],
+      output: contains('> foo 2.0.0'),
+    );
+
+    await d.appDir(dependencies: {'foo': '^2.0.0'}).validate();
+  });
+
+  test('`dependency@resolvable` can be combined with --tighten', () async {
+    final server = await servePackages();
+    server.serve('bar', '1.0.0', deps: {'baz': '^1.0.0'});
+    server.serve('baz', '1.0.0');
+    server.serve('qux', '1.0.0', deps: {'baz': '^1.0.0'});
+
+    await d
+        .appDir(dependencies: {'bar': '>=1.0.0 <3.0.0', 'qux': '^1.0.0'})
+        .create();
+
+    await pubGet();
+
+    server.serve('bar', '2.0.0', deps: {'baz': '^1.0.0'});
+    server.serve('bar', '3.0.0', deps: {'baz': '^2.0.0'});
+    server.serve('baz', '2.0.0');
+
+    await pubUpgrade(
+      args: ['--tighten', 'bar@resolvable'],
+      output: allOf(contains('> bar 2.0.0'), isNot(contains('bar 3.0.0'))),
+    );
+
+    await d.appDir(dependencies: {'bar': '^2.0.0', 'qux': '^1.0.0'}).validate();
   });
 
   test('dependency target uses @ instead of colon', () async {

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -81,6 +81,32 @@ void main() {
     },
   );
 
+  test(
+    '`--major-versions` rejects transitive dependency targets with suffixes',
+    () async {
+      final server = await servePackages();
+      server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
+      server.serve('bar', '1.0.0');
+
+      await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+      await pubGet(output: contains('+ foo 1.0.0'));
+
+      await pubUpgrade(
+        args: ['--major-versions', 'bar@^2.0.0'],
+        error: allOf(
+          contains(
+            'Dependencies specified in `dart pub upgrade --major-versions '
+            '<dependencies>`',
+          ),
+          contains('be direct'),
+          contains(' - bar'),
+        ),
+        exitCode: exit_codes.USAGE,
+      );
+    },
+  );
+
   test('`--unlock-transitive --major-versions` allows transitive dependencies '
       'be upgraded along with the named packages', () async {
     final server = await servePackages();
@@ -280,6 +306,25 @@ void main() {
         contains('> baz 1.5.0'),
         isNot(contains('baz 2.0.0')),
       ),
+    );
+  });
+
+  test('`dependency@resolvable` honors other target constraints', () async {
+    final server = await servePackages();
+    server.serve('bar', '1.0.0', deps: {'baz': '<2.0.0'});
+    server.serve('baz', '1.0.0');
+
+    await d.appDir(dependencies: {'bar': 'any', 'baz': 'any'}).create();
+
+    await pubGet(output: contains('+ bar 1.0.0'));
+
+    server.serve('bar', '2.0.0', deps: {'baz': '^2.0.0'});
+    server.serve('baz', '1.5.0');
+    server.serve('baz', '2.0.0');
+
+    await pubUpgrade(
+      args: ['bar@1.0.0', 'baz@resolvable'],
+      output: allOf(contains('> baz 1.5.0'), isNot(contains('baz 2.0.0'))),
     );
   });
 

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -567,7 +567,7 @@ void main() {
       await pubUpgrade(
         args: ['--major-versions', 'foo@latest'],
         error: contains(
-          'Cannot use `@<version>`, `@latest`, or `@resolvable` with '
+          'Cannot use `@<constraint>`, `@latest`, or `@resolvable` with '
           '`--major-versions`.',
         ),
         exitCode: exit_codes.USAGE,
@@ -582,7 +582,7 @@ void main() {
     await pubUpgrade(
       args: ['--tighten', 'foo@1.0.0'],
       error: contains(
-        'Cannot use `@<version>`, `@latest`, or `@resolvable` with '
+        'Cannot use `@<constraint>`, `@latest`, or `@resolvable` with '
         '`--tighten`.',
       ),
       exitCode: exit_codes.USAGE,
@@ -604,7 +604,7 @@ void main() {
         error: allOf(
           contains('Unknown upgrade target `$target`.'),
           contains('Use `<package>`'),
-          contains('`<package>@<version>`'),
+          contains('`<package>@<constraint>`'),
           contains('`<package>@latest`'),
           contains('`<package>@resolvable`.'),
         ),
@@ -617,18 +617,13 @@ void main() {
     await servePackages();
     await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
 
-    for (final target in [
-      'foo@',
-      'foo@Latest',
-      'foo@not-a-version',
-      'foo@^1.0.0',
-    ]) {
+    for (final target in ['foo@', 'foo@Latest', 'foo@not-a-version']) {
       await pubUpgrade(
         args: [target],
         error: allOf(
           contains('Unknown upgrade target `$target`.'),
           contains('Use `<package>`'),
-          contains('`<package>@<version>`'),
+          contains('`<package>@<constraint>`'),
           contains('`<package>@latest`'),
           contains('`<package>@resolvable`.'),
         ),
@@ -646,11 +641,32 @@ void main() {
       error: allOf(
         contains('Could not parse upgrade target `foo@bar@latest`.'),
         contains('Use `<package>`'),
-        contains('`<package>@<version>`'),
+        contains('`<package>@<constraint>`'),
         contains('`<package>@latest`'),
         contains('`<package>@resolvable`.'),
       ),
       exitCode: exit_codes.USAGE,
+    );
+  });
+
+  test('`dependency@constraint` upgrades a transitive dependency '
+      'with a constraint', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0', deps: {'bar': 'any'});
+    server.serve('bar', '1.0.0');
+
+    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+    await pubGet(output: contains('+ foo 1.0.0'));
+
+    server.serve('bar', '1.1.0');
+    server.serve('bar', '1.5.0');
+    server.serve('bar', '2.0.0');
+
+    // Upgrades to 1.5.0 because it's the latest satisfying <2.0.0
+    await pubUpgrade(
+      args: ['bar@<2.0.0'],
+      output: allOf(contains('> bar 1.5.0'), isNot(contains('bar 2.0.0'))),
     );
   });
 }

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -888,6 +888,56 @@ void main() {
   });
 
   test(
+    '`dependency@constraint` suggestion does not fall through to examples',
+    () async {
+      final server = await servePackages();
+      server.serve('foo', '1.0.0');
+
+      await d.dir(appPath, [
+        d.appPubspec(dependencies: {'foo': '^1.0.0'}),
+        d.dir('example', [
+          d.pubspec({
+            'name': 'myapp_example',
+            'dependencies': {'foo': '^1.0.0'},
+          }),
+        ]),
+      ]).create();
+
+      await pubGet(args: ['--example'], output: contains('+ foo 1.0.0'));
+
+      server.serve('foo', '2.0.0');
+
+      final suggestedArgs = ['--major-versions', '--no-example', 'foo@2.0.0'];
+
+      for (final args in [
+        ['foo@2.0.0'],
+        ['--no-example', 'foo@2.0.0'],
+      ]) {
+        await pubUpgrade(
+          args: args,
+          error: allOf(
+            contains('The requested constraint `2.0.0` for `foo`'),
+            contains(['dart', 'pub', 'upgrade', ...suggestedArgs].join(' ')),
+          ),
+          exitCode: exit_codes.DATA,
+        );
+      }
+
+      await pubUpgrade(args: suggestedArgs, output: contains('> foo 2.0.0'));
+
+      await d.dir(appPath, [
+        d.appPubspec(dependencies: {'foo': '^2.0.0'}),
+        d.dir('example', [
+          d.pubspec({
+            'name': 'myapp_example',
+            'dependencies': {'foo': '^1.0.0'},
+          }),
+        ]),
+      ]).validate();
+    },
+  );
+
+  test(
     '`dependency@constraint` allows overlap with the root constraint',
     () async {
       final server = await servePackages();

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -580,6 +580,33 @@ void main() {
     },
   );
 
+  test(
+    '`dependency@constraint` constrains the final --major-versions solve',
+    () async {
+      final server = await servePackages();
+      server.serve('foo', '1.0.0');
+
+      await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+      await pubGet();
+
+      server.serve('foo', '1.5.0');
+      server.serve('foo', '1.6.0');
+
+      await pubUpgrade(
+        args: ['--major-versions', 'foo@<=1.5.0'],
+        output: allOf(contains('> foo 1.5.0'), isNot(contains('foo 1.6.0'))),
+      );
+
+      await d.dir(appPath, [
+        d.file(
+          'pubspec.lock',
+          allOf(contains('version: "1.5.0"'), isNot(contains('1.6.0'))),
+        ),
+      ]).validate();
+    },
+  );
+
   test('`dependency@latest` can be combined with --major-versions', () async {
     final server = await servePackages();
     server.serve('bar', '1.0.0');

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -247,4 +247,20 @@ void main() {
       );
     },
   );
+
+  test('dependency target cannot contain multiple colons', () async {
+    await servePackages();
+    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+    await pubUpgrade(
+      args: ['foo:bar:latest'],
+      error: allOf(
+        contains('Could not parse upgrade target `foo:bar:latest`.'),
+        contains('Use `<package>`'),
+        contains('`<package>:latest`'),
+        contains('`<package>:resolvable`.'),
+      ),
+      exitCode: exit_codes.USAGE,
+    );
+  });
 }

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -218,6 +218,225 @@ void main() {
     );
   });
 
+  test('`dependency:latest` is resolved separately for examples', () async {
+    final server = await servePackages();
+    server.serve('bar', '1.0.0');
+
+    await d.dir(appPath, [
+      d.appPubspec(dependencies: {'bar': '^1.0.0'}),
+      d.dir('bar', [d.libPubspec('bar', '2.0.0'), d.libDir('bar')]),
+      d.dir('example', [
+        d.pubspec({
+          'name': 'app_example',
+          'dependencies': {
+            'bar': {'path': '../bar'},
+          },
+        }),
+      ]),
+    ]).create();
+
+    await pubGet(args: ['--example']);
+
+    server.serve('bar', '1.5.0');
+
+    await pubUpgrade(
+      args: ['--example', 'bar:latest'],
+      output: contains('> bar 1.5.0'),
+    );
+
+    await d.dir(appPath, [
+      d.dir('example', [
+        d.file(
+          'pubspec.lock',
+          allOf(contains('source: path'), contains('version: "2.0.0"')),
+        ),
+      ]),
+    ]).validate();
+  });
+
+  test('`dependency:latest` can target an example-only dependency', () async {
+    final server = await servePackages();
+    server.serve('bar', '1.0.0');
+
+    await d.dir(appPath, [
+      d.appPubspec(),
+      d.dir('example', [
+        d.pubspec({
+          'name': 'app_example',
+          'dependencies': {'bar': 'any'},
+        }),
+      ]),
+    ]).create();
+
+    await pubGet(args: ['--example']);
+
+    server.serve('bar', '2.0.0');
+
+    await pubUpgrade(
+      args: ['--example', 'bar:latest'],
+      output: contains('Got dependencies in'),
+    );
+
+    await d.dir(appPath, [
+      d.dir('example', [
+        d.file(
+          'pubspec.lock',
+          allOf(contains('source: hosted'), contains('version: "2.0.0"')),
+        ),
+      ]),
+    ]).validate();
+  });
+
+  test('`--unlock-transitive` can target an example-only dependency', () async {
+    final server = await servePackages();
+    server.serve('root_dep', '1.0.0');
+    server.serve('foo', '1.0.0', deps: {'bar': '^1.0.0'});
+    server.serve('bar', '1.0.0');
+
+    await d.dir(appPath, [
+      d.appPubspec(dependencies: {'root_dep': 'any'}),
+      d.dir('example', [
+        d.pubspec({
+          'name': 'app_example',
+          'dependencies': {'foo': 'any'},
+        }),
+      ]),
+    ]).create();
+
+    await pubGet(args: ['--example']);
+
+    server.serve('root_dep', '2.0.0');
+    server.serve('foo', '1.5.0', deps: {'bar': '^1.0.0'});
+    server.serve('bar', '1.5.0');
+
+    await pubUpgrade(
+      args: ['--example', '--unlock-transitive', 'foo:latest'],
+      output: contains('Got dependencies in'),
+    );
+
+    await d.dir(appPath, [
+      d.file(
+        'pubspec.lock',
+        allOf(contains('root_dep:'), contains('version: "1.0.0"')),
+      ),
+      d.dir('example', [
+        d.file(
+          'pubspec.lock',
+          allOf(
+            matches(RegExp(r'bar:[\s\S]*version: "1\.5\.0"')),
+            matches(RegExp(r'foo:[\s\S]*version: "1\.5\.0"')),
+          ),
+        ),
+      ]),
+    ]).validate();
+  });
+
+  test('`--unlock-transitive` does not unlock unrelated examples', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0');
+    server.serve('example_dep', '1.0.0');
+
+    await d.dir(appPath, [
+      d.appPubspec(dependencies: {'foo': 'any'}),
+      d.dir('example', [
+        d.pubspec({
+          'name': 'app_example',
+          'dependencies': {'example_dep': 'any'},
+        }),
+      ]),
+    ]).create();
+
+    await pubGet(args: ['--example']);
+
+    server.serve('foo', '1.5.0');
+    server.serve('example_dep', '2.0.0');
+
+    await pubUpgrade(
+      args: ['--example', '--unlock-transitive', 'foo:latest'],
+      output: allOf(contains('> foo 1.5.0'), contains('Got dependencies in')),
+    );
+
+    await d.dir(appPath, [
+      d.dir('example', [
+        d.file(
+          'pubspec.lock',
+          allOf(contains('example_dep:'), contains('version: "1.0.0"')),
+        ),
+      ]),
+    ]).validate();
+  });
+
+  test('`dependency:latest` uses the dependency source from pubspec', () async {
+    final server = await servePackages();
+    server.serve('bar', '1.0.0');
+    server.serve('bar', '1.5.0');
+
+    await d.dir('bar', [
+      d.libPubspec('bar', '2.0.0'),
+      d.libDir('bar'),
+    ]).create();
+
+    await d.appDir(dependencies: {'bar': '^1.0.0'}).create();
+
+    await pubGet(output: contains('+ bar 1.5.0'));
+
+    await d
+        .appDir(
+          dependencies: {
+            'bar': {'path': '../bar'},
+          },
+        )
+        .create();
+
+    await pubUpgrade(
+      args: ['bar:latest'],
+      output: contains('* bar 2.0.0 from path'),
+    );
+
+    await d.dir(appPath, [
+      d.file(
+        'pubspec.lock',
+        allOf(contains('source: path'), contains('version: "2.0.0"')),
+      ),
+    ]).validate();
+  });
+
+  test('`dependency:latest` uses the dependency override source', () async {
+    final server = await servePackages();
+    server.serve('bar', '1.0.0');
+    server.serve('bar', '2.0.0');
+
+    await d.dir('bar', [
+      d.libPubspec('bar', '3.0.0'),
+      d.libDir('bar'),
+    ]).create();
+
+    await d
+        .appDir(
+          dependencies: {'bar': 'any'},
+          pubspec: {
+            'dependency_overrides': {
+              'bar': {'path': '../bar'},
+            },
+          },
+        )
+        .create();
+
+    await pubGet();
+
+    await pubUpgrade(
+      args: ['bar:latest'],
+      output: contains('No dependencies changed.'),
+    );
+
+    await d.dir(appPath, [
+      d.file(
+        'pubspec.lock',
+        allOf(contains('source: path'), contains('version: "3.0.0"')),
+      ),
+    ]).validate();
+  });
+
   test(
     '`dependency:latest` requires a package from the current resolution',
     () async {
@@ -231,6 +450,26 @@ void main() {
       );
     },
   );
+
+  test('`dependency:latest` requires a package from the current resolution '
+      'with examples', () async {
+    await servePackages();
+    await d.dir(appPath, [
+      d.appPubspec(),
+      d.dir('example', [
+        d.pubspec({'name': 'app_example'}),
+      ]),
+    ]).create();
+
+    await pubUpgrade(
+      args: ['--example', 'missing:latest'],
+      error: allOf(
+        contains('Package `missing` is not in the current resolution.'),
+        contains('It was not found in the root package or any examples.'),
+      ),
+      exitCode: exit_codes.DATA,
+    );
+  });
 
   test(
     '`dependency:latest` cannot be combined with --major-versions',

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -558,35 +558,42 @@ void main() {
     );
   });
 
-  test(
-    '`dependency@latest` cannot be combined with --major-versions',
-    () async {
-      await servePackages();
-      await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+  test('`dependency@constraint` can be combined with --major-versions', () async {
+    final server = await servePackages();
+    server.serve('bar', '1.0.0');
 
-      await pubUpgrade(
-        args: ['--major-versions', 'foo@latest'],
-        error: contains(
-          'Cannot use `@<constraint>`, `@latest`, or `@resolvable` with '
-          '`--major-versions`.',
-        ),
-        exitCode: exit_codes.USAGE,
-      );
-    },
-  );
+    await d.appDir(dependencies: {'bar': '^1.0.0'}).create();
 
-  test('`dependency@version` cannot be combined with --tighten', () async {
-    await servePackages();
-    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+    await pubGet();
+
+    server.serve('bar', '2.0.0');
+    server.serve('bar', '3.0.0');
 
     await pubUpgrade(
-      args: ['--tighten', 'foo@1.0.0'],
-      error: contains(
-        'Cannot use `@<constraint>`, `@latest`, or `@resolvable` with '
-        '`--tighten`.',
-      ),
-      exitCode: exit_codes.USAGE,
+      args: ['--major-versions', 'bar@^2.0.0'],
+      output: contains('> bar 2.0.0'),
     );
+
+    await d.appDir(dependencies: {'bar': '^2.0.0'}).validate();
+  });
+
+  test('`dependency@constraint` can be combined with --tighten', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0');
+
+    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+    await pubGet();
+
+    server.serve('foo', '1.5.0');
+    server.serve('foo', '2.0.0');
+
+    await pubUpgrade(
+      args: ['--tighten', 'foo@<2.0.0'],
+      output: contains('> foo 1.5.0'),
+    );
+
+    await d.appDir(dependencies: {'foo': '^1.5.0'}).validate();
   });
 
   test('dependency target uses @ instead of colon', () async {

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -841,4 +841,170 @@ void main() {
       output: allOf(contains('> bar 1.5.0'), isNot(contains('bar 2.0.0'))),
     );
   });
+
+  test('`dependency@constraint` suggests --major-versions when blocked by '
+      'the root constraint', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0');
+
+    await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
+
+    await pubGet(
+      workingDirectory: d.sandbox,
+      args: ['--directory', appPath],
+      output: contains('+ foo 1.0.0'),
+    );
+
+    server.serve('foo', '2.0.0');
+
+    final suggestedArgs = [
+      '--major-versions',
+      '--tighten',
+      '--directory',
+      appPath,
+      'foo@2.0.0',
+    ];
+
+    await pubUpgrade(
+      workingDirectory: d.sandbox,
+      args: ['--tighten', '--directory', appPath, 'foo@2.0.0'],
+      error: allOf(
+        contains('The requested constraint `2.0.0` for `foo`'),
+        contains('current constraint `^1.0.0`'),
+        contains('pubspec.yaml'),
+        contains(['dart', 'pub', 'upgrade', ...suggestedArgs].join(' ')),
+        isNot(contains('version solving failed')),
+      ),
+      exitCode: exit_codes.DATA,
+    );
+
+    await pubUpgrade(
+      workingDirectory: d.sandbox,
+      args: suggestedArgs,
+      output: contains('> foo 2.0.0'),
+    );
+
+    await d.appDir(dependencies: {'foo': '^2.0.0'}).validate();
+  });
+
+  test(
+    '`dependency@constraint` allows overlap with the root constraint',
+    () async {
+      final server = await servePackages();
+      server.serve('foo', '1.0.0');
+
+      await d.appDir(dependencies: {'foo': '>=1.0.0 <3.0.0'}).create();
+
+      await pubGet(output: contains('+ foo 1.0.0'));
+
+      server.serve('foo', '2.0.0');
+
+      await pubUpgrade(args: ['foo@2.0.0'], output: contains('> foo 2.0.0'));
+    },
+  );
+
+  test('`dependency@constraint` suggests --major-versions when blocked by '
+      'a workspace constraint', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0');
+
+    await d.dir(appPath, [
+      d.libPubspec(
+        'myapp',
+        '1.0.0',
+        sdk: '^3.5.0',
+        extras: {
+          'workspace': ['a'],
+        },
+      ),
+      d.dir('a', [
+        d.libPubspec(
+          'a',
+          '1.0.0',
+          deps: {'foo': '^1.0.0'},
+          resolutionWorkspace: true,
+        ),
+      ]),
+    ]).create();
+
+    await pubGet(
+      workingDirectory: d.sandbox,
+      args: ['--directory', appPath],
+      environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+      output: contains('+ foo 1.0.0'),
+    );
+
+    server.serve('foo', '2.0.0');
+
+    final suggestedArgs = [
+      '--major-versions',
+      '--directory',
+      appPath,
+      'foo@2.0.0',
+    ];
+
+    await pubUpgrade(
+      workingDirectory: d.sandbox,
+      args: ['--directory', appPath, 'foo@2.0.0'],
+      environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+      error: allOf(
+        contains('The requested constraint `2.0.0` for `foo`'),
+        contains('current constraint `^1.0.0`'),
+        matches(RegExp(r'a[\\/]pubspec\.yaml')),
+        contains(['dart', 'pub', 'upgrade', ...suggestedArgs].join(' ')),
+      ),
+      exitCode: exit_codes.DATA,
+    );
+
+    await pubUpgrade(
+      workingDirectory: d.sandbox,
+      args: suggestedArgs,
+      environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+      output: contains('> foo 2.0.0'),
+    );
+
+    await d.dir(appPath, [
+      d.libPubspec(
+        'myapp',
+        '1.0.0',
+        sdk: '^3.5.0',
+        extras: {
+          'workspace': ['a'],
+        },
+      ),
+      d.dir('a', [
+        d.libPubspec(
+          'a',
+          '1.0.0',
+          deps: {'foo': '^2.0.0'},
+          resolutionWorkspace: true,
+        ),
+      ]),
+    ]).validate();
+  });
+
+  test('`dependency@constraint` does not suggest --major-versions for '
+      'dependency override conflicts', () async {
+    await servePackages();
+
+    await d
+        .appDir(
+          dependencies: {'foo': 'any'},
+          pubspec: {
+            'dependency_overrides': {'foo': '1.0.0'},
+          },
+        )
+        .create();
+
+    await pubUpgrade(
+      args: ['foo@2.0.0'],
+      error: allOf(
+        contains('The requested constraint `2.0.0` for `foo`'),
+        contains('dependency override constraint `1.0.0`'),
+        contains('Update or remove the dependency override before retrying.'),
+        isNot(contains('--major-versions')),
+      ),
+      exitCode: exit_codes.DATA,
+    );
+  });
 }


### PR DESCRIPTION
Adds package:latest and package:resolvable targets to pub upgrade so users can force a transitive package to latest or latest-resolvable and get the solver explanation when it cannot be selected.

- Target constraints are evaluated per entrypoint, so --example uses each example's dependency graph and sources.
- --unlock-transitive stays scoped when a target only exists in another active entrypoint.
- Latest lookup respects dependency overrides and current pubspec sources instead of stale lockfile sources.

Fixes #4569
Related to #3685