### PR TITLE
Add ApiBreakageValidator to run dart_apitool before dart pub publish

### DIFF
--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -14,6 +14,7 @@ import 'path.dart';
 import 'sdk.dart';
 import 'system_cache.dart';
 import 'validator/analyze.dart';
+import 'validator/api_breakage.dart';
 import 'validator/changelog.dart';
 import 'validator/compiled_dartdoc.dart';
 import 'validator/dependency.dart';
@@ -146,6 +147,7 @@ abstract class Validator {
     final validators = [
       FileCaseValidator(),
       AnalyzeValidator(),
+      ApiBreakageValidator(),
       GitignoreValidator(),
       GitStatusValidator(),
       PubspecValidator(),

--- a/lib/src/validator/api_breakage.dart
+++ b/lib/src/validator/api_breakage.dart
@@ -43,6 +43,7 @@ class ApiBreakageValidator extends Validator {
 
     // If currentVersion is already a breaking SemVer bump relative to
     // previousVersion, breaking changes are expected.
+    // We compare baseVersion to account for pre-release versions.
     if (isBreakingVersionBump(previousVersion, currentVersion)) {
       return;
     }
@@ -52,14 +53,16 @@ class ApiBreakageValidator extends Validator {
       final previousDir = cache.getDirectory(downloadResult.packageId);
       final currentDir = package.dir;
 
-      final oldApi = await PackageApiAnalyzer(
-        packagePath: previousDir,
-        doAnalyzePlatformConstraints: false,
-      ).analyze();
-      final newApi = await PackageApiAnalyzer(
-        packagePath: currentDir,
-        doAnalyzePlatformConstraints: false,
-      ).analyze();
+      final oldApi =
+          await PackageApiAnalyzer(
+            packagePath: previousDir,
+            doAnalyzePlatformConstraints: false,
+          ).analyze();
+      final newApi =
+          await PackageApiAnalyzer(
+            packagePath: currentDir,
+            doAnalyzePlatformConstraints: false,
+          ).analyze();
 
       final diffResult = PackageApiDiffer().diff(
         oldApi: oldApi,
@@ -100,10 +103,9 @@ class ApiBreakageValidator extends Validator {
 /// Returns true if [newVersion] is a breaking change version bump over
 /// [oldVersion] according to Dart Semantic Versioning rules.
 bool isBreakingVersionBump(Version oldVersion, Version newVersion) {
-  final baseNewVersion = Version(
-    newVersion.major,
-    newVersion.minor,
-    newVersion.patch,
-  );
-  return baseNewVersion >= oldVersion.nextBreaking;
+  return newVersion.baseVersion >= oldVersion.nextBreaking;
+}
+
+extension on Version {
+  Version get baseVersion => Version(major, minor, patch);
 }

--- a/lib/src/validator/api_breakage.dart
+++ b/lib/src/validator/api_breakage.dart
@@ -96,8 +96,8 @@ class ApiBreakageValidator extends Validator {
           'bump.\n'
           'Suggested version: '
           '${baselineForBreakingCheck.version.nextBreaking}\n'
-          'Please bump your version according to Semantic Versioning before '
-          'publishing.\n'
+          'Consider either bumping your version or fixing the breaking '
+          'change(s) before publishing.\n'
           '\nDetected breaking changes:',
         );
         for (final change in breakingChanges) {

--- a/lib/src/validator/api_breakage.dart
+++ b/lib/src/validator/api_breakage.dart
@@ -1,0 +1,104 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:dart_apitool/api_tool.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+import '../exceptions.dart';
+import '../log.dart' as log;
+import '../package_name.dart';
+import '../validator.dart';
+
+/// A validator that uses `dart_apitool` to check for breaking API changes
+/// compared to the previous published version on the package server.
+///
+/// Emits a warning during `dart pub publish` if breaking changes are detected
+/// when publishing a non-breaking version bump (e.g. minor or patch bump).
+class ApiBreakageValidator extends Validator {
+  @override
+  Future<void> validate() async {
+    final hostedSource = cache.hosted;
+    List<PackageId> existingVersions;
+    try {
+      existingVersions = await cache.getVersions(
+        hostedSource.refFor(package.name, url: serverUrl.toString()),
+      );
+    } on PackageNotFoundException {
+      existingVersions = [];
+    }
+    existingVersions.sort((a, b) => a.version.compareTo(b.version));
+
+    final currentVersion = package.version;
+    final previousRelease = existingVersions.lastWhereOrNull(
+      (id) => id.version < currentVersion,
+    );
+
+    if (previousRelease == null) return;
+
+    final previousVersion = previousRelease.version;
+
+    // If currentVersion is already a breaking SemVer bump relative to
+    // previousVersion, breaking changes are expected.
+    if (isBreakingVersionBump(previousVersion, currentVersion)) {
+      return;
+    }
+
+    try {
+      final downloadResult = await cache.downloadPackage(previousRelease);
+      final previousDir = cache.getDirectory(downloadResult.packageId);
+      final currentDir = package.dir;
+
+      final oldApi = await PackageApiAnalyzer(
+        packagePath: previousDir,
+        doAnalyzePlatformConstraints: false,
+      ).analyze();
+      final newApi = await PackageApiAnalyzer(
+        packagePath: currentDir,
+        doAnalyzePlatformConstraints: false,
+      ).analyze();
+
+      final diffResult = PackageApiDiffer().diff(
+        oldApi: oldApi,
+        newApi: newApi,
+      );
+
+      final breakingChanges =
+          diffResult.apiChanges
+              .where(
+                (change) =>
+                    change.isBreaking && change.affectedDeclaration != null,
+              )
+              .toList();
+
+      if (breakingChanges.isNotEmpty) {
+        final buffer = StringBuffer();
+        buffer.writeln(
+          'Breaking API change(s) detected compared to published version '
+          '$previousVersion.\n'
+          'Your current version ($currentVersion) is not a breaking SemVer '
+          'bump.\n'
+          'Suggested version: ${previousVersion.nextBreaking}\n'
+          'Please bump your version according to Semantic Versioning before '
+          'publishing.\n'
+          '\nDetected breaking changes:',
+        );
+        for (final change in breakingChanges) {
+          buffer.writeln('  - ${change.changeDescription}');
+        }
+        warnings.add(buffer.toString().trimRight());
+      }
+    } catch (error, stackTrace) {
+      log.fine('dart_apitool analysis failed:\n$error\n$stackTrace');
+    }
+  }
+}
+
+/// Returns true if [newVersion] is a breaking change version bump over
+/// [oldVersion] according to Dart Semantic Versioning rules.
+bool isBreakingVersionBump(Version oldVersion, Version newVersion) {
+  return newVersion >= oldVersion.nextBreaking;
+}

--- a/lib/src/validator/api_breakage.dart
+++ b/lib/src/validator/api_breakage.dart
@@ -100,5 +100,10 @@ class ApiBreakageValidator extends Validator {
 /// Returns true if [newVersion] is a breaking change version bump over
 /// [oldVersion] according to Dart Semantic Versioning rules.
 bool isBreakingVersionBump(Version oldVersion, Version newVersion) {
-  return newVersion >= oldVersion.nextBreaking;
+  final baseNewVersion = Version(
+    newVersion.major,
+    newVersion.minor,
+    newVersion.patch,
+  );
+  return baseNewVersion >= oldVersion.nextBreaking;
 }

--- a/lib/src/validator/api_breakage.dart
+++ b/lib/src/validator/api_breakage.dart
@@ -41,10 +41,20 @@ class ApiBreakageValidator extends Validator {
 
     final previousVersion = previousRelease.version;
 
-    // If currentVersion is already a breaking SemVer bump relative to
-    // previousVersion, breaking changes are expected.
-    // We compare baseVersion to account for pre-release versions.
-    if (isBreakingVersionBump(previousVersion, currentVersion)) {
+    // Find the latest stable release before currentVersion to determine if
+    // currentVersion represents a breaking release cycle.
+    final previousStable = existingVersions.lastWhereOrNull(
+      (id) => !id.version.isPreRelease && id.version < currentVersion,
+    );
+
+    // If currentVersion is already a breaking SemVer bump relative to the
+    // previous stable version (or previous release), breaking changes are
+    // expected.
+    final baselineForBreakingCheck = previousStable ?? previousRelease;
+    if (isBreakingVersionBump(
+      baselineForBreakingCheck.version,
+      currentVersion,
+    )) {
       return;
     }
 
@@ -84,7 +94,8 @@ class ApiBreakageValidator extends Validator {
           '$previousVersion.\n'
           'Your current version ($currentVersion) is not a breaking SemVer '
           'bump.\n'
-          'Suggested version: ${previousVersion.nextBreaking}\n'
+          'Suggested version: '
+          '${baselineForBreakingCheck.version.nextBreaking}\n'
           'Please bump your version according to Semantic Versioning before '
           'publishing.\n'
           '\nDetected breaking changes:',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.2.0"
+  ansicolor:
+    dependency: transitive
+    description:
+      name: ansicolor
+      sha256: "50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.9"
   args:
     dependency: "direct main"
     description:
@@ -41,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.1"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
   checks:
     dependency: "direct dev"
     description:
@@ -73,6 +105,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  colorize:
+    dependency: transitive
+    description:
+      name: colorize
+      sha256: "584746cd6ba1cba0633b6720f494fe6f9601c4170f0666c1579d2aa2a61071ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  colorize_lumberdash:
+    dependency: transitive
+    description:
+      name: colorize_lumberdash
+      sha256: "6069ad908445caab046e93738c4f941536b6266076f2998b4ac6c012355eb1ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
+  console:
+    dependency: transitive
+    description:
+      name: console
+      sha256: e04e7824384c5b39389acdd6dc7d33f3efe6b232f6f16d7626f194f6a01ad69a
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   convert:
     dependency: "direct main"
     description:
@@ -97,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  dart_apitool:
+    dependency: "direct main"
+    description:
+      name: dart_apitool
+      sha256: e2d855e0016ecf913c081b9a4b79693d668d36490c96af724231c1b5f8e49cd5
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.23.2"
   dart_flutter_team_lints:
     dependency: "direct dev"
     description:
@@ -105,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.5.2"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   file:
     dependency: "direct main"
     description:
@@ -113,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   frontend_server_client:
     dependency: "direct main"
     description:
@@ -169,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.12.0"
   lints:
     dependency: transitive
     description:
@@ -185,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  lumberdash:
+    dependency: transitive
+    description:
+      name: lumberdash
+      sha256: "1bc3750c094adb7f213a61883ca9878ba052fde52d9974b9039598c651fe096c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   matcher:
     dependency: transitive
     description:
@@ -233,6 +329,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
+  plist_parser:
+    dependency: transitive
+    description:
+      name: plist_parser
+      sha256: bd54826ac383526262e90cfe68779b73c817721de2efd769d070e2ff637af71c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.7"
   pool:
     dependency: "direct main"
     description:
@@ -241,6 +353,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.2"
   pub_semver:
     dependency: "direct main"
     description:
@@ -249,6 +369,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  pubspec_manager:
+    dependency: transitive
+    description:
+      name: pubspec_manager
+      sha256: "416609635f6c53ab759223ae66e71282e61a863c13ec47d60381e4b8046c2a71"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   shelf:
     dependency: "direct main"
     description:
@@ -289,6 +425,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  simple_sparse_list:
+    dependency: transitive
+    description:
+      name: simple_sparse_list
+      sha256: aa648fd240fa39b49dcd11c19c266990006006de6699a412de485695910fbc1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -313,6 +457,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  stack:
+    dependency: transitive
+    description:
+      name: stack
+      sha256: f5a3032c965b74f394dc6aa138c82373a3403438c68cf5d8e6ef2bc2698949bf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   stack_trace:
     dependency: "direct main"
     description:
@@ -337,6 +489,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  strings:
+    dependency: transitive
+    description:
+      name: strings
+      sha256: "8eccabcaad5f3b2d02b2bf8ca31ce1466fac7339229fd0472d63790f8c18095f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
   tar:
     dependency: "direct main"
     description:
@@ -393,6 +553,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   typed_data:
     dependency: "direct main"
     description:
@@ -401,6 +569,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  unicode:
+    dependency: transitive
+    description:
+      name: unicode
+      sha256: a6f7bcfc8ea1d5ce1f6c0b1c39117a9919f4953edd9fd7a64090a9796c499b57
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.9"
+  vector_math:
+    dependency: transitive
+    description:
+      name: vector_math
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -449,6 +633,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: "direct main"
     description:
@@ -466,4 +658,4 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.10.0 <4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,11 +109,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "64b6e78bc30400675abadfca016dd68f84ab942b"
-      resolved-ref: "64b6e78bc30400675abadfca016dd68f84ab942b"
+      ref: "6e94a0652c4c1c5566062408cd4263a7682a8e17"
+      resolved-ref: "6e94a0652c4c1c5566062408cd4263a7682a8e17"
       url: "https://github.com/mosuem/dart_apitool.git"
     source: git
-    version: "0.23.3"
+    version: "0.24.0"
   dart_flutter_team_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,22 +17,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.2.0"
-  ansicolor:
-    dependency: transitive
-    description:
-      name: ansicolor
-      sha256: "50e982d500bc863e1d703448afdbf9e5a72eb48840a4f766fa361ffd6877055f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.3"
-  archive:
-    dependency: transitive
-    description:
-      name: archive
-      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.9"
   args:
     dependency: "direct main"
     description:
@@ -57,14 +41,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  characters:
-    dependency: transitive
-    description:
-      name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -105,30 +81,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
-  colorize:
-    dependency: transitive
-    description:
-      name: colorize
-      sha256: "584746cd6ba1cba0633b6720f494fe6f9601c4170f0666c1579d2aa2a61071ba"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
-  colorize_lumberdash:
-    dependency: transitive
-    description:
-      name: colorize_lumberdash
-      sha256: "6069ad908445caab046e93738c4f941536b6266076f2998b4ac6c012355eb1ba"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
-  console:
-    dependency: transitive
-    description:
-      name: console
-      sha256: e04e7824384c5b39389acdd6dc7d33f3efe6b232f6f16d7626f194f6a01ad69a
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.1.0"
   convert:
     dependency: "direct main"
     description:
@@ -156,11 +108,12 @@ packages:
   dart_apitool:
     dependency: "direct main"
     description:
-      name: dart_apitool
-      sha256: e2d855e0016ecf913c081b9a4b79693d668d36490c96af724231c1b5f8e49cd5
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.23.2"
+      path: "."
+      ref: d94e6f6bf4ba268e14387a1059efd28c089a2799
+      resolved-ref: d94e6f6bf4ba268e14387a1059efd28c089a2799
+      url: "https://github.com/bmw-tech/dart_apitool.git"
+    source: git
+    version: "0.23.3"
   dart_flutter_team_lints:
     dependency: "direct dev"
     description:
@@ -169,14 +122,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.5.2"
-  ffi:
-    dependency: transitive
-    description:
-      name: ffi
-      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
   file:
     dependency: "direct main"
     description:
@@ -273,14 +218,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  lumberdash:
-    dependency: transitive
-    description:
-      name: lumberdash
-      sha256: "1bc3750c094adb7f213a61883ca9878ba052fde52d9974b9039598c651fe096c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
   matcher:
     dependency: transitive
     description:
@@ -329,22 +266,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.2"
-  plist_parser:
-    dependency: transitive
-    description:
-      name: plist_parser
-      sha256: bd54826ac383526262e90cfe68779b73c817721de2efd769d070e2ff637af71c
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.7"
   pool:
     dependency: "direct main"
     description:
@@ -353,14 +274,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
-  posix:
-    dependency: transitive
-    description:
-      name: posix
-      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.5.2"
   pub_semver:
     dependency: "direct main"
     description:
@@ -369,14 +282,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  pubspec_manager:
-    dependency: transitive
-    description:
-      name: pubspec_manager
-      sha256: "416609635f6c53ab759223ae66e71282e61a863c13ec47d60381e4b8046c2a71"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.3"
   pubspec_parse:
     dependency: transitive
     description:
@@ -425,14 +330,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
-  simple_sparse_list:
-    dependency: transitive
-    description:
-      name: simple_sparse_list
-      sha256: aa648fd240fa39b49dcd11c19c266990006006de6699a412de485695910fbc1f
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -457,14 +354,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
-  stack:
-    dependency: transitive
-    description:
-      name: stack
-      sha256: f5a3032c965b74f394dc6aa138c82373a3403438c68cf5d8e6ef2bc2698949bf
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.2"
   stack_trace:
     dependency: "direct main"
     description:
@@ -489,14 +378,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
-  strings:
-    dependency: transitive
-    description:
-      name: strings
-      sha256: "8eccabcaad5f3b2d02b2bf8ca31ce1466fac7339229fd0472d63790f8c18095f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.1"
   tar:
     dependency: "direct main"
     description:
@@ -553,14 +434,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
-  tuple:
-    dependency: transitive
-    description:
-      name: tuple
-      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   typed_data:
     dependency: "direct main"
     description:
@@ -569,22 +442,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
-  unicode:
-    dependency: transitive
-    description:
-      name: unicode
-      sha256: a6f7bcfc8ea1d5ce1f6c0b1c39117a9919f4953edd9fd7a64090a9796c499b57
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.9"
-  vector_math:
-    dependency: transitive
-    description:
-      name: vector_math
-      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:
@@ -633,14 +490,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.6.1"
   yaml:
     dependency: "direct main"
     description:
@@ -658,4 +507,4 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
+  dart: ">=3.9.0 <4.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -109,9 +109,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: d94e6f6bf4ba268e14387a1059efd28c089a2799
-      resolved-ref: d94e6f6bf4ba268e14387a1059efd28c089a2799
-      url: "https://github.com/bmw-tech/dart_apitool.git"
+      ref: "64b6e78bc30400675abadfca016dd68f84ab942b"
+      resolved-ref: "64b6e78bc30400675abadfca016dd68f84ab942b"
+      url: "https://github.com/mosuem/dart_apitool.git"
     source: git
     version: "0.23.3"
   dart_flutter_team_lints:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   collection: ^1.19.1
   convert: ^3.1.2
   crypto: ^3.0.7
+  dart_apitool: ^0.23.2
   file: ^7.0.1
   frontend_server_client: ^4.0.0
   glob: ^2.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   dart_apitool:
     git:
       url: https://github.com/mosuem/dart_apitool.git
-      ref: 64b6e78bc30400675abadfca016dd68f84ab942b
+      ref: 6e94a0652c4c1c5566062408cd4263a7682a8e17
   file: ^7.0.1
   frontend_server_client: ^4.0.0
   glob: ^2.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,10 @@ dependencies:
   collection: ^1.19.1
   convert: ^3.1.2
   crypto: ^3.0.7
-  dart_apitool: ^0.23.2
+  dart_apitool:
+    git:
+      url: https://github.com/bmw-tech/dart_apitool.git
+      ref: d94e6f6bf4ba268e14387a1059efd28c089a2799
   file: ^7.0.1
   frontend_server_client: ^4.0.0
   glob: ^2.1.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   crypto: ^3.0.7
   dart_apitool:
     git:
-      url: https://github.com/bmw-tech/dart_apitool.git
-      ref: d94e6f6bf4ba268e14387a1059efd28c089a2799
+      url: https://github.com/mosuem/dart_apitool.git
+      ref: 64b6e78bc30400675abadfca016dd68f84ab942b
   file: ^7.0.1
   frontend_server_client: ^4.0.0
   glob: ^2.1.3

--- a/test/descriptor.dart
+++ b/test/descriptor.dart
@@ -47,7 +47,7 @@ DirectoryDescriptor validPackage({
   file('LICENSE', 'Eh, do what you want.'),
   file('README.md', "This package isn't real."),
   file('CHANGELOG.md', '# $version\nFirst version\n'),
-  dir('lib', [file('test_pkg.dart', 'int i = 1;')]),
+  dir('lib', [file('test_pkg.dart', 'main() => "test_pkg";')]),
 ]);
 
 /// Returns a descriptor of a snapshot that can't be run by the current VM.

--- a/test/validator/api_breakage_test.dart
+++ b/test/validator/api_breakage_test.dart
@@ -97,9 +97,7 @@ void main() {
           'environment': {'sdk': '>=3.1.2 <=3.2.0'},
         },
         contents: [
-          d.dir('lib', [
-            d.file('test_pkg.dart', 'void foo() {}'),
-          ]),
+          d.dir('lib', [d.file('test_pkg.dart', 'void foo() {}')]),
         ],
       );
 
@@ -108,9 +106,7 @@ void main() {
         d.file('LICENSE', 'Eh, do what you want.'),
         d.file('README.md', "This package isn't real."),
         d.file('CHANGELOG.md', '# 1.1.0\nFirst version\n'),
-        d.dir('lib', [
-          d.file('test_pkg.dart', 'void foo() {}\nvoid bar() {}'),
-        ]),
+        d.dir('lib', [d.file('test_pkg.dart', 'void foo() {}\nvoid bar() {}')]),
       ]).create();
 
       await expectValidation();
@@ -127,9 +123,7 @@ void main() {
             'environment': {'sdk': '>=3.1.2 <=3.2.0'},
           },
           contents: [
-            d.dir('lib', [
-              d.file('test_pkg.dart', 'void foo() {}'),
-            ]),
+            d.dir('lib', [d.file('test_pkg.dart', 'void foo() {}')]),
           ],
         );
 
@@ -138,9 +132,7 @@ void main() {
           d.file('LICENSE', 'Eh, do what you want.'),
           d.file('README.md', "This package isn't real."),
           d.file('CHANGELOG.md', '# 2.0.0\nFirst version\n'),
-          d.dir('lib', [
-            d.file('test_pkg.dart', 'void bar() {}'),
-          ]),
+          d.dir('lib', [d.file('test_pkg.dart', 'void bar() {}')]),
         ]).create();
 
         await expectValidation();
@@ -158,9 +150,7 @@ void main() {
             'environment': {'sdk': '>=3.1.2 <=3.2.0'},
           },
           contents: [
-            d.dir('lib', [
-              d.file('test_pkg.dart', 'void foo() {}'),
-            ]),
+            d.dir('lib', [d.file('test_pkg.dart', 'void foo() {}')]),
           ],
         );
 
@@ -169,9 +159,7 @@ void main() {
           d.file('LICENSE', 'Eh, do what you want.'),
           d.file('README.md', "This package isn't real."),
           d.file('CHANGELOG.md', '# 0.3.0-wip\nFirst version\n'),
-          d.dir('lib', [
-            d.file('test_pkg.dart', 'void bar() {}'),
-          ]),
+          d.dir('lib', [d.file('test_pkg.dart', 'void bar() {}')]),
         ]).create();
 
         await expectValidation();
@@ -189,9 +177,7 @@ void main() {
             'environment': {'sdk': '>=3.1.2 <=3.2.0'},
           },
           contents: [
-            d.dir('lib', [
-              d.file('test_pkg.dart', 'void foo() {}'),
-            ]),
+            d.dir('lib', [d.file('test_pkg.dart', 'void foo() {}')]),
           ],
         );
 
@@ -200,9 +186,7 @@ void main() {
           d.file('LICENSE', 'Eh, do what you want.'),
           d.file('README.md', "This package isn't real."),
           d.file('CHANGELOG.md', '# 1.1.0\nFirst version\n'),
-          d.dir('lib', [
-            d.file('test_pkg.dart', 'void bar() {}'),
-          ]),
+          d.dir('lib', [d.file('test_pkg.dart', 'void bar() {}')]),
         ]).create();
 
         await expectValidationWarning(

--- a/test/validator/api_breakage_test.dart
+++ b/test/validator/api_breakage_test.dart
@@ -46,6 +46,16 @@ void main() {
       );
     });
 
+    test('1.0.0 to 1.1.0-dev is not breaking', () {
+      expect(
+        isBreakingVersionBump(
+          Version.parse('1.0.0'),
+          Version.parse('1.1.0-dev'),
+        ),
+        isFalse,
+      );
+    });
+
     test('0.1.0 to 0.1.1 is not breaking', () {
       expect(
         isBreakingVersionBump(Version.parse('0.1.0'), Version.parse('0.1.1')),
@@ -166,6 +176,130 @@ void main() {
       },
     );
 
+    test('no warnings when iterating on a breaking prerelease cycle', () async {
+      final server = await servePackages();
+      server.serve(
+        'test_pkg',
+        '0.2.0',
+        pubspec: {
+          'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+        },
+        contents: [
+          d.dir('lib', [d.file('test_pkg.dart', 'void foo() {}')]),
+        ],
+      );
+      server.serve(
+        'test_pkg',
+        '0.3.0-dev.1',
+        pubspec: {
+          'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+        },
+        contents: [
+          d.dir('lib', [d.file('test_pkg.dart', 'void bar() {}')]),
+        ],
+      );
+
+      await d.dir(appPath, [
+        d.validPubspec(extras: {'version': '0.3.0-dev.2'}),
+        d.file('LICENSE', 'Eh, do what you want.'),
+        d.file('README.md', "This package isn't real."),
+        d.file('CHANGELOG.md', '# 0.3.0-dev.2\nFirst version\n'),
+        d.dir('lib', [d.file('test_pkg.dart', 'void baz() {}')]),
+      ]).create();
+
+      await expectValidation();
+    });
+
+    test(
+      'no warnings if SDK constraint is bumped in minor without API breakage',
+      () async {
+        final server = await servePackages();
+        server.serve(
+          'test_pkg',
+          '1.0.0',
+          pubspec: {
+            'environment': {'sdk': '^3.0.0'},
+          },
+          contents: [
+            d.dir('lib', [d.file('test_pkg.dart', 'void foo() {}')]),
+          ],
+        );
+
+        await d.dir(appPath, [
+          d.validPubspec(
+            extras: {
+              'version': '1.1.0',
+              'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+            },
+          ),
+          d.file('LICENSE', 'Eh, do what you want.'),
+          d.file('README.md', "This package isn't real."),
+          d.file('CHANGELOG.md', '# 1.1.0\nFirst version\n'),
+          d.dir('lib', [
+            d.file('test_pkg.dart', 'void foo() {}\nvoid bar() {}'),
+          ]),
+        ]).create();
+
+        await expectValidation();
+      },
+    );
+
+    test(
+      'no warnings on a clean backport patch when a higher major exists',
+      () async {
+        final server = await servePackages();
+        server.serve(
+          'test_pkg',
+          '1.0.0',
+          pubspec: {
+            'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+          },
+          contents: [
+            d.dir('lib', [d.file('test_pkg.dart', 'void foo() {}')]),
+          ],
+        );
+        server.serve(
+          'test_pkg',
+          '1.1.0',
+          pubspec: {
+            'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+          },
+          contents: [
+            d.dir('lib', [
+              d.file('test_pkg.dart', 'void foo() {}\nvoid bar() {}'),
+            ]),
+          ],
+        );
+        server.serve(
+          'test_pkg',
+          '2.0.0',
+          pubspec: {
+            'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+          },
+          contents: [
+            d.dir('lib', [d.file('test_pkg.dart', 'void completelyNew() {}')]),
+          ],
+        );
+
+        await d.dir(appPath, [
+          d.validPubspec(extras: {'version': '1.1.1'}),
+          d.file('LICENSE', 'Eh, do what you want.'),
+          d.file('README.md', "This package isn't real."),
+          d.file('CHANGELOG.md', '# 1.1.1\nFirst version\n'),
+          d.dir('lib', [
+            d.file(
+              'test_pkg.dart',
+              'void foo() {}\nvoid bar() {}\nvoid patchFix() {}',
+            ),
+          ]),
+        ]).create();
+
+        await expectValidation(
+          message: contains('Package has 0 warnings and 1 hint.'),
+        );
+      },
+    );
+
     test(
       'warns if breaking changes are published with a minor version bump',
       () async {
@@ -192,6 +326,129 @@ void main() {
         await expectValidationWarning(
           'Breaking API change(s) detected compared to published version '
           '1.0.0.',
+        );
+      },
+    );
+
+    test(
+      'warns if breaking changes are in a non-breaking prerelease bump',
+      () async {
+        final server = await servePackages();
+        server.serve(
+          'test_pkg',
+          '1.0.0',
+          pubspec: {
+            'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+          },
+          contents: [
+            d.dir('lib', [d.file('test_pkg.dart', 'void foo() {}')]),
+          ],
+        );
+
+        await d.dir(appPath, [
+          d.validPubspec(extras: {'version': '1.1.0-dev.1'}),
+          d.file('LICENSE', 'Eh, do what you want.'),
+          d.file('README.md', "This package isn't real."),
+          d.file('CHANGELOG.md', '# 1.1.0-dev.1\nFirst version\n'),
+          d.dir('lib', [d.file('test_pkg.dart', 'void bar() {}')]),
+        ]).create();
+
+        await expectValidationWarning(
+          'Breaking API change(s) detected compared to published version '
+          '1.0.0.',
+        );
+      },
+    );
+
+    test(
+      'warns if breaking changes are in a patch bump on an older branch',
+      () async {
+        final server = await servePackages();
+        server.serve(
+          'test_pkg',
+          '1.0.0',
+          pubspec: {
+            'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+          },
+          contents: [
+            d.dir('lib', [d.file('test_pkg.dart', 'void foo() {}')]),
+          ],
+        );
+        server.serve(
+          'test_pkg',
+          '1.1.0',
+          pubspec: {
+            'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+          },
+          contents: [
+            d.dir('lib', [
+              d.file('test_pkg.dart', 'void foo() {}\nvoid bar() {}'),
+            ]),
+          ],
+        );
+        server.serve(
+          'test_pkg',
+          '2.0.0',
+          pubspec: {
+            'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+          },
+          contents: [
+            d.dir('lib', [d.file('test_pkg.dart', 'void completelyNew() {}')]),
+          ],
+        );
+
+        await d.dir(appPath, [
+          d.validPubspec(extras: {'version': '1.1.1'}),
+          d.file('LICENSE', 'Eh, do what you want.'),
+          d.file('README.md', "This package isn't real."),
+          d.file('CHANGELOG.md', '# 1.1.1\nFirst version\n'),
+          d.dir('lib', [d.file('test_pkg.dart', 'void foo() {}')]),
+        ]).create();
+
+        await expectValidationWarning(
+          'Breaking API change(s) detected compared to published version '
+          '1.1.0.',
+        );
+      },
+    );
+
+    test(
+      'warns with all breaking changes listed when multiple exist',
+      () async {
+        final server = await servePackages();
+        server.serve(
+          'test_pkg',
+          '1.0.0',
+          pubspec: {
+            'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+          },
+          contents: [
+            d.dir('lib', [
+              d.file('test_pkg.dart', 'class MyClass {} void myFunction() {}'),
+            ]),
+          ],
+        );
+
+        await d.dir(appPath, [
+          d.validPubspec(extras: {'version': '1.1.0'}),
+          d.file('LICENSE', 'Eh, do what you want.'),
+          d.file('README.md', "This package isn't real."),
+          d.file('CHANGELOG.md', '# 1.1.0\nFirst version\n'),
+          d.dir('lib', [d.file('test_pkg.dart', 'void replacement() {}')]),
+        ]).create();
+
+        await expectValidation(
+          message: allOf([
+            contains(
+              'Breaking API change(s) detected compared to published version '
+              '1.0.0.',
+            ),
+            contains('Interface "MyClass" removed'),
+            contains('Function "myFunction" removed'),
+            contains('Suggested version: 2.0.0'),
+            contains('Package has 1 warning.'),
+          ]),
+          exitCode: 65,
         );
       },
     );

--- a/test/validator/api_breakage_test.dart
+++ b/test/validator/api_breakage_test.dart
@@ -36,6 +36,16 @@ void main() {
       );
     });
 
+    test('1.0.0 to 2.0.0-dev is breaking', () {
+      expect(
+        isBreakingVersionBump(
+          Version.parse('1.0.0'),
+          Version.parse('2.0.0-dev'),
+        ),
+        isTrue,
+      );
+    });
+
     test('0.1.0 to 0.1.1 is not breaking', () {
       expect(
         isBreakingVersionBump(Version.parse('0.1.0'), Version.parse('0.1.1')),
@@ -47,6 +57,26 @@ void main() {
       expect(
         isBreakingVersionBump(Version.parse('0.1.0'), Version.parse('0.2.0')),
         isTrue,
+      );
+    });
+
+    test('0.2.0 to 0.3.0-wip is breaking', () {
+      expect(
+        isBreakingVersionBump(
+          Version.parse('0.2.0'),
+          Version.parse('0.3.0-wip'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('0.2.0 to 0.2.1-wip is not breaking', () {
+      expect(
+        isBreakingVersionBump(
+          Version.parse('0.2.0'),
+          Version.parse('0.2.1-wip'),
+        ),
+        isFalse,
       );
     });
   });
@@ -108,6 +138,37 @@ void main() {
           d.file('LICENSE', 'Eh, do what you want.'),
           d.file('README.md', "This package isn't real."),
           d.file('CHANGELOG.md', '# 2.0.0\nFirst version\n'),
+          d.dir('lib', [
+            d.file('test_pkg.dart', 'void bar() {}'),
+          ]),
+        ]).create();
+
+        await expectValidation();
+      },
+    );
+
+    test(
+      'no warnings if breaking changes are in a breaking prerelease bump',
+      () async {
+        final server = await servePackages();
+        server.serve(
+          'test_pkg',
+          '0.2.0',
+          pubspec: {
+            'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+          },
+          contents: [
+            d.dir('lib', [
+              d.file('test_pkg.dart', 'void foo() {}'),
+            ]),
+          ],
+        );
+
+        await d.dir(appPath, [
+          d.validPubspec(extras: {'version': '0.3.0-wip'}),
+          d.file('LICENSE', 'Eh, do what you want.'),
+          d.file('README.md', "This package isn't real."),
+          d.file('CHANGELOG.md', '# 0.3.0-wip\nFirst version\n'),
           d.dir('lib', [
             d.file('test_pkg.dart', 'void bar() {}'),
           ]),

--- a/test/validator/api_breakage_test.dart
+++ b/test/validator/api_breakage_test.dart
@@ -1,0 +1,154 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'package:pub/src/validator/api_breakage.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+import 'utils.dart';
+
+void main() {
+  group('isBreakingVersionBump', () {
+    test('1.0.0 to 1.0.1 is not breaking', () {
+      expect(
+        isBreakingVersionBump(Version.parse('1.0.0'), Version.parse('1.0.1')),
+        isFalse,
+      );
+    });
+
+    test('1.0.0 to 1.1.0 is not breaking', () {
+      expect(
+        isBreakingVersionBump(Version.parse('1.0.0'), Version.parse('1.1.0')),
+        isFalse,
+      );
+    });
+
+    test('1.0.0 to 2.0.0 is breaking', () {
+      expect(
+        isBreakingVersionBump(Version.parse('1.0.0'), Version.parse('2.0.0')),
+        isTrue,
+      );
+    });
+
+    test('0.1.0 to 0.1.1 is not breaking', () {
+      expect(
+        isBreakingVersionBump(Version.parse('0.1.0'), Version.parse('0.1.1')),
+        isFalse,
+      );
+    });
+
+    test('0.1.0 to 0.2.0 is breaking', () {
+      expect(
+        isBreakingVersionBump(Version.parse('0.1.0'), Version.parse('0.2.0')),
+        isTrue,
+      );
+    });
+  });
+
+  group('ApiBreakageValidator', () {
+    test('no warnings if package has never been published', () async {
+      await servePackages();
+      await d.validPackage().create();
+      await expectValidation();
+    });
+
+    test('no warnings if no breaking changes are made', () async {
+      final server = await servePackages();
+      server.serve(
+        'test_pkg',
+        '1.0.0',
+        pubspec: {
+          'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+        },
+        contents: [
+          d.dir('lib', [
+            d.file('test_pkg.dart', 'void foo() {}'),
+          ]),
+        ],
+      );
+
+      await d.dir(appPath, [
+        d.validPubspec(extras: {'version': '1.1.0'}),
+        d.file('LICENSE', 'Eh, do what you want.'),
+        d.file('README.md', "This package isn't real."),
+        d.file('CHANGELOG.md', '# 1.1.0\nFirst version\n'),
+        d.dir('lib', [
+          d.file('test_pkg.dart', 'void foo() {}\nvoid bar() {}'),
+        ]),
+      ]).create();
+
+      await expectValidation();
+    });
+
+    test(
+      'no warnings if breaking changes are accompanied by breaking bump',
+      () async {
+        final server = await servePackages();
+        server.serve(
+          'test_pkg',
+          '1.0.0',
+          pubspec: {
+            'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+          },
+          contents: [
+            d.dir('lib', [
+              d.file('test_pkg.dart', 'void foo() {}'),
+            ]),
+          ],
+        );
+
+        await d.dir(appPath, [
+          d.validPubspec(extras: {'version': '2.0.0'}),
+          d.file('LICENSE', 'Eh, do what you want.'),
+          d.file('README.md', "This package isn't real."),
+          d.file('CHANGELOG.md', '# 2.0.0\nFirst version\n'),
+          d.dir('lib', [
+            d.file('test_pkg.dart', 'void bar() {}'),
+          ]),
+        ]).create();
+
+        await expectValidation();
+      },
+    );
+
+    test(
+      'warns if breaking changes are published with a minor version bump',
+      () async {
+        final server = await servePackages();
+        server.serve(
+          'test_pkg',
+          '1.0.0',
+          pubspec: {
+            'environment': {'sdk': '>=3.1.2 <=3.2.0'},
+          },
+          contents: [
+            d.dir('lib', [
+              d.file('test_pkg.dart', 'void foo() {}'),
+            ]),
+          ],
+        );
+
+        await d.dir(appPath, [
+          d.validPubspec(extras: {'version': '1.1.0'}),
+          d.file('LICENSE', 'Eh, do what you want.'),
+          d.file('README.md', "This package isn't real."),
+          d.file('CHANGELOG.md', '# 1.1.0\nFirst version\n'),
+          d.dir('lib', [
+            d.file('test_pkg.dart', 'void bar() {}'),
+          ]),
+        ]).create();
+
+        await expectValidationWarning(
+          'Breaking API change(s) detected compared to published version '
+          '1.0.0.',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
Implements https://github.com/dart-lang/sdk/issues/63970

Adds `ApiBreakageValidator` to validate whether breaking API changes are being published with a non-breaking version bump (e.g. minor or patch update). Uses `dart_apitool` in-process to diff public APIs against the baseline published package version.