### PR TITLE
Preserve spaces in nested package paths

### DIFF
--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -301,14 +301,11 @@ See $workspacesDocUrl for more information.
   }) {
     final packageDir = dir;
     final root = git.repoRoot(packageDir) ?? packageDir;
-    beneath =
-        p
-            .toUri(
-              p.normalize(
-                p.relative(p.join(packageDir, beneath ?? '.'), from: root),
-              ),
-            )
-            .path;
+    beneath = p.posix.joinAll(
+      p.split(
+        p.normalize(p.relative(p.join(packageDir, beneath ?? '.'), from: root)),
+      ),
+    );
     if (beneath == './') beneath = '.';
     String resolve(String path) {
       if (platform.isWindows) {

--- a/test/package_list_files_test.dart
+++ b/test/package_list_files_test.dart
@@ -497,6 +497,21 @@ void main() {
       });
     });
 
+    test('lists files when the package path contains spaces', () async {
+      await d.dir(appPath, [
+        d.dir('path with spaces', [
+          d.dir('package', [d.appPubspec(), d.file('file.txt', 'contents')]),
+        ]),
+      ]).create();
+
+      createEntrypoint(p.join(appPath, 'path with spaces', 'package'));
+
+      expect(entrypoint!.workspaceRoot.listFiles(), {
+        p.join(root, 'pubspec.yaml'),
+        p.join(root, 'file.txt'),
+      });
+    });
+
     test('ignores files that are gitignored', () async {
       await d.dir(appPath, [
         d.file('.gitignore', '*.txt'),


### PR DESCRIPTION
Packages nested beneath a Git repository path containing spaces can fail to publish because `Package.listFiles()` converts the relative filesystem path to a URI. The encoded `%20` path is then treated as a literal file path.

This preserves literal path components while converting separators to the POSIX form expected by ignore matching. The package file-listing suite covers the regression and existing ignore and symlink behavior.

Fixes #4221.
