### PR TITLE
Fast-path literal workspace entries to avoid O(N^2) traversal using full globbing

### DIFF
--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -589,6 +589,14 @@ See https://dart.dev/go/workspaces-stray-files for details.
   }
 }
 
+/// Returns whether [s] contains any glob wildcard syntax characters.
+///
+/// We intentionally do not account for backslash-escaped wildcards (like `\*`).
+/// Paths without any of these characters are guaranteed to be plain relative
+/// paths that can be checked directly on the filesystem without unescaping or
+/// glob parsing. Paths containing these characters (even if escaped) are
+/// delegated to `package:glob` to handle unescaping properly and to avoid
+/// conflicting with Windows `\` path separators.
 bool _hasGlobWildcards(String s) =>
     s.contains('*') || s.contains('?') || s.contains('[') || s.contains('{');
 String _useBackSlashesOnWindows(String path) {

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -181,7 +181,8 @@ class Package {
         pubspec.workspace.expand((workspacePath) {
           final packages = <Package>[];
           var globHint = '';
-          if (pubspec.languageVersion.supportsWorkspaceGlobs) {
+          if (pubspec.languageVersion.supportsWorkspaceGlobs &&
+              _hasGlobWildcards(workspacePath)) {
             final Glob glob;
             try {
               glob = Glob(workspacePath);
@@ -200,9 +201,14 @@ class Package {
               );
             }
           } else {
-            final pubspecPath = p.join(dir, workspacePath, 'pubspec.yaml');
+            final pubspecPath = p.join(
+              dir,
+              _useBackSlashesOnWindows(workspacePath),
+              'pubspec.yaml',
+            );
             if (!fileExists(pubspecPath)) {
-              if (_looksLikeGlob(workspacePath)) {
+              if (!pubspec.languageVersion.supportsWorkspaceGlobs &&
+                  _hasGlobWildcards(workspacePath)) {
                 globHint = '''
 \n\nGlob syntax is only supported from language version ${LanguageVersion.firstVersionWithWorkspaceGlobs}.
 Consider changing the language version of ${p.join(dir, 'pubspec.yaml')} to ${LanguageVersion.firstVersionWithWorkspaceGlobs}.
@@ -583,7 +589,8 @@ See https://dart.dev/go/workspaces-stray-files for details.
   }
 }
 
-bool _looksLikeGlob(String s) => Glob.quote(s) != s;
+bool _hasGlobWildcards(String s) =>
+    s.contains('*') || s.contains('?') || s.contains('[') || s.contains('{');
 String _useBackSlashesOnWindows(String path) {
   if (platform.isWindows) {
     return p.joinAll(p.split(path));

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -1996,6 +1996,100 @@ Consider changing the language version of .${s}pubspec.yaml to 3.11.'''),
       ]).validate();
     },
   );
+
+  test('literal workspace entries with platform separators work with newer '
+      'language versions', () async {
+    await dir(appPath, [
+      libPubspec(
+        'myapp',
+        '1.2.3',
+        extras: {
+          'workspace': [p.join('pkgs', 'foo')],
+        },
+        sdk: '^3.11.0',
+      ),
+      dir('pkgs', [
+        dir('foo', [libPubspec('foo', '1.1.1', resolutionWorkspace: true)]),
+      ]),
+    ]).create();
+    await pubGet(environment: {'_PUB_TEST_SDK_VERSION': '3.11.0'});
+    await dir(appPath, [
+      packageConfigFile([
+        packageConfigEntry(name: 'myapp', path: '.'),
+        packageConfigEntry(name: 'foo', path: 'pkgs/foo'),
+      ], generatorVersion: '3.11.0'),
+    ]).validate();
+  });
+
+  test('literal workspace entries with special characters work with newer '
+      'language versions', () async {
+    await dir(appPath, [
+      libPubspec(
+        'myapp',
+        '1.2.3',
+        extras: {
+          'workspace': [
+            'pkgs/my space',
+            'pkgs/@scope',
+            'pkgs/pkg.v1',
+            'pkgs/pkg+plus',
+            'pkgs/pkg(paren)',
+          ],
+        },
+        sdk: '^3.11.0',
+      ),
+      dir('pkgs', [
+        dir('my space', [
+          libPubspec('my_space', '1.1.1', resolutionWorkspace: true),
+        ]),
+        dir('@scope', [
+          libPubspec('scope_pkg', '1.1.1', resolutionWorkspace: true),
+        ]),
+        dir('pkg.v1', [
+          libPubspec('pkg_v1', '1.1.1', resolutionWorkspace: true),
+        ]),
+        dir('pkg+plus', [
+          libPubspec('pkg_plus', '1.1.1', resolutionWorkspace: true),
+        ]),
+        dir('pkg(paren)', [
+          libPubspec('pkg_paren', '1.1.1', resolutionWorkspace: true),
+        ]),
+      ]),
+    ]).create();
+    await pubGet(environment: {'_PUB_TEST_SDK_VERSION': '3.11.0'});
+    await dir(appPath, [
+      packageConfigFile([
+        packageConfigEntry(name: 'myapp', path: '.'),
+        packageConfigEntry(name: 'my_space', path: 'pkgs/my space'),
+        packageConfigEntry(name: 'scope_pkg', path: 'pkgs/@scope'),
+        packageConfigEntry(name: 'pkg_v1', path: 'pkgs/pkg.v1'),
+        packageConfigEntry(name: 'pkg_plus', path: 'pkgs/pkg+plus'),
+        packageConfigEntry(name: 'pkg_paren', path: 'pkgs/pkg(paren)'),
+      ], generatorVersion: '3.11.0'),
+    ]).validate();
+  });
+
+  test('non-existent literal workspace entry gives good error with newer '
+      'language versions', () async {
+    await dir(appPath, [
+      libPubspec(
+        'myapp',
+        '1.2.3',
+        extras: {
+          'workspace': ['pkgs/nonexistent'],
+        },
+        sdk: '^3.11.0',
+      ),
+    ]).create();
+    await pubGet(
+      environment: {'_PUB_TEST_SDK_VERSION': '3.11.0'},
+      error: contains(
+        'No workspace packages matching `pkgs/nonexistent`.\n'
+        'That was included in the workspace of `.${s}pubspec.yaml`.',
+      ),
+      exitCode: DATA,
+    );
+  });
 }
 
 final s = p.separator;

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -2087,7 +2087,7 @@ Consider changing the language version of .${s}pubspec.yaml to 3.11.'''),
         'No workspace packages matching `pkgs/nonexistent`.\n'
         'That was included in the workspace of `.${s}pubspec.yaml`.',
       ),
-      exitCode: DATA,
+      exitCode: 1,
     );
   });
 }

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -1960,6 +1960,42 @@ Consider changing the language version of .${s}pubspec.yaml to 3.11.'''),
       ], generatorVersion: '3.11.0'),
     ]).validate();
   });
+
+  test(
+    'literal workspace entries are resolved with newer language versions',
+    () async {
+      await dir(appPath, [
+        libPubspec(
+          'myapp',
+          '1.2.3',
+          extras: {
+            'workspace': ['pkgs/foo-bar', 'pkgs/baz_qux', 'other_pkgs/*'],
+          },
+          sdk: '^3.11.0',
+        ),
+        dir('pkgs', [
+          dir('foo-bar', [
+            libPubspec('foo_bar', '1.1.1', resolutionWorkspace: true),
+          ]),
+          dir('baz_qux', [
+            libPubspec('baz_qux', '1.1.1', resolutionWorkspace: true),
+          ]),
+        ]),
+        dir('other_pkgs', [
+          dir('a', [libPubspec('a', '1.1.1', resolutionWorkspace: true)]),
+        ]),
+      ]).create();
+      await pubGet(environment: {'_PUB_TEST_SDK_VERSION': '3.11.0'});
+      await dir(appPath, [
+        packageConfigFile([
+          packageConfigEntry(name: 'myapp', path: '.'),
+          packageConfigEntry(name: 'foo_bar', path: 'pkgs/foo-bar'),
+          packageConfigEntry(name: 'baz_qux', path: 'pkgs/baz_qux'),
+          packageConfigEntry(name: 'a', path: 'other_pkgs/a'),
+        ], generatorVersion: '3.11.0'),
+      ]).validate();
+    },
+  );
 }
 
 final s = p.separator;


### PR DESCRIPTION
When resolving workspace members in language versions >= 3.11, entries without glob wildcard syntax characters (`*`, `?`, `[`, `{`) are now resolved directly via a filesystem check rather than delegating to `package:glob`'s `listSync`.

Delegating literal entries (such as `packages/package_0`) to `package:glob` caused `listSync` to enumerate the entire `packages/` directory for each of the $N$ entries, causing an $O(N^2)$ explosion in directory entries traversed.

Fixes #4850