### PR TITLE
Warn if analysis options are included from a file outside the package

### DIFF
--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -13,6 +13,7 @@ import 'package.dart';
 import 'path.dart';
 import 'sdk.dart';
 import 'system_cache.dart';
+import 'validator/analysis_options.dart';
 import 'validator/analyze.dart';
 import 'validator/changelog.dart';
 import 'validator/compiled_dartdoc.dart';
@@ -145,6 +146,7 @@ abstract class Validator {
   }) async {
     final validators = [
       FileCaseValidator(),
+      AnalysisOptionsValidator(),
       AnalyzeValidator(),
       GitignoreValidator(),
       GitStatusValidator(),

--- a/lib/src/validator/analysis_options.dart
+++ b/lib/src/validator/analysis_options.dart
@@ -1,0 +1,116 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+
+import '../io.dart';
+import '../path.dart';
+import '../validator.dart';
+
+/// Validates that `analysis_options.yaml` (and other analysis options files)
+/// do not include configuration from a local file outside the package.
+///
+/// Including files outside the package causes analysis errors on `pub.dev`
+/// and for consumers because those external files are not included in the
+/// published archive.
+final class AnalysisOptionsValidator extends Validator {
+  @override
+  Future<void> validate() async {
+    final candidates = <String>{
+      if (fileExists(p.join(package.dir, 'analysis_options.yaml')))
+        p.canonicalize(p.join(package.dir, 'analysis_options.yaml')),
+      if (fileExists(p.join(package.dir, '.analysis_options')))
+        p.canonicalize(p.join(package.dir, '.analysis_options')),
+      for (final file in files)
+        if (p.basename(file) == 'analysis_options.yaml' ||
+            p.basename(file) == '.analysis_options')
+          p.canonicalize(file),
+    };
+
+    final visited = <String>{};
+    for (final candidate in candidates) {
+      _validateAnalysisOptionsFile(candidate, visited);
+    }
+  }
+
+  void _validateAnalysisOptionsFile(String filePath, Set<String> visited) {
+    if (!visited.add(filePath)) return;
+    if (!fileExists(filePath)) return;
+
+    final String contents;
+    try {
+      contents = readTextFile(filePath);
+    } on IOException {
+      return;
+    }
+
+    final Object? yaml;
+    try {
+      yaml = loadYaml(contents);
+    } on FormatException {
+      return;
+    }
+
+    if (yaml is! Map) return;
+
+    final include = yaml['include'];
+    final includes = <String>[];
+    if (include is String) {
+      includes.add(include);
+    } else if (include is YamlScalar && include.value is String) {
+      includes.add(include.value as String);
+    } else if (include is List) {
+      for (final item in include) {
+        if (item is String) {
+          includes.add(item);
+        } else if (item is YamlScalar && item.value is String) {
+          includes.add(item.value as String);
+        }
+      }
+    }
+
+    final packageDir = p.canonicalize(package.dir);
+
+    for (final includeUri in includes) {
+      final parsedUri = Uri.tryParse(includeUri);
+      if (parsedUri != null && parsedUri.scheme == 'package') {
+        continue;
+      }
+
+      final String targetPath;
+      if (parsedUri != null && parsedUri.scheme == 'file') {
+        targetPath = p.canonicalize(p.fromUri(parsedUri));
+      } else if (parsedUri != null &&
+          parsedUri.hasScheme &&
+          parsedUri.scheme != 'file') {
+        continue;
+      } else if (p.isAbsolute(includeUri)) {
+        targetPath = p.canonicalize(includeUri);
+      } else {
+        targetPath = p.canonicalize(p.join(p.dirname(filePath), includeUri));
+      }
+
+      final isInsidePackage =
+          p.isWithin(packageDir, targetPath) ||
+          p.equals(packageDir, targetPath);
+
+      if (!isInsidePackage) {
+        final relOptionsPath = p.relative(filePath, from: package.dir);
+        warnings.add(
+          'The analysis options file `$relOptionsPath` includes '
+          '`$includeUri`, which points to a file outside the package.\n'
+          'Files outside the package are not included in the published '
+          'package.\n\n'
+          'Consider using a package URI (e.g. `package:lints/recommended.yaml`) '
+          'or inlining the options.',
+        );
+      } else if (fileExists(targetPath)) {
+        _validateAnalysisOptionsFile(targetPath, visited);
+      }
+    }
+  }
+}

--- a/test/validator/analysis_options_test.dart
+++ b/test/validator/analysis_options_test.dart
@@ -1,0 +1,249 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'package:pub/src/exit_codes.dart';
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+import 'utils.dart';
+
+void main() {
+  test('passes if no analysis_options.yaml exists', () async {
+    await d.dir(appPath, [
+      d.validPubspec(),
+      d.file('LICENSE', 'Eh, do what you want.'),
+      d.file('README.md', "This package isn't real."),
+      d.file('CHANGELOG.md', '# 1.0.0\nFirst version\n'),
+      d.dir('lib', [d.file('test_pkg.dart', 'int i = 1;')]),
+    ]).create();
+
+    await expectValidation();
+  });
+
+  test('passes if analysis_options.yaml has no include', () async {
+    await d.dir(appPath, [
+      d.validPubspec(),
+      d.file('LICENSE', 'Eh, do what you want.'),
+      d.file('README.md', "This package isn't real."),
+      d.file('CHANGELOG.md', '# 1.0.0\nFirst version\n'),
+      d.file('analysis_options.yaml', '''
+linter:
+  rules:
+    - avoid_empty_else
+'''),
+      d.dir('lib', [d.file('test_pkg.dart', 'int i = 1;')]),
+    ]).create();
+
+    await expectValidation();
+  });
+
+  test('passes if analysis_options.yaml includes package: URI', () async {
+    await d.dir(appPath, [
+      d.validPubspec(),
+      d.file('LICENSE', 'Eh, do what you want.'),
+      d.file('README.md', "This package isn't real."),
+      d.file('CHANGELOG.md', '# 1.0.0\nFirst version\n'),
+      d.file('analysis_options.yaml', '''
+include: package:lints/recommended.yaml
+'''),
+      d.dir('lib', [d.file('test_pkg.dart', 'int i = 1;')]),
+    ]).create();
+
+    await expectValidation();
+  });
+
+  test(
+    'passes if analysis_options.yaml includes a local file inside the package',
+    () async {
+      await d.dir(appPath, [
+        d.validPubspec(),
+        d.file('LICENSE', 'Eh, do what you want.'),
+        d.file('README.md', "This package isn't real."),
+        d.file('CHANGELOG.md', '# 1.0.0\nFirst version\n'),
+        d.file('analysis_options.yaml', '''
+include: custom_options.yaml
+'''),
+        d.file('custom_options.yaml', '''
+linter:
+  rules:
+    - avoid_empty_else
+'''),
+        d.dir('lib', [d.file('test_pkg.dart', 'int i = 1;')]),
+      ]).create();
+
+      await expectValidation();
+    },
+  );
+
+  test(
+    'passes if subfolder analysis_options.yaml includes root options',
+    () async {
+      await d.dir(appPath, [
+        d.validPubspec(),
+        d.file('LICENSE', 'Eh, do what you want.'),
+        d.file('README.md', "This package isn't real."),
+        d.file('CHANGELOG.md', '# 1.0.0\nFirst version\n'),
+        d.file('analysis_options.yaml', '''
+linter:
+  rules:
+    - avoid_empty_else
+'''),
+        d.dir('example', [
+          d.file('analysis_options.yaml', '''
+include: ../analysis_options.yaml
+'''),
+        ]),
+        d.dir('lib', [d.file('test_pkg.dart', 'int i = 1;')]),
+      ]).create();
+
+      await expectValidation();
+    },
+  );
+
+  test(
+    'warns if analysis_options.yaml includes a file from parent directory',
+    () async {
+      await d.file('parent_options.yaml', '''
+linter:
+  rules:
+    - avoid_empty_else
+''').create();
+
+      await d.dir(appPath, [
+        d.validPubspec(),
+        d.file('LICENSE', 'Eh, do what you want.'),
+        d.file('README.md', "This package isn't real."),
+        d.file('CHANGELOG.md', '# 1.0.0\nFirst version\n'),
+        d.file('analysis_options.yaml', '''
+include: ../parent_options.yaml
+'''),
+        d.dir('lib', [d.file('test_pkg.dart', 'int i = 1;')]),
+      ]).create();
+
+      await expectValidationWarning(
+        'The analysis options file `analysis_options.yaml` includes '
+        '`../parent_options.yaml`, which points to a file outside the package.',
+      );
+    },
+  );
+
+  test(
+    'warns if subfolder analysis_options.yaml includes a file outside package',
+    () async {
+      await d.file('parent_options.yaml', '''
+linter:
+  rules:
+    - avoid_empty_else
+''').create();
+
+      await d.dir(appPath, [
+        d.validPubspec(),
+        d.file('LICENSE', 'Eh, do what you want.'),
+        d.file('README.md', "This package isn't real."),
+        d.file('CHANGELOG.md', '# 1.0.0\nFirst version\n'),
+        d.dir('example', [
+          d.file('analysis_options.yaml', '''
+include: ../../parent_options.yaml
+'''),
+        ]),
+        d.dir('lib', [d.file('test_pkg.dart', 'int i = 1;')]),
+      ]).create();
+
+      await expectValidationWarning(
+        'The analysis options file `example/analysis_options.yaml` includes '
+        '`../../parent_options.yaml`, which points to a file outside the package.',
+      );
+    },
+  );
+
+  test('warns if transitive include points outside package', () async {
+    await d.file('parent_options.yaml', '''
+linter:
+  rules:
+    - avoid_empty_else
+''').create();
+
+    await d.dir(appPath, [
+      d.validPubspec(),
+      d.file('LICENSE', 'Eh, do what you want.'),
+      d.file('README.md', "This package isn't real."),
+      d.file('CHANGELOG.md', '# 1.0.0\nFirst version\n'),
+      d.file('analysis_options.yaml', '''
+include: internal_options.yaml
+'''),
+      d.file('internal_options.yaml', '''
+include: ../parent_options.yaml
+'''),
+      d.dir('lib', [d.file('test_pkg.dart', 'int i = 1;')]),
+    ]).create();
+
+    await expectValidationWarning(
+      'The analysis options file `internal_options.yaml` includes '
+      '`../parent_options.yaml`, which points to a file outside the package.',
+    );
+  });
+
+  test('warns if file: URI points outside package', () async {
+    final parentFile = d.file('parent_options.yaml', '''
+linter:
+  rules:
+    - avoid_empty_else
+''');
+    await parentFile.create();
+
+    final parentUri = Uri.file(parentFile.io.path).toString();
+
+    await d.dir(appPath, [
+      d.validPubspec(),
+      d.file('LICENSE', 'Eh, do what you want.'),
+      d.file('README.md', "This package isn't real."),
+      d.file('CHANGELOG.md', '# 1.0.0\nFirst version\n'),
+      d.file('analysis_options.yaml', '''
+include: $parentUri
+'''),
+      d.dir('lib', [d.file('test_pkg.dart', 'int i = 1;')]),
+    ]).create();
+
+    await expectValidationWarning(
+      'The analysis options file `analysis_options.yaml` includes '
+      '`$parentUri`, which points to a file outside the package.',
+    );
+  });
+
+  test('warns with --directory flag', () async {
+    await d.file('parent_options.yaml', '''
+linter:
+  rules:
+    - avoid_empty_else
+''').create();
+
+    await d.dir(appPath, [
+      d.validPubspec(),
+      d.file('LICENSE', 'Eh, do what you want.'),
+      d.file('README.md', "This package isn't real."),
+      d.file('CHANGELOG.md', '# 1.0.0\nFirst version\n'),
+      d.file('analysis_options.yaml', '''
+include: ../parent_options.yaml
+'''),
+      d.dir('lib', [d.file('test_pkg.dart', 'int i = 1;')]),
+    ]).create();
+
+    await expectValidation(
+      message: allOf([
+        contains(
+          'The analysis options file `analysis_options.yaml` includes '
+          '`../parent_options.yaml`, which points to a file outside the package.',
+        ),
+        contains('Package has 1 warning.'),
+      ]),
+      exitCode: DATA,
+      extraArgs: ['--directory', appPath],
+      workingDirectory: d.sandbox,
+    );
+  });
+}

--- a/test/validator/analysis_options_test.dart
+++ b/test/validator/analysis_options_test.dart
@@ -6,6 +6,7 @@
 library;
 
 import 'package:pub/src/exit_codes.dart';
+import 'package:pub/src/path.dart';
 import 'package:test/test.dart';
 
 import '../descriptor.dart' as d;
@@ -155,8 +156,10 @@ include: ../../parent_options.yaml
       ]).create();
 
       await expectValidationWarning(
-        'The analysis options file `example/analysis_options.yaml` includes '
-        '`../../parent_options.yaml`, which points to a file outside the package.',
+        'The analysis options file '
+        '`${p.join('example', 'analysis_options.yaml')}` includes '
+        '`../../parent_options.yaml`, which points to a file outside the '
+        'package.',
       );
     },
   );


### PR DESCRIPTION
Fixes #4853.

Adds `AnalysisOptionsValidator` to warn when `analysis_options.yaml` (or any other analysis options file in the package) includes a configuration file outside the package directory.