### PR TITLE
solver: suggest workspace resolution fixes

### DIFF
--- a/lib/src/solver/solve_suggestions.dart
+++ b/lib/src/solver/solve_suggestions.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'dart:io';
-
 import 'package:pub_semver/pub_semver.dart';
 
 import '../command_runner.dart';
@@ -155,7 +154,12 @@ String _packageAddCommand(
   final command = StringBuffer('$topLevelProgram pub add');
   if (_needsDirectoryOption(package)) {
     final packageDir = escapeShellArgument(
-      p.normalize(p.relative(package.dir)),
+      p.normalize(
+        p.relative(
+          p.canonicalize(p.absolute(package.dir)),
+          from: p.canonicalize(p.current),
+        ),
+      ),
     );
     command.write(' --directory $packageDir');
   }
@@ -180,8 +184,7 @@ String _upgradeMajorVersionsCommand(Entrypoint entrypoint) {
 bool _needsDirectoryOption(Package package) {
   final currentDir = p.canonicalize(p.current);
   final packageDir = p.canonicalize(p.absolute(package.dir));
-  return !p.equals(currentDir, packageDir) &&
-      !p.isWithin(packageDir, currentDir);
+  return !p.equals(currentDir, packageDir);
 }
 
 bool _samePackage(Package a, Package b) {
@@ -373,9 +376,20 @@ class _ResolutionContext {
         priority: 4,
       );
     } else {
+      final packagesNeedingConstraintChanges = {
+        for (final update in updatedPackageVersions)
+          if (!update.range.constraint.allows(update.id.version))
+            update.id.name,
+      };
+      final command = StringBuffer(_upgradeMajorVersionsCommand(entrypoint));
+      final sortedPackageNames =
+          packagesNeedingConstraintChanges.toList()..sort();
+      for (final packageName in sortedPackageNames) {
+        command.write(' ${escapeShellArgument(packageName)}');
+      }
       return _ResolutionSuggestion(
         '* Try an upgrade of your constraints: '
-        '${_upgradeMajorVersionsCommand(entrypoint)}',
+        '$command',
         priority: 4,
       );
     }

--- a/lib/src/solver/solve_suggestions.dart
+++ b/lib/src/solver/solve_suggestions.dart
@@ -9,9 +9,11 @@ import '../flutter_releases.dart';
 import '../io.dart';
 import '../package.dart';
 import '../package_name.dart';
+import '../path.dart';
 import '../pubspec_utils.dart';
 import '../solver.dart';
 import '../source/hosted.dart';
+import '../source/root.dart';
 import '../system_cache.dart';
 import 'incompatibility.dart';
 import 'incompatibility_cause.dart';
@@ -32,10 +34,6 @@ Future<String?> suggestResolutionAlternatives(
   Iterable<String> unlock,
   SystemCache cache,
 ) async {
-  if (entrypoint.workspaceRoot.workspaceChildren.isNotEmpty) {
-    // TODO(https://github.com/dart-lang/pub/issues/4227): handle workspaces.
-    return null;
-  }
   final resolutionContext = _ResolutionContext(
     entrypoint: entrypoint,
     type: type,
@@ -98,33 +96,99 @@ class _ResolutionSuggestion {
   _ResolutionSuggestion(this.suggestion, {this.priority = 0});
 }
 
-String packageAddDescription(Entrypoint entrypoint, PackageId id) {
+String? packageAddDescription(
+  Package package,
+  PackageId id, {
+  PackageRange? originalRange,
+  required bool isDev,
+}) {
   final name = id.name;
-  final isDev = entrypoint.workspaceRoot.pubspec.devDependencies.containsKey(
-    name,
-  );
-  final resolvedDescription = id.description;
+  final resolvedDescription = id.description.description;
+  final description =
+      resolvedDescription is RootDescription
+          ? originalRange?.description
+          : resolvedDescription;
   final String descriptor;
-  final d = resolvedDescription.description.serializeForPubspec(
-    containingDir:
-        Directory
-            .current
-            .path, // The add command will resolve file names relative to CWD.
-    // This currently should have no implications as we don't create suggestions
-    // for path-packages.
-    languageVersion: entrypoint.workspaceRoot.pubspec.languageVersion,
-  );
-  if (d == null) {
-    descriptor = VersionConstraint.compatibleWith(id.version).toString();
+  if (resolvedDescription is RootDescription) {
+    if (description == null || description is RootDescription) {
+      descriptor = VersionConstraint.compatibleWith(id.version).toString();
+    } else if (description is! HostedDescription) {
+      return null;
+    } else {
+      final d = description.serializeForPubspec(
+        containingDir: Directory.current.path,
+        languageVersion: package.pubspec.languageVersion,
+      );
+      if (d == null) {
+        descriptor = VersionConstraint.compatibleWith(id.version).toString();
+      } else {
+        descriptor = json.encode({
+          'version': VersionConstraint.compatibleWith(id.version).toString(),
+          description.source.name: d,
+        });
+      }
+    }
   } else {
-    descriptor = json.encode({
-      'version': VersionConstraint.compatibleWith(id.version).toString(),
-      id.source.name: d,
-    });
+    final d = resolvedDescription.serializeForPubspec(
+      containingDir: Directory.current.path,
+      languageVersion: package.pubspec.languageVersion,
+    );
+    if (d == null) {
+      descriptor = VersionConstraint.compatibleWith(id.version).toString();
+    } else {
+      descriptor = json.encode({
+        'version': VersionConstraint.compatibleWith(id.version).toString(),
+        resolvedDescription.source.name: d,
+      });
+    }
   }
 
   final devPart = isDev ? 'dev:' : '';
   return '$devPart$name:${escapeShellArgument(descriptor)}';
+}
+
+String _packageAddCommand(
+  Entrypoint entrypoint,
+  Package package,
+  Iterable<String> addDescriptions,
+) {
+  final command = StringBuffer('$topLevelProgram pub add');
+  if (_needsDirectoryOption(package)) {
+    final packageDir = escapeShellArgument(
+      p.normalize(p.relative(package.dir)),
+    );
+    command.write(' --directory $packageDir');
+  }
+  command.write(' ${addDescriptions.join(' ')}');
+  return command.toString();
+}
+
+String _upgradeMajorVersionsCommand(Entrypoint entrypoint) {
+  final command = StringBuffer('$topLevelProgram pub upgrade');
+  final currentDir = p.canonicalize(p.current);
+  final workspaceDir = p.canonicalize(p.absolute(entrypoint.workspaceRoot.dir));
+  if (!p.equals(currentDir, workspaceDir)) {
+    final relativeWorkspaceDir = escapeShellArgument(
+      p.normalize(p.relative(entrypoint.workspaceRoot.dir)),
+    );
+    command.write(' --directory $relativeWorkspaceDir');
+  }
+  command.write(' --major-versions');
+  return command.toString();
+}
+
+bool _needsDirectoryOption(Package package) {
+  final currentDir = p.canonicalize(p.current);
+  final packageDir = p.canonicalize(p.absolute(package.dir));
+  return !p.equals(currentDir, packageDir) &&
+      !p.isWithin(packageDir, currentDir);
+}
+
+bool _samePackage(Package a, Package b) {
+  return p.equals(
+    p.canonicalize(p.absolute(a.dir)),
+    p.canonicalize(p.absolute(b.dir)),
+  );
 }
 
 class _ResolutionContext {
@@ -182,59 +246,59 @@ class _ResolutionContext {
   /// Attempt another resolution with a relaxed constraint on [name]. If that
   /// resolves, suggest upgrading to that version.
   Future<_ResolutionSuggestion?> suggestSinglePackageUpdate(String name) async {
-    // TODO(https://github.com/dart-lang/pub/issues/4127): This should
-    // operate on all packages in workspace.
-    final originalRange =
-        entrypoint.workspaceRoot.dependencies[name] ??
-        entrypoint.workspaceRoot.devDependencies[name];
-    if (originalRange == null ||
-        originalRange.description is! HostedDescription) {
-      // We can only relax constraints on hosted dependencies.
-      return null;
-    }
-    final originalConstraint = originalRange.constraint;
-    final relaxedPubspec = stripVersionBounds(
-      entrypoint.workspaceRoot.pubspec,
-      stripOnly: [name],
-      stripLowerBound: true,
-    );
+    for (final (:package, :range, :isDev) in _workspaceDependencyRanges(name)) {
+      if (range.description is! HostedDescription) {
+        continue;
+      }
+      final originalConstraint = range.constraint;
+      final relaxedWorkspace = entrypoint.workspaceRoot.transformWorkspace(
+        (workspacePackage) =>
+            _samePackage(workspacePackage, package)
+                ? stripVersionBounds(
+                  workspacePackage.pubspec,
+                  stripOnly: [name],
+                  stripLowerBound: true,
+                )
+                : workspacePackage.pubspec,
+      );
 
-    final result = await _tryResolve(
-      Package(
-        relaxedPubspec,
-        entrypoint.workspaceRoot.dir,
-        entrypoint.workspaceRoot.workspaceChildren,
-      ),
-    );
-    if (result == null) {
-      return null;
-    }
-    final resolvingPackage = result.packages.firstWhere((p) => p.name == name);
+      final result = await _tryResolve(relaxedWorkspace);
+      if (result == null) {
+        continue;
+      }
+      final resolvingPackage = result.packages.firstWhere(
+        (p) => p.name == name,
+      );
 
-    final addDescription = packageAddDescription(entrypoint, resolvingPackage);
+      final addDescription = packageAddDescription(
+        package,
+        resolvingPackage,
+        originalRange: range,
+        isDev: isDev,
+      );
+      if (addDescription == null) continue;
+      final command = _packageAddCommand(entrypoint, package, [addDescription]);
 
-    var priority = 1;
-    var suggestion =
-        '* Try updating your constraint on $name: '
-        '$topLevelProgram pub add $addDescription';
-    if (originalConstraint is VersionRange) {
-      final min = originalConstraint.min;
-      if (min != null) {
-        if (resolvingPackage.version < min) {
-          priority = 3;
-          suggestion =
-              '* Consider downgrading your constraint on $name: '
-              '$topLevelProgram pub add $addDescription';
-        } else {
-          priority = 2;
-          suggestion =
-              '* Try upgrading your constraint on $name: '
-              '$topLevelProgram pub add $addDescription';
+      var priority = 1;
+      var suggestion = '* Try updating your constraint on $name: $command';
+      if (originalConstraint is VersionRange) {
+        final min = originalConstraint.min;
+        if (min != null) {
+          if (resolvingPackage.version < min) {
+            priority = 3;
+            suggestion =
+                '* Consider downgrading your constraint on $name: $command';
+          } else {
+            priority = 2;
+            suggestion = '* Try upgrading your constraint on $name: $command';
+          }
         }
       }
+
+      return _ResolutionSuggestion(suggestion, priority: priority);
     }
 
-    return _ResolutionSuggestion(suggestion, priority: priority);
+    return null;
   }
 
   /// Attempt resolving with all version constraints relaxed. If that resolves,
@@ -242,30 +306,37 @@ class _ResolutionContext {
   Future<_ResolutionSuggestion?> suggestUnlockingAll({
     required bool stripLowerBound,
   }) async {
-    final originalPubspec = entrypoint.workspaceRoot.pubspec;
-    final relaxedPubspec = stripVersionBounds(
-      originalPubspec,
-      stripLowerBound: stripLowerBound,
+    final originalWorkspace = entrypoint.workspaceRoot.transitiveWorkspace;
+    final relaxedWorkspace = entrypoint.workspaceRoot.transformWorkspace(
+      (package) =>
+          stripVersionBounds(package.pubspec, stripLowerBound: stripLowerBound),
     );
 
-    final result = await _tryResolve(
-      Package(
-        relaxedPubspec,
-        entrypoint.workspaceRoot.dir,
-        entrypoint.workspaceRoot.workspaceChildren,
-      ),
-    );
+    final result = await _tryResolve(relaxedWorkspace);
     if (result == null) {
       return null;
     }
-    final updatedPackageVersions = <PackageId>[];
-    for (final id in result.packages) {
-      final originalConstraint =
-          (originalPubspec.dependencies[id.name] ??
-                  originalPubspec.devDependencies[id.name])
-              ?.constraint;
-      if (originalConstraint != null) {
-        updatedPackageVersions.add(id);
+    final resolvedPackages = {for (final id in result.packages) id.name: id};
+    final updatedPackageVersions =
+        <({Package package, PackageRange range, PackageId id, bool isDev})>[];
+    for (final package in originalWorkspace) {
+      void addUpdate(PackageRange range, {required bool isDev}) {
+        final id = resolvedPackages[range.name];
+        if (id != null) {
+          updatedPackageVersions.add((
+            package: package,
+            range: range,
+            id: id,
+            isDev: isDev,
+          ));
+        }
+      }
+
+      for (final range in package.dependencies.values) {
+        addUpdate(range, isDev: false);
+      }
+      for (final range in package.devDependencies.values) {
+        addUpdate(range, isDev: true);
       }
     }
     if (stripLowerBound && updatedPackageVersions.length > 5) {
@@ -273,19 +344,38 @@ class _ResolutionContext {
       return null;
     }
     if (stripLowerBound) {
-      updatedPackageVersions.sort((a, b) => a.name.compareTo(b.name));
-      final formattedConstraints = updatedPackageVersions
-          .map((e) => packageAddDescription(entrypoint, e))
-          .join(' ');
+      if (updatedPackageVersions.isEmpty) return null;
+      final package = updatedPackageVersions.first.package;
+      if (updatedPackageVersions.any((update) {
+        return !_samePackage(update.package, package);
+      })) {
+        return null;
+      }
+      updatedPackageVersions.sort((a, b) => a.id.name.compareTo(b.id.name));
+      final formattedConstraints = <String>[];
+      for (final update in updatedPackageVersions) {
+        final description = packageAddDescription(
+          package,
+          update.id,
+          originalRange: update.range,
+          isDev: update.isDev,
+        );
+        if (description == null) return null;
+        formattedConstraints.add(description);
+      }
+      final command = _packageAddCommand(
+        entrypoint,
+        package,
+        formattedConstraints,
+      );
       return _ResolutionSuggestion(
-        '* Try updating the following constraints: '
-        '$topLevelProgram pub add $formattedConstraints',
+        '* Try updating the following constraints: $command',
         priority: 4,
       );
     } else {
       return _ResolutionSuggestion(
         '* Try an upgrade of your constraints: '
-        '$topLevelProgram pub upgrade --major-versions',
+        '${_upgradeMajorVersionsCommand(entrypoint)}',
         priority: 4,
       );
     }
@@ -307,6 +397,20 @@ class _ResolutionContext {
       );
     } on SolveFailure {
       return null;
+    }
+  }
+
+  Iterable<({Package package, PackageRange range, bool isDev})>
+  _workspaceDependencyRanges(String name) sync* {
+    for (final package in entrypoint.workspaceRoot.transitiveWorkspace) {
+      final dependency = package.dependencies[name];
+      if (dependency != null) {
+        yield (package: package, range: dependency, isDev: false);
+      }
+      final devDependency = package.devDependencies[name];
+      if (devDependency != null) {
+        yield (package: package, range: devDependency, isDev: true);
+      }
     }
   }
 }

--- a/test/solve_suggestions_test.dart
+++ b/test/solve_suggestions_test.dart
@@ -164,6 +164,113 @@ void main() {
   );
 
   test(
+    'suggests one upgrade for a package constrained across a workspace',
+    () async {
+      final server = await servePackages();
+      server.serve('foo', '1.0.0', deps: {'bar': '^2.0.0'});
+      server.serve('bar', '1.0.0');
+      server.serve('bar', '2.0.0');
+
+      await d.dir(appPath, [
+        d.libPubspec(
+          'myApp',
+          '1.0.0',
+          deps: {'foo': '^1.0.0', 'bar': '^1.0.0'},
+          extras: {
+            'workspace': ['pkgs/a'],
+          },
+          sdk: '^3.5.0',
+        ),
+        d.dir('pkgs', [
+          d.dir('a', [
+            d.libPubspec(
+              'a',
+              '1.0.0',
+              deps: {'bar': '^1.0.0'},
+              resolutionWorkspace: true,
+            ),
+          ]),
+        ]),
+      ]).create();
+
+      await pubGet(
+        error: matches(
+          RegExp(
+            r'^\* Try an upgrade of your constraints: '
+            r'dart pub upgrade --major-versions bar$',
+            multiLine: true,
+          ),
+        ),
+        environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+      );
+    },
+  );
+
+  test('serializes workspace member path suggestions from cwd', () async {
+    await d.dir(appPath, [
+      d.libPubspec(
+        'myApp',
+        '1.0.0',
+        extras: {
+          'workspace': ['pkgs/a'],
+        },
+        sdk: '^3.5.0',
+      ),
+      d.dir('pkgs', [
+        d.dir('a', [
+          d.dir('lib'),
+          d.libPubspec(
+            'a',
+            '1.0.0',
+            deps: {
+              'bar': {'path': '../bar', 'version': '^1.0.0'},
+            },
+            resolutionWorkspace: true,
+          ),
+        ]),
+        d.dir('bar', [d.libPubspec('bar', '2.0.0')]),
+      ]),
+    ]).create();
+
+    final packageDir = escapeShellArgument('..');
+    await pubGet(
+      workingDirectory: p.join(d.sandbox, appPath, 'pkgs', 'a', 'lib'),
+      error: contains(
+        '* Try updating the following constraints: '
+        'dart pub add --directory $packageDir '
+        'bar:\'{"version":"^2.0.0","path":"../../bar"}\'',
+      ),
+      environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+    );
+
+    await pubAdd(
+      args: [
+        '--directory',
+        '..',
+        'bar:{"version":"^2.0.0","path":"../../bar"}',
+      ],
+      workingDirectory: p.join(d.sandbox, appPath, 'pkgs', 'a', 'lib'),
+      environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+      output: contains('Changed 1 dependency in'),
+    );
+
+    await d.dir(appPath, [
+      d.dir('pkgs', [
+        d.dir('a', [
+          d.libPubspec(
+            'a',
+            '1.0.0',
+            deps: {
+              'bar': {'path': '../bar', 'version': '^2.0.0'},
+            },
+            resolutionWorkspace: true,
+          ),
+        ]),
+      ]),
+    ]).validate();
+  });
+
+  test(
     'preserves a dependency source when suggesting a workspace member version',
     () async {
       final server = await startPackageServer();
@@ -254,7 +361,8 @@ void main() {
         workingDirectory: d.sandbox,
         error: contains(
           '* Try an upgrade of your constraints: '
-          'dart pub upgrade --directory $appPath --major-versions',
+          'dart pub upgrade --directory $appPath --major-versions '
+          'bar bar1 bar2 foo foo1 foo2',
         ),
       );
     },

--- a/test/solve_suggestions_test.dart
+++ b/test/solve_suggestions_test.dart
@@ -5,8 +5,9 @@
 @TestOn('vm')
 library;
 
+import 'package:pub/src/io.dart' show escapeShellArgument;
+import 'package:pub/src/path.dart' show p;
 import 'package:shelf/shelf.dart';
-
 import 'package:test/test.dart';
 import 'package:test_descriptor/test_descriptor.dart';
 
@@ -113,6 +114,87 @@ void main() {
     );
   });
 
+  test(
+    'suggests an update to a package constraint in a workspace member',
+    () async {
+      final server = await servePackages();
+      server.serve('foo', '1.0.0', deps: {'bar': '^2.0.0'});
+      server.serve('foo', '0.9.0', deps: {'bar': '^1.0.0'});
+      server.serve('bar', '1.0.0');
+      server.serve('bar', '2.0.0');
+
+      await d.dir(appPath, [
+        d.libPubspec(
+          'myApp',
+          '1.0.0',
+          extras: {
+            'workspace': ['pkgs/a'],
+          },
+          sdk: '^3.5.0',
+        ),
+        d.dir('pkgs', [
+          d.dir('a', [
+            d.libPubspec(
+              'a',
+              '1.0.0',
+              deps: {'foo': '^1.0.0'},
+              devDeps: {'bar': '^1.0.0'},
+              resolutionWorkspace: true,
+            ),
+          ]),
+        ]),
+      ]).create();
+
+      final packageDir = escapeShellArgument(p.join('pkgs', 'a'));
+      await pubGet(
+        args: ['--directory', p.join('pkgs', 'a')],
+        error: allOf([
+          contains(
+            '* Try upgrading your constraint on bar: '
+            'dart pub add --directory $packageDir dev:bar:^2.0.0',
+          ),
+          contains(
+            '* Consider downgrading your constraint on foo: '
+            'dart pub add --directory $packageDir foo:^0.9.0',
+          ),
+        ]),
+        environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+      );
+    },
+  );
+
+  test(
+    'preserves a dependency source when suggesting a workspace member version',
+    () async {
+      final server = await startPackageServer();
+
+      await d.dir(appPath, [
+        d.libPubspec(
+          'myApp',
+          '1.0.0',
+          deps: {
+            'a': {'version': '^2.0.0', 'hosted': server.url},
+          },
+          extras: {
+            'workspace': ['pkgs/a'],
+          },
+          sdk: '^3.5.0',
+        ),
+        d.dir('pkgs', [
+          d.dir('a', [d.libPubspec('a', '1.0.0', resolutionWorkspace: true)]),
+        ]),
+      ]).create();
+
+      await pubGet(
+        error: contains(
+          '* Consider downgrading your constraint on a: dart pub add '
+          'a:\'{"version":"^1.0.0","hosted":"${server.url}"}\'',
+        ),
+        environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+      );
+    },
+  );
+
   test('suggests updates to multiple packages', () async {
     final server = await servePackages();
     server.serve('foo', '1.0.0', deps: {'bar': '2.0.0'});
@@ -168,10 +250,45 @@ void main() {
         ),
       ]).create();
       await pubGet(
+        args: ['--directory', appPath],
+        workingDirectory: d.sandbox,
         error: contains(
           '* Try an upgrade of your constraints: '
-          'dart pub upgrade --major-versions',
+          'dart pub upgrade --directory $appPath --major-versions',
         ),
+      );
+    },
+  );
+
+  test(
+    'does not suggest versioned path descriptors for workspace members',
+    () async {
+      await d.dir(appPath, [
+        d.libPubspec(
+          'myApp',
+          '1.0.0',
+          deps: {
+            'a': {'path': 'pkgs/a', 'version': '^2.0.0'},
+          },
+          extras: {
+            'workspace': ['pkgs/a'],
+          },
+          sdk: '^3.5.0',
+        ),
+        d.dir('pkgs', [
+          d.dir('a', [d.libPubspec('a', '1.0.0', resolutionWorkspace: true)]),
+        ]),
+      ]).create();
+
+      await pubGet(
+        error: allOf([
+          contains(
+            'Because myApp depends on both a ^2.0.0 from path and a, '
+            'version solving failed.',
+          ),
+          isNot(contains('You can try')),
+        ]),
+        environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
       );
     },
   );

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -1339,8 +1339,7 @@ Changed 1 constraint in b${s}pubspec.yaml:
     );
   });
 
-  // TODO(https://github.com/dart-lang/pub/issues/4227): we want to enable this at some point.
-  test('No suggestions for workspaces', () async {
+  test('suggests fixes for dependencies on workspace members', () async {
     final server = await servePackages();
     server.serve('dev_dep', '1.0.0');
     await dir(appPath, [
@@ -1361,9 +1360,15 @@ Changed 1 constraint in b${s}pubspec.yaml:
     ]).create();
     await pubGet(
       environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
-      error:
+      error: allOf([
+        contains(
           'Because myapp depends on both a 2.0.0 and a, '
           'version solving failed.',
+        ),
+        contains(
+          '* Consider downgrading your constraint on a: dart pub add a:^1.0.0',
+        ),
+      ]),
     );
   });
 


### PR DESCRIPTION
Enables version solving suggestions for workspace dependency conflicts.

This locates the owning workspace pubspec for direct hosted constraints, emits directory-aware pub add and major-upgrade commands, preserves hosted sources for workspace member suggestions, and suppresses invalid path/git root descriptors.

Fixes #4227.
Related to #4127.