### PR TITLE
Upgrade CLI util to 0.5.0

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -14,7 +14,7 @@ import 'dart:typed_data';
 
 import 'package:async/async.dart';
 import 'package:cli_util/cli_util.dart'
-    show EnvironmentNotFoundException, applicationConfigHome;
+    show BaseDirectories, EnvironmentNotFoundException;
 import 'package:collection/collection.dart';
 import 'package:file/file.dart' as f;
 import 'package:file/local.dart' as f;
@@ -1372,7 +1372,7 @@ final String? dartConfigDir = () {
     return null;
   }
   try {
-    return applicationConfigHome('dart');
+    return BaseDirectories('dart').configHome;
   } on EnvironmentNotFoundException {
     return null;
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: "direct main"
     description:
       name: cli_util
-      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
+      sha256: "5909d2c6b66817222779e1eedc19e0e28b76d1df7bd9856a4792ccb9881df358"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.5.1"
   collection:
     dependency: "direct main"
     description:
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.5.2"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   file:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   analyzer: ^10.2.0
   args: ^2.7.0
   async: ^2.13.0
-  cli_util: ^0.4.2
+  cli_util: ^0.5.0
   collection: ^1.19.1
   convert: ^3.1.2
   crypto: ^3.0.7


### PR DESCRIPTION
Upgrade CLI utils to version 0.5.0 and fix deprecations

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
