### PR TITLE
Support skipping/ignoring specific publication validations

### DIFF
--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -130,6 +130,13 @@ class LishCommand extends PubCommand {
       help: 'Do not treat warnings as fatal.',
       negatable: false,
     );
+    argParser.addMultiOption(
+      'ignore-validation',
+      help:
+          'Ignore a specific validation (can be passed multiple times).\n'
+          'Valid names are: ${allValidatorNames.join(', ')}',
+      valueHelp: 'name',
+    );
   }
 
   Future<void> _publishUsingClient(
@@ -442,6 +449,20 @@ the \$PUB_HOSTED_URL environment variable.''');
     final warnings = <String>[];
     final errors = <String>[];
 
+    final cliIgnored = argResults.multiOption('ignore-validation');
+    for (final name in cliIgnored) {
+      if (!allValidatorNames.contains(name)) {
+        usageException(
+          'Unrecognized validator name "$name" passed to '
+          '`--ignore-validation`.\n'
+          'Valid validator names are: ${allValidatorNames.join(', ')}.',
+        );
+      }
+    }
+    final allIgnored = entrypoint.workPackage.pubspec.ignoredValidations.union(
+      cliIgnored.toSet(),
+    );
+
     await log.spinner(
       'Validating package',
       () async => await Validator.runAll(
@@ -452,6 +473,7 @@ the \$PUB_HOSTED_URL environment variable.''');
         hints: hints,
         warnings: warnings,
         errors: errors,
+        ignoredValidations: allIgnored,
       ),
     );
 

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -541,6 +541,7 @@ environment:
     () => falseSecrets,
     () => sdkConstraints,
     () => ignoredAdvisories,
+    () => ignoredValidations,
   ]);
 
   /// Returns the type of dependency from this package onto [name].

--- a/lib/src/pubspec_parse.dart
+++ b/lib/src/pubspec_parse.dart
@@ -8,6 +8,7 @@ import 'package:yaml/yaml.dart';
 
 import 'exceptions.dart';
 import 'utils.dart' show ExpectField, identifierRegExp;
+import 'validator.dart' show allValidatorNames;
 
 /// A regular expression matching allowed package names.
 ///
@@ -144,6 +145,51 @@ abstract class PubspecBase {
   }
 
   Set<String>? _ignoredAdvisories;
+
+  /// The list of publication validations to be ignored during package
+  /// publication.
+  ///
+  /// It is an error if this is not a list of strings, or contains unrecognized
+  /// validator names.
+  Set<String> get ignoredValidations {
+    var validations = _ignoredValidations;
+    if (validations != null) {
+      return validations;
+    }
+    validations = <String>{};
+
+    Never ignoredValidationsError(SourceSpan span, [String? message]) => _error(
+      message ??
+          '"ignored_validations" field must be a list of validator names',
+      span,
+    );
+
+    final ignoredValidationsNode = fields.nodes['ignored_validations'];
+    if (ignoredValidationsNode == null) {
+      return _ignoredValidations = Set.unmodifiable(validations);
+    }
+    if (ignoredValidationsNode is! YamlList) {
+      ignoredValidationsError(ignoredValidationsNode.span);
+    }
+    for (final node in ignoredValidationsNode.nodes) {
+      final value = node.value;
+      if (value is! String) {
+        ignoredValidationsError(node.span);
+      }
+      if (!allValidatorNames.contains(value)) {
+        ignoredValidationsError(
+          node.span,
+          'Unrecognized validator name "$value" in "ignored_validations". '
+          'Valid validator names are: ${allValidatorNames.join(', ')}.',
+        );
+      }
+      validations.add(value);
+    }
+
+    return _ignoredValidations = Set.unmodifiable(validations);
+  }
+
+  Set<String>? _ignoredValidations;
 
   /// The list of patterns covering _false-positive secrets_ in the package.
   ///

--- a/lib/src/validator.dart
+++ b/lib/src/validator.dart
@@ -39,6 +39,35 @@ import 'validator/sdk_constraint.dart';
 import 'validator/size.dart';
 import 'validator/strict_dependencies.dart';
 
+/// The canonical names of all publication validators.
+const allValidatorNames = {
+  'analyze',
+  'changelog',
+  'compiled_dartdoc',
+  'dependencies',
+  'dependency_overrides',
+  'deprecated_fields',
+  'devtools_extension',
+  'executables',
+  'file_case',
+  'flutter_constraint',
+  'flutter_plugin_format',
+  'git_status',
+  'gitignore',
+  'leak_detection',
+  'license',
+  'name',
+  'package_layout',
+  'pubspec_exists',
+  'pubspec_fields',
+  'pubspec_typos',
+  'readme',
+  'relative_version_numbering',
+  'sdk_constraint',
+  'size',
+  'strict_dependencies',
+};
+
 /// The base class for validators that check whether a package is fit for
 /// uploading.
 ///
@@ -47,6 +76,9 @@ import 'validator/strict_dependencies.dart';
 /// package not to be uploaded; warnings will require the user to confirm the
 /// upload.
 abstract class Validator {
+  /// The canonical name of this validator.
+  String get name;
+
   /// The accumulated errors for this validator.
   ///
   /// Filled by calling [validate].
@@ -142,6 +174,7 @@ abstract class Validator {
     required List<String> hints,
     required List<String> warnings,
     required List<String> errors,
+    Set<String> ignoredValidations = const {},
   }) async {
     final validators = [
       FileCaseValidator(),
@@ -183,11 +216,47 @@ abstract class Validator {
         await validator.validate();
       }),
     ).then((_) {
-      hints.addAll([for (final validator in validators) ...validator.hints]);
-      warnings.addAll([
-        for (final validator in validators) ...validator.warnings,
+      final activeValidators = validators.where(
+        (v) => !ignoredValidations.contains(v.name),
+      );
+      final ignored = validators.where(
+        (v) => ignoredValidations.contains(v.name),
+      );
+
+      hints.addAll([
+        for (final validator in activeValidators) ...validator.hints,
       ]);
-      errors.addAll([for (final validator in validators) ...validator.errors]);
+      warnings.addAll([
+        for (final validator in activeValidators) ...validator.warnings,
+      ]);
+      errors.addAll([
+        for (final validator in activeValidators) ...validator.errors,
+      ]);
+
+      for (final validator in ignored) {
+        if (entrypoint.workPackage.pubspec.ignoredValidations.contains(
+          validator.name,
+        )) {
+          if (validator.errors.isEmpty && validator.warnings.isEmpty) {
+            warnings.add(
+              'Validation "${validator.name}" was ignored in pubspec.yaml, '
+              'but produced no warnings or errors. Consider removing it from '
+              '"ignored_validations".',
+            );
+          }
+        }
+      }
+
+      final ignoredWithIssues =
+          ignored
+              .where((v) => v.errors.isNotEmpty || v.warnings.isNotEmpty)
+              .map((v) => v.name)
+              .toList();
+      if (ignoredWithIssues.isNotEmpty) {
+        log.message(
+          'Ignored validation issues from: ${ignoredWithIssues.join(', ')}.\n',
+        );
+      }
 
       String presentDiagnostics(List<String> diagnostics) => diagnostics
           .map((diagnostic) => "* ${diagnostic.split('\n').join('\n  ')}\n")

--- a/lib/src/validator/analyze.dart
+++ b/lib/src/validator/analyze.dart
@@ -11,7 +11,9 @@ import '../platform_info.dart';
 import '../validator.dart';
 
 /// Runs `dart analyze` and gives a warning if it returns non-zero.
-class AnalyzeValidator extends Validator {
+final class AnalyzeValidator extends Validator {
+  @override
+  String get name => 'analyze';
   // Only analyze dart code in the following sub-folders and files.
   static const List<String> _entriesToAnalyze = [
     'bin',

--- a/lib/src/validator/changelog.dart
+++ b/lib/src/validator/changelog.dart
@@ -14,7 +14,9 @@ import '../validator.dart';
 final _changelogRegexp = RegExp(r'^CHANGELOG($|\.)', caseSensitive: false);
 
 /// A validator that validates a package's changelog file.
-class ChangelogValidator extends Validator {
+final class ChangelogValidator extends Validator {
+  @override
+  String get name => 'changelog';
   @override
   Future<void> validate() async {
     final changelog = filesBeneath(

--- a/lib/src/validator/compiled_dartdoc.dart
+++ b/lib/src/validator/compiled_dartdoc.dart
@@ -9,7 +9,9 @@ import '../path.dart';
 import '../validator.dart';
 
 /// Validates that a package doesn't contain compiled Dartdoc output.
-class CompiledDartdocValidator extends Validator {
+final class CompiledDartdocValidator extends Validator {
+  @override
+  String get name => 'compiled_dartdoc';
   @override
   Future validate() {
     return Future.sync(() {

--- a/lib/src/validator/dependency.dart
+++ b/lib/src/validator/dependency.dart
@@ -16,7 +16,9 @@ import '../source/sdk.dart';
 import '../validator.dart';
 
 /// A validator that validates a package's dependencies.
-class DependencyValidator extends Validator {
+final class DependencyValidator extends Validator {
+  @override
+  String get name => 'dependencies';
   @override
   Future validate() async {
     /// Whether any dependency has a caret constraint.

--- a/lib/src/validator/dependency_override.dart
+++ b/lib/src/validator/dependency_override.dart
@@ -8,7 +8,9 @@ import '../validator.dart';
 
 /// Complains (with a hint) if any of the transitive dependencies of a package's
 /// non-dev dependencies are overridden anywhere in the workspace.
-class DependencyOverrideValidator extends Validator {
+final class DependencyOverrideValidator extends Validator {
+  @override
+  String get name => 'dependency_overrides';
   @override
   Future<void> validate() async {
     final graph = await context.entrypoint.packageGraph;

--- a/lib/src/validator/deprecated_fields.dart
+++ b/lib/src/validator/deprecated_fields.dart
@@ -8,7 +8,9 @@ import '../validator.dart';
 
 /// A validator that validates that a pubspec is not including deprecated fields
 /// which are no longer read.
-class DeprecatedFieldsValidator extends Validator {
+final class DeprecatedFieldsValidator extends Validator {
+  @override
+  String get name => 'deprecated_fields';
   @override
   Future validate() async {
     if (package.pubspec.fields.containsKey('transformers')) {

--- a/lib/src/validator/devtools_extension.dart
+++ b/lib/src/validator/devtools_extension.dart
@@ -10,7 +10,9 @@ import '../validator.dart';
 
 //   If the `extension/devtools/` directory exists
 //  verify the directory contains a file `config.yaml` and a non-empty `build/` directory
-class DevtoolsExtensionValidator extends Validator {
+final class DevtoolsExtensionValidator extends Validator {
+  @override
+  String get name => 'devtools_extension';
   static String docUrl = 'https://docs.flutter.dev/tools/devtools/extensions';
 
   @override

--- a/lib/src/validator/directory.dart
+++ b/lib/src/validator/directory.dart
@@ -9,7 +9,9 @@ import '../path.dart';
 import '../validator.dart';
 
 /// A validator that validates a package's top-level directories.
-class DirectoryValidator extends Validator {
+final class DirectoryValidator extends Validator {
+  @override
+  String get name => 'package_layout';
   static final _pluralNames = [
     'benchmarks',
     'docs',

--- a/lib/src/validator/executable.dart
+++ b/lib/src/validator/executable.dart
@@ -10,7 +10,9 @@ import '../validator.dart';
 
 /// Validates that a package's pubspec doesn't contain executables that
 /// reference non-existent scripts.
-class ExecutableValidator extends Validator {
+final class ExecutableValidator extends Validator {
+  @override
+  String get name => 'executables';
   @override
   Future validate() async {
     final binFiles = filesBeneath(

--- a/lib/src/validator/file_case.dart
+++ b/lib/src/validator/file_case.dart
@@ -9,7 +9,9 @@ import 'package:collection/collection.dart';
 import '../validator.dart';
 
 /// Validates that a package files all are unique even after case-normalization.
-class FileCaseValidator extends Validator {
+final class FileCaseValidator extends Validator {
+  @override
+  String get name => 'file_case';
   @override
   Future validate() async {
     final lowerCaseToFile = <String, String>{};

--- a/lib/src/validator/flutter_constraint.dart
+++ b/lib/src/validator/flutter_constraint.dart
@@ -9,7 +9,9 @@ import 'package:pub_semver/pub_semver.dart';
 import '../validator.dart';
 
 /// Validates that a package's flutter constraint doesn't contain an upper bound
-class FlutterConstraintValidator extends Validator {
+final class FlutterConstraintValidator extends Validator {
+  @override
+  String get name => 'flutter_constraint';
   static const explanationUrl =
       'https://dart.dev/go/flutter-upper-bound-deprecation';
 

--- a/lib/src/validator/flutter_plugin_format.dart
+++ b/lib/src/validator/flutter_plugin_format.dart
@@ -17,7 +17,9 @@ const _pluginDocsUrl =
 ///
 /// See:
 /// https://flutter.dev/docs/development/packages-and-plugins/developing-packages
-class FlutterPluginFormatValidator extends Validator {
+final class FlutterPluginFormatValidator extends Validator {
+  @override
+  String get name => 'flutter_plugin_format';
   @override
   Future validate() async {
     final pubspec = package.pubspec;

--- a/lib/src/validator/git_status.dart
+++ b/lib/src/validator/git_status.dart
@@ -16,7 +16,9 @@ import '../validator.dart';
 ///
 /// Doesn't report on newly added files, as generated files might not be checked
 /// in to git.
-class GitStatusValidator extends Validator {
+final class GitStatusValidator extends Validator {
+  @override
+  String get name => 'git_status';
   @override
   Future<void> validate() async {
     if (!package.inGitRepo) {

--- a/lib/src/validator/gitignore.dart
+++ b/lib/src/validator/gitignore.dart
@@ -19,7 +19,9 @@ import '../validator.dart';
 /// A validator that validates that no checked in files are ignored by a
 /// .gitignore. These would be considered part of the package by previous
 /// versions of pub.
-class GitignoreValidator extends Validator {
+final class GitignoreValidator extends Validator {
+  @override
+  String get name => 'gitignore';
   @override
   Future<void> validate() async {
     if (package.inGitRepo) {

--- a/lib/src/validator/leak_detection.dart
+++ b/lib/src/validator/leak_detection.dart
@@ -29,6 +29,9 @@ const _falseSecretsDocumentationLink = 'https://dart.dev/go/false-secrets';
 /// accidentally leaked.
 final class LeakDetectionValidator extends Validator {
   @override
+  String get name => 'leak_detection';
+
+  @override
   Future<void> validate() async {
     // Load `false_secrets` from `pubspec.yaml`.
     final falseSecrets = Ignore(

--- a/lib/src/validator/license.dart
+++ b/lib/src/validator/license.dart
@@ -13,7 +13,9 @@ final licenseLike = RegExp(
 );
 
 /// A validator that checks that a LICENSE-like file exists.
-class LicenseValidator extends Validator {
+final class LicenseValidator extends Validator {
+  @override
+  String get name => 'license';
   @override
   Future validate() {
     return Future.sync(() {

--- a/lib/src/validator/name.dart
+++ b/lib/src/validator/name.dart
@@ -11,7 +11,9 @@ import '../validator.dart';
 
 /// A validator that the name of a package is legal and matches the library name
 /// in the case of a single library.
-class NameValidator extends Validator {
+final class NameValidator extends Validator {
+  @override
+  String get name => 'name';
   @override
   Future validate() {
     return Future.sync(() {

--- a/lib/src/validator/pubspec.dart
+++ b/lib/src/validator/pubspec.dart
@@ -12,7 +12,9 @@ import '../validator.dart';
 ///
 /// In most cases this is clearly true, since pub can't run without a pubspec,
 /// but it's possible that the pubspec is gitignored.
-class PubspecValidator extends Validator {
+final class PubspecValidator extends Validator {
+  @override
+  String get name => 'pubspec_exists';
   @override
   Future validate() async {
     if (!filesBeneath(

--- a/lib/src/validator/pubspec_field.dart
+++ b/lib/src/validator/pubspec_field.dart
@@ -8,7 +8,9 @@ import '../validator.dart';
 
 /// A validator that checks that the pubspec has valid "author" and "homepage"
 /// fields.
-class PubspecFieldValidator extends Validator {
+final class PubspecFieldValidator extends Validator {
+  @override
+  String get name => 'pubspec_fields';
   @override
   Future<void> validate() {
     _validateFieldIsString('description');

--- a/lib/src/validator/pubspec_typo.dart
+++ b/lib/src/validator/pubspec_typo.dart
@@ -6,7 +6,9 @@ import '../levenshtein.dart';
 import '../validator.dart';
 
 /// Validates that a package's pubspec does not contain any typos in its keys.
-class PubspecTypoValidator extends Validator {
+final class PubspecTypoValidator extends Validator {
+  @override
+  String get name => 'pubspec_typos';
   @override
   Future validate() async {
     final fields = package.pubspec.fields;
@@ -74,6 +76,7 @@ const _validPubspecKeys = [
   'funding',
   'topics',
   'ignored_advisories',
+  'ignored_validations',
   'workspace',
   'resolution',
 ];

--- a/lib/src/validator/readme.dart
+++ b/lib/src/validator/readme.dart
@@ -12,7 +12,9 @@ import '../validator.dart';
 final _readmeRegexp = RegExp(r'^README($|\.)', caseSensitive: false);
 
 /// Validates that a package's README exists and is valid utf-8.
-class ReadmeValidator extends Validator {
+final class ReadmeValidator extends Validator {
+  @override
+  String get name => 'readme';
   @override
   Future<void> validate() async {
     // Find the path to the README file at the root of the entrypoint.

--- a/lib/src/validator/relative_version_numbering.dart
+++ b/lib/src/validator/relative_version_numbering.dart
@@ -16,7 +16,9 @@ import '../validator.dart';
 ///
 /// Gives an info when publishing a new version, if the latest published
 /// version lower to this was not opted into null-safety.
-class RelativeVersionNumberingValidator extends Validator {
+final class RelativeVersionNumberingValidator extends Validator {
+  @override
+  String get name => 'relative_version_numbering';
   static const String semverUrl =
       'https://dart.dev/tools/pub/versioning#semantic-versions';
 

--- a/lib/src/validator/sdk_constraint.dart
+++ b/lib/src/validator/sdk_constraint.dart
@@ -14,7 +14,9 @@ import '../validator.dart';
 /// * has an upper bound.
 /// * is not depending on a prerelease, unless the package itself is a
 /// prerelease.
-class SdkConstraintValidator extends Validator {
+final class SdkConstraintValidator extends Validator {
+  @override
+  String get name => 'sdk_constraint';
   @override
   Future validate() async {
     final dartConstraint = package.pubspec.dartSdkConstraint;

--- a/lib/src/validator/size.dart
+++ b/lib/src/validator/size.dart
@@ -11,7 +11,9 @@ import '../validator.dart';
 const _maxSize = 100 * 1024 * 1024;
 
 /// A validator that validates that a package isn't too big.
-class SizeValidator extends Validator {
+final class SizeValidator extends Validator {
+  @override
+  String get name => 'size';
   @override
   Future<void> validate() async {
     if (packageSize <= _maxSize) return;

--- a/lib/src/validator/strict_dependencies.dart
+++ b/lib/src/validator/strict_dependencies.dart
@@ -17,7 +17,10 @@ import '../utils.dart';
 import '../validator.dart';
 
 /// Validates that Dart source files only import declared dependencies.
-class StrictDependenciesValidator extends Validator {
+final class StrictDependenciesValidator extends Validator {
+  @override
+  String get name => 'strict_dependencies';
+
   /// Lazily returns all dependency uses in [files].
   ///
   /// Files that do not parse and directives that don't import or export

--- a/test/testdata/goldens/help_test/pub publish --help.txt
+++ b/test/testdata/goldens/help_test/pub publish --help.txt
@@ -5,12 +5,16 @@ $ pub publish --help
 Publish the current package to pub.dev.
 
 Usage: pub publish [options]
--h, --help               Print this usage information.
--n, --dry-run            Validate but do not publish the package.
--f, --force              Publish without confirmation if there are no errors.
-    --skip-validation    Publish without validation and resolution (this will ignore errors).
--C, --directory=<dir>    Run this in the directory <dir>.
-    --ignore-warnings    Do not treat warnings as fatal.
+-h, --help                        Print this usage information.
+-n, --dry-run                     Validate but do not publish the package.
+-f, --force                       Publish without confirmation if there are no errors.
+    --skip-validation             Publish without validation and resolution (this will ignore errors).
+-C, --directory=<dir>             Run this in the directory <dir>.
+    --ignore-warnings             Do not treat warnings as fatal.
+    --ignore-validation=<name>    Ignore a specific validation (can be passed multiple times).
+                                  Valid names are: analyze, changelog, compiled_dartdoc, dependencies, dependency_overrides, deprecated_fields, devtools_extension, executables, file_case,
+                                  flutter_constraint, flutter_plugin_format, git_status, gitignore, leak_detection, license, name, package_layout, pubspec_exists, pubspec_fields, pubspec_typos,
+                                  readme, relative_version_numbering, sdk_constraint, size, strict_dependencies
 
 Run "pub help" to see global options.
 See https://dart.dev/tools/pub/cmd/pub-lish for detailed documentation.

--- a/test/validator/ignored_validations_test.dart
+++ b/test/validator/ignored_validations_test.dart
@@ -1,0 +1,194 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'package:pub/src/exit_codes.dart';
+import 'package:pub/src/io.dart';
+import 'package:pub/src/path.dart';
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+import 'utils.dart';
+
+void main() {
+  test('ignores a warning using ignored_validations in pubspec.yaml', () async {
+    final pkg = d.validPackage(
+      pubspecExtras: {
+        'ignored_validations': ['readme'],
+      },
+    );
+    await pkg.create();
+    deleteEntry(p.join(d.sandbox, 'myapp/README.md'));
+
+    await expectValidation(
+      message: allOf([
+        contains('Ignored validation issues from: readme.'),
+        contains('Package has 0 warnings.'),
+      ]),
+    );
+  });
+
+  test('ignores an error using ignored_validations in pubspec.yaml', () async {
+    final pkg = d.validPackage(
+      pubspecExtras: {
+        'ignored_validations': ['license'],
+      },
+    );
+    await pkg.create();
+    deleteEntry(p.join(d.sandbox, 'myapp/LICENSE'));
+
+    await expectValidation(
+      message: allOf([
+        contains('Ignored validation issues from: license.'),
+        contains('Package has 0 warnings.'),
+      ]),
+    );
+  });
+
+  test('ignores a warning using --ignore-validation CLI flag', () async {
+    final pkg = d.validPackage();
+    await pkg.create();
+    deleteEntry(p.join(d.sandbox, 'myapp/README.md'));
+
+    await expectValidation(
+      extraArgs: ['--ignore-validation=readme'],
+      message: allOf([
+        contains('Ignored validation issues from: readme.'),
+        contains('Package has 0 warnings.'),
+      ]),
+    );
+  });
+
+  test('ignores an error using --ignore-validation CLI flag', () async {
+    final pkg = d.validPackage();
+    await pkg.create();
+    deleteEntry(p.join(d.sandbox, 'myapp/LICENSE'));
+
+    await expectValidation(
+      extraArgs: ['--ignore-validation=license'],
+      message: allOf([
+        contains('Ignored validation issues from: license.'),
+        contains('Package has 0 warnings.'),
+      ]),
+    );
+  });
+
+  test(
+    'warns if ignored_validations entry in pubspec.yaml was unnecessary',
+    () async {
+      final pkg = d.validPackage(
+        pubspecExtras: {
+          'ignored_validations': ['readme'],
+        },
+      );
+      await pkg.create();
+
+      await expectValidationWarning(
+        'Validation "readme" was ignored in pubspec.yaml, but produced no '
+        'warnings or errors. Consider removing it from "ignored_validations".',
+      );
+    },
+  );
+
+  test('does not warn for unnecessary CLI --ignore-validation flag', () async {
+    final pkg = d.validPackage();
+    await pkg.create();
+
+    await expectValidation(
+      extraArgs: ['--ignore-validation=readme'],
+      message: contains('Package has 0 warnings.'),
+    );
+  });
+
+  test('fails if unrecognized validator name is in pubspec.yaml', () async {
+    final pkg = d.validPackage(
+      pubspecExtras: {
+        'ignored_validations': ['not_a_validator'],
+      },
+    );
+    await pkg.create();
+
+    await runPub(
+      args: ['publish', '--dry-run'],
+      error: contains(
+        'Unrecognized validator name "not_a_validator" in '
+        '"ignored_validations".',
+      ),
+      exitCode: DATA,
+    );
+  });
+
+  test('fails if ignored_validations is not a list in pubspec.yaml', () async {
+    final pkg = d.validPackage(
+      pubspecExtras: {'ignored_validations': 'not_a_list'},
+    );
+    await pkg.create();
+
+    await runPub(
+      args: ['publish', '--dry-run'],
+      error: contains(
+        '"ignored_validations" field must be a list of validator names',
+      ),
+      exitCode: DATA,
+    );
+  });
+
+  test(
+    'fails if unrecognized validator name is passed to --ignore-validation',
+    () async {
+      final pkg = d.validPackage();
+      await pkg.create();
+
+      await runPub(
+        args: ['publish', '--dry-run', '--ignore-validation=not_a_validator'],
+        error: contains(
+          'Unrecognized validator name "not_a_validator" passed to '
+          '`--ignore-validation`.',
+        ),
+        exitCode: USAGE,
+      );
+    },
+  );
+
+  test('combines ignored validations from pubspec.yaml and CLI', () async {
+    final pkg = d.validPackage(
+      pubspecExtras: {
+        'ignored_validations': ['readme'],
+      },
+    );
+    await pkg.create();
+    deleteEntry(p.join(d.sandbox, 'myapp/README.md'));
+    deleteEntry(p.join(d.sandbox, 'myapp/LICENSE'));
+
+    await expectValidation(
+      extraArgs: ['--ignore-validation=license'],
+      message: allOf([
+        contains('Ignored validation issues from: license, readme.'),
+        contains('Package has 0 warnings.'),
+      ]),
+    );
+  });
+
+  test('ignores pubspec_exists and package_layout validations', () async {
+    final pkg = d.validPackage(
+      pubspecExtras: {
+        'ignored_validations': ['package_layout'],
+      },
+    );
+    await pkg.create();
+    await d.dir(appPath, [
+      d.dir('examples', [d.file('example.dart', 'void main() {}')]),
+    ]).create();
+
+    await expectValidation(
+      message: allOf([
+        contains('Ignored validation issues from: package_layout.'),
+        contains('Package has 0 warnings.'),
+      ]),
+    );
+  });
+}

--- a/test/validator/pubspec_typo_test.dart
+++ b/test/validator/pubspec_typo_test.dart
@@ -38,6 +38,7 @@ void main() {
           'executables': '',
           'publish_to': '',
           'flutter': {},
+          'ignored_validations': ['git_status'],
         }),
       ]).create();
 


### PR DESCRIPTION
Allows skipping specific publication validations either declaratively via `ignored_validations` in `pubspec.yaml` or imperatively via `--ignore-validation=<name>` on `dart pub publish`.

- Adds `name` property to publication `Validator` base class.
- Defines canonical validator names across all 25 validators.
- Adds `ignored_validations` list field to `pubspec.yaml`.
- Adds `--ignore-validation` multi-option to `pub publish`.
- Emits a warning if an entry in `ignored_validations` produced no errors or warnings.
- Logs an informational note when validation issues were ignored.
- Adds comprehensive tests in `test/validator/ignored_validations_test.dart`.