### PR TITLE
Preserve workspace package identity during conflict resolution

### DIFF
--- a/lib/src/solver/partial_solution.dart
+++ b/lib/src/solver/partial_solution.dart
@@ -14,6 +14,12 @@ import 'term.dart';
 ///
 /// See https://github.com/dart-lang/pub/tree/master/doc/solver.md#partial-solution.
 class PartialSolution {
+  /// The canonical [PackageRef]s of workspace root packages, keyed by package
+  /// name.
+  ///
+  /// A dependency on any member of a workspace is treated as a dependency on
+  /// that workspace's root package, so all solver operations canonicalize
+  /// member references through this map before registering or relating terms.
   final Map<String, PackageRef> _rootRefs;
 
   PartialSolution([this._rootRefs = const {}]);
@@ -145,7 +151,6 @@ class PartialSolution {
   ///
   /// Throws a [StateError] if [term] isn't satisfied by `this`.
   Assignment satisfier(Term term) {
-    term = Term(canonicalize(term.package), term.isPositive);
     final prefix = PartialSolution(_rootRefs);
     for (var assignment in _assignments) {
       if (assignment.package.name != term.package.name) continue;

--- a/lib/src/solver/partial_solution.dart
+++ b/lib/src/solver/partial_solution.dart
@@ -14,6 +14,10 @@ import 'term.dart';
 ///
 /// See https://github.com/dart-lang/pub/tree/master/doc/solver.md#partial-solution.
 class PartialSolution {
+  final Map<String, PackageRef> _rootRefs;
+
+  PartialSolution([this._rootRefs = const {}]);
+
   /// The assignments that have been made so far, in the order they were
   /// assigned.
   final _assignments = <Assignment>[];
@@ -69,6 +73,7 @@ class PartialSolution {
 
   /// Adds an assignment of [package] as a derivation.
   void derive(PackageRange package, bool isPositive, Incompatibility cause) {
+    package = canonicalize(package);
     _assign(
       Assignment.derivation(
         package,
@@ -140,27 +145,13 @@ class PartialSolution {
   ///
   /// Throws a [StateError] if [term] isn't satisfied by `this`.
   Assignment satisfier(Term term) {
-    Term? assignedTerm;
+    term = Term(canonicalize(term.package), term.isPositive);
+    final prefix = PartialSolution(_rootRefs);
     for (var assignment in _assignments) {
       if (assignment.package.name != term.package.name) continue;
 
-      if (!assignment.package.isRoot &&
-          assignment.package.toRef() != term.package.toRef()) {
-        // not foo from hosted has no bearing on foo from git
-        if (!assignment.isPositive) continue;
-
-        // foo from hosted satisfies not foo from git
-        assert(!term.isPositive);
-        return assignment;
-      }
-
-      assignedTerm =
-          assignedTerm == null
-              ? assignment
-              : assignedTerm.intersect(assignment);
-
-      // As soon as we have enough assignments to satisfy [term], return them.
-      if (assignedTerm!.satisfies(term)) return assignment;
+      prefix._register(assignment);
+      if (prefix.satisfies(term)) return assignment;
     }
 
     throw StateError('[BUG] $term is not satisfied.');
@@ -175,6 +166,7 @@ class PartialSolution {
   /// Returns the relationship between the package versions allowed by all
   /// assignments in `this` and those allowed by [term].
   SetRelation relation(Term term) {
+    term = Term(canonicalize(term.package), term.isPositive);
     final positive = _positive[term.package.name];
     if (positive != null) return positive.relation(term);
 
@@ -184,11 +176,13 @@ class PartialSolution {
     final byRef = _negative[term.package.name];
     if (byRef == null) return SetRelation.overlapping;
 
-    // not foo from git is a superset of foo from hosted
-    // not foo from git overlaps not foo from hosted
     final negative = byRef[term.package.toRef()];
     if (negative == null) return SetRelation.overlapping;
 
     return negative.relation(term);
   }
+
+  /// Returns [package] with its workspace root reference, if it has one.
+  PackageRange canonicalize(PackageRange package) =>
+      _rootRefs[package.name]?.withConstraint(package.constraint) ?? package;
 }

--- a/lib/src/solver/version_solver.dart
+++ b/lib/src/solver/version_solver.dart
@@ -48,7 +48,10 @@ class VersionSolver {
 
   /// The partial solution that contains package versions we've selected and
   /// assignments we've derived from those versions and [_incompatibilities].
-  final _solution = PartialSolution();
+  late final _solution = PartialSolution({
+    for (final package in _rootPackages.values)
+      package.name: PackageRef.root(package),
+  });
 
   /// Package listers that lazily convert package versions' dependencies into
   /// incompatibilities.
@@ -330,7 +333,9 @@ class VersionSolver {
         for (var term in incompatibility.terms)
           if (term != mostRecentTerm) term,
         for (var term in mostRecentSatisfier.cause!.terms)
-          if (term.package != mostRecentSatisfier.package) term,
+          if (_solution.canonicalize(term.package) !=
+              mostRecentSatisfier.package)
+            term,
       ];
 
       // The [mostRecentSatisfier] may not satisfy [mostRecentTerm] on its own

--- a/test/partial_solution_test.dart
+++ b/test/partial_solution_test.dart
@@ -58,6 +58,13 @@ void main() {
     }
   });
 
+  test('finds a satisfier for a non-root workspace reference', () {
+    final hostedNegative = Term(firstRef.withConstraint(firstVersion), false);
+    final solution = solutionFor([hostedNegative]);
+
+    expect(solution.satisfier(hostedNegative).index, 0);
+  });
+
   test('keeps ordinary source references separate', () {
     final solution = PartialSolution();
     final firstNegative = Term(firstRef.withConstraint(firstVersion), false);

--- a/test/partial_solution_test.dart
+++ b/test/partial_solution_test.dart
@@ -1,0 +1,124 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'package:pub/src/package_name.dart';
+import 'package:pub/src/solver/incompatibility.dart';
+import 'package:pub/src/solver/incompatibility_cause.dart';
+import 'package:pub/src/solver/partial_solution.dart';
+import 'package:pub/src/solver/term.dart';
+import 'package:pub/src/source/hosted.dart';
+import 'package:pub/src/source/root.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final firstVersion = Version(1, 0, 0);
+  final secondVersion = Version(2, 0, 0);
+  final firstRef = PackageRef(
+    'foo',
+    HostedDescription('foo', 'https://first.example'),
+  );
+  final secondRef = PackageRef(
+    'foo',
+    HostedDescription('foo', 'https://second.example'),
+  );
+  final rootRef = PackageRef('foo', RootDescription('/workspace/foo'));
+  final cause = Incompatibility([
+    Term(rootRef.withConstraint(VersionConstraint.any), true),
+  ], NoVersionsIncompatibilityCause());
+
+  PartialSolution solutionFor(Iterable<Term> terms) {
+    final solution = PartialSolution({'foo': rootRef});
+    for (final term in terms) {
+      solution.derive(term.package, term.isPositive, cause);
+    }
+    return solution;
+  }
+
+  test('finds satisfiers across root-compatible source references', () {
+    final firstNegative = Term(firstRef.withConstraint(firstVersion), false);
+    final secondNegative = Term(secondRef.withConstraint(secondVersion), false);
+    final rootNegative = Term(
+      rootRef.withConstraint(firstVersion.union(secondVersion)),
+      false,
+    );
+
+    for (final terms in [
+      [firstNegative, secondNegative],
+      [secondNegative, firstNegative],
+    ]) {
+      final solution = solutionFor(terms);
+
+      expect(solution.satisfies(rootNegative), isTrue);
+      expect(solution.satisfier(rootNegative).index, 1);
+    }
+  });
+
+  test('keeps ordinary source references separate', () {
+    final solution = PartialSolution();
+    final firstNegative = Term(firstRef.withConstraint(firstVersion), false);
+    final secondNegative = Term(secondRef.withConstraint(secondVersion), false);
+
+    solution.derive(firstNegative.package, false, cause);
+    solution.derive(secondNegative.package, false, cause);
+
+    expect(solution.satisfies(firstNegative), isTrue);
+    expect(solution.satisfies(secondNegative), isTrue);
+    expect(
+      solution.satisfies(Term(firstRef.withConstraint(secondVersion), false)),
+      isFalse,
+    );
+    expect(
+      solution.satisfies(Term(secondRef.withConstraint(firstVersion), false)),
+      isFalse,
+    );
+  });
+
+  test('applies root negatives regardless of assignment order', () {
+    final rootNegative = Term(rootRef.withConstraint(firstVersion), false);
+    final positive = Term(firstRef.withConstraint(VersionConstraint.any), true);
+    final firstNegative = Term(firstRef.withConstraint(firstVersion), false);
+
+    for (final terms in [
+      [rootNegative, positive],
+      [positive, rootNegative],
+    ]) {
+      final solution = solutionFor(terms);
+
+      expect(solution.satisfies(firstNegative), isTrue);
+    }
+  });
+
+  test('preserves root projections when positive references mix', () {
+    final rootPositive = Term(
+      rootRef.withConstraint(VersionConstraint.any),
+      true,
+    );
+    final firstPositive = Term(
+      firstRef.withConstraint(VersionConstraint.any),
+      true,
+    );
+    final secondNegative = Term(secondRef.withConstraint(secondVersion), false);
+    final rootNegative = Term(rootRef.withConstraint(secondVersion), false);
+
+    final rootSolution = solutionFor([rootPositive, secondNegative]);
+    expect(rootSolution.satisfies(rootNegative), isTrue);
+    expect(rootSolution.satisfier(rootNegative).index, 1);
+
+    final rootFirst = solutionFor([
+      rootPositive,
+      secondNegative,
+      firstPositive,
+    ]);
+    expect(rootFirst.satisfies(rootNegative), isTrue);
+    expect(rootFirst.satisfier(rootNegative).index, 1);
+
+    final rootLast = solutionFor([firstPositive, secondNegative, rootPositive]);
+    expect(rootLast.satisfies(rootNegative), isTrue);
+    expect(rootLast.satisfier(rootNegative).index, 1);
+  });
+}

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -169,6 +169,67 @@ void main() {
     ], generatorVersion: '3.5.0').validate();
   });
 
+  test('reports dependency conflicts with nested workspace members', () async {
+    final server = await servePackages();
+    server.serve('workspace_dep', '1.0.0');
+    server.serve('shared_dep', '1.0.0');
+    server.serve('shared_dep', '2.0.0');
+    await dir(appPath, [
+      libPubspec(
+        'myapp',
+        '1.2.3',
+        devDeps: {'shared_dep': '^2.0.0'},
+        extras: {
+          'workspace': ['pkgs/app', 'pkgs/inner'],
+        },
+        sdk: '^3.5.0',
+      ),
+      dir('pkgs', [
+        dir('app', [
+          libPubspec(
+            'app',
+            '1.0.0',
+            deps: {'workspace_dep': 'any'},
+            resolutionWorkspace: true,
+          ),
+        ]),
+        dir('inner', [
+          libPubspec(
+            'inner',
+            '1.0.0',
+            extras: {
+              'workspace': ['workspace_dep'],
+            },
+            resolutionWorkspace: true,
+          ),
+          dir('workspace_dep', [
+            libPubspec(
+              'workspace_dep',
+              '1.0.0',
+              devDeps: {'shared_dep': '^1.0.0'},
+              resolutionWorkspace: true,
+            ),
+          ]),
+        ]),
+      ]),
+    ]).create();
+
+    await pubGet(
+      environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+      error: allOf(
+        contains('workspace_dep'),
+        contains('shared_dep ^1.0.0'),
+        contains('shared_dep ^2.0.0'),
+        contains('version solving failed.'),
+        isNot(contains('Null check operator used on a null value')),
+        isNot(contains('!term.isPositive')),
+        isNot(
+          contains('Duplicate name workspace_dep in generated package config'),
+        ),
+      ),
+    );
+  });
+
   test('checks constraints between workspace members', () async {
     await servePackages();
     await dir(appPath, [


### PR DESCRIPTION
Nested workspaces can currently reach conflict resolution with a workspace package represented by both its root and declared dependency source. `PartialSolution` then records inconsistent package identities, causing an ordinary dependency conflict to fail with an assertion or null error instead of a solver explanation.

This canonicalizes every transitive workspace package to its root reference at the `PartialSolution` boundary, including conflict cause comparisons, while leaving ordinary non-workspace sources distinct. Satisfier lookup now replays assignments through the same canonical state.

The regression reproduces the conflicting nested-workspace constraints and verifies a normal version-solving failure. Focused `PartialSolution` coverage checks assignment order and source separation.

Fixes #4652
