### PR TITLE
Fix workspace globs not respecting IOOverrides

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -1543,6 +1543,18 @@ final class _IOOverrides extends IOOverrides {
       fileSystem.directory(path).watch(events: events, recursive: recursive);
 }
 
+/// The [f.FileSystem] used by the current [io.IOOverrides].
+///
+/// If running in a zone with overrides of type [_IOOverrides],
+/// returns the overridden filesystem. Otherwise, returns a [f.LocalFileSystem].
+f.FileSystem get currentFileSystem {
+  final current = io.IOOverrides.current;
+  if (current is _IOOverrides) {
+    return current.fileSystem;
+  }
+  return const f.LocalFileSystem();
+}
+
 /// Wrap a [Stream<List<int>>] as [Stdin].
 final class StdinStream extends StreamView<List<int>> implements Stdin {
   StdinStream(super.stream);

--- a/lib/src/package.dart
+++ b/lib/src/package.dart
@@ -5,7 +5,6 @@
 import 'dart:io';
 
 import 'package:glob/glob.dart';
-import 'package:glob/list_local_fs.dart';
 import 'package:pub_semver/pub_semver.dart';
 
 import 'exceptions.dart';
@@ -188,7 +187,14 @@ class Package {
             } on FormatException catch (e) {
               fail('Failed to parse glob `$workspacePath`. $e');
             }
-            for (final globResult in glob.listSync(root: dir)) {
+            final globResults =
+                glob
+                    .listFileSystemSync(
+                      currentFileSystem,
+                      root: p.absolute(dir),
+                    )
+                    .toList();
+            for (final globResult in globResults) {
               final pubspecPath = p.join(globResult.path, 'pubspec.yaml');
               if (!fileExists(pubspecPath)) continue;
               packages.add(

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -8,8 +8,12 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:file/memory.dart';
 import 'package:pub/src/exit_codes.dart';
+import 'package:pub/src/io.dart';
+import 'package:pub/src/package.dart';
 import 'package:pub/src/path.dart';
+import 'package:pub/src/pubspec.dart';
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';
@@ -2020,6 +2024,37 @@ Consider changing the language version of .${s}pubspec.yaml to 3.11.'''),
         packageConfigEntry(name: 'b', path: 'pkgs/b'),
       ], generatorVersion: '3.11.0'),
     ]).validate();
+  });
+
+  test('globs are resolved when using overridden filesystem', () async {
+    final fs = MemoryFileSystem();
+    fs.directory('/myapp').createSync();
+    fs.file('/myapp/pubspec.yaml').writeAsStringSync('''
+name: myapp
+version: 1.2.3
+workspace:
+  - pkgs/a
+environment:
+  sdk: '^3.11.0'
+''');
+    fs.directory('/myapp/pkgs/a').createSync(recursive: true);
+    fs.file('/myapp/pkgs/a/pubspec.yaml').writeAsStringSync('''
+name: a
+version: 1.1.1
+resolution: workspace
+environment:
+  sdk: '^3.11.0'
+''');
+
+    await withOverrides(() async {
+      final package = Package.load(
+        '/myapp',
+        loadPubspec: Pubspec.loadRootWithSources(
+          (name) => throw UnimplementedError(),
+        ),
+      );
+      expect(package.transitiveWorkspace.map((pkg) => pkg.name), contains('a'));
+    }, fileSystem: fs);
   });
 }
 

--- a/test/workspace_test.dart
+++ b/test/workspace_test.dart
@@ -2027,9 +2027,13 @@ Consider changing the language version of .${s}pubspec.yaml to 3.11.'''),
   });
 
   test('globs are resolved when using overridden filesystem', () async {
-    final fs = MemoryFileSystem();
-    fs.directory('/myapp').createSync();
-    fs.file('/myapp/pubspec.yaml').writeAsStringSync('''
+    final fs = MemoryFileSystem(
+      style:
+          Platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix,
+    );
+    final myappPath = fs.path.absolute('myapp');
+    fs.directory(myappPath).createSync(recursive: true);
+    fs.file(fs.path.join(myappPath, 'pubspec.yaml')).writeAsStringSync('''
 name: myapp
 version: 1.2.3
 workspace:
@@ -2037,8 +2041,9 @@ workspace:
 environment:
   sdk: '^3.11.0'
 ''');
-    fs.directory('/myapp/pkgs/a').createSync(recursive: true);
-    fs.file('/myapp/pkgs/a/pubspec.yaml').writeAsStringSync('''
+    final pkgAPath = fs.path.join(myappPath, 'pkgs', 'a');
+    fs.directory(pkgAPath).createSync(recursive: true);
+    fs.file(fs.path.join(pkgAPath, 'pubspec.yaml')).writeAsStringSync('''
 name: a
 version: 1.1.1
 resolution: workspace
@@ -2048,7 +2053,7 @@ environment:
 
     await withOverrides(() async {
       final package = Package.load(
-        '/myapp',
+        myappPath,
         loadPubspec: Pubspec.loadRootWithSources(
           (name) => throw UnimplementedError(),
         ),


### PR DESCRIPTION
Currently the workspace resolution using `glob.listSync()` does not respect an overridden filesystem when using IOOverrides. This breaks workspace resolution when run in an non-local environment, like `pkg:dartpad` where pub runs as part of a WASM web worker.

This PR fixes this by using `glob.listFileSystemSync()` with the file system set by `_IOOverrides` if exists, and otherwise falls back to the default behavior of using `LocalFileSystem`. It also fixes an additional bug with using globs in a web environment by providing the root directory as an absolute path.

CC @goderbauer @jonasfj 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
