### PR TITLE
validator: recognize analysis server plugin entrypoints

### DIFF
--- a/lib/src/validator/name.dart
+++ b/lib/src/validator/name.dart
@@ -9,8 +9,7 @@ import '../path.dart';
 import '../utils.dart';
 import '../validator.dart';
 
-/// A validator that the name of a package is legal and matches the library name
-/// in the case of a single library.
+/// A validator that checks package and library names.
 class NameValidator extends Validator {
   @override
   Future validate() {
@@ -18,10 +17,25 @@ class NameValidator extends Validator {
       _checkName(package.name);
 
       final libraries = _libraries(files);
+      final isAnalysisServerPlugin = package.dependencies.containsKey(
+        'analysis_server_plugin',
+      );
+      final pluginEntrypoint = p.join('lib', 'main.dart');
+
+      if (isAnalysisServerPlugin && !libraries.contains(pluginEntrypoint)) {
+        warnings.add(
+          'Packages that depend on `analysis_server_plugin` should contain '
+          'a `lib/main.dart` entrypoint.\n'
+          'The analysis server loads plugins from this file.',
+        );
+      }
 
       if (libraries.length == 1) {
         final libName = p.basenameWithoutExtension(libraries[0]);
-        if (libName == package.name) return;
+        if (libName == package.name ||
+            isAnalysisServerPlugin && libraries[0] == pluginEntrypoint) {
+          return;
+        }
         warnings.add(
           'The name of "${libraries[0]}", "$libName", should match '
           'the name of the package, "${package.name}".\n'

--- a/test/validator/name_test.dart
+++ b/test/validator/name_test.dart
@@ -17,6 +17,11 @@ import 'utils.dart';
 
 Validator name() => NameValidator();
 
+const _missingPluginEntrypointWarning =
+    'Packages that depend on `analysis_server_plugin` should contain '
+    'a `lib/main.dart` entrypoint.\n'
+    'The analysis server loads plugins from this file.';
+
 void main() {
   group('should consider a package valid if it', () {
     setUp(d.validPackage().create);
@@ -41,6 +46,19 @@ void main() {
       ]).create();
       await expectValidationDeprecated(name);
     });
+
+    test('is an analysis server plugin with a main library', () async {
+      deleteEntry(p.join(d.sandbox, appPath, 'lib', 'test_pkg.dart'));
+      await d.dir(appPath, [
+        d.libPubspec(
+          'test_pkg',
+          '1.0.0',
+          deps: {'analysis_server_plugin': '^0.3.0'},
+        ),
+        d.dir('lib', [d.file('main.dart', 'final plugin = Object();')]),
+      ]).create();
+      await expectValidationDeprecated(name);
+    });
   });
 
   group('should consider a package invalid if it', () {
@@ -58,5 +76,41 @@ void main() {
       ]).create();
       await expectValidationDeprecated(name, warnings: isNotEmpty);
     });
+
+    test('is an analysis server plugin without a main library', () async {
+      await d.dir(appPath, [
+        d.libPubspec(
+          'test_pkg',
+          '1.0.0',
+          deps: {'analysis_server_plugin': '^0.3.0'},
+        ),
+      ]).create();
+      await expectValidationDeprecated(
+        name,
+        warnings: [_missingPluginEntrypointWarning],
+      );
+    });
+
+    test(
+      'is an analysis server plugin with only a mismatched library',
+      () async {
+        deleteEntry(p.join(d.sandbox, appPath, 'lib', 'test_pkg.dart'));
+        await d.dir(appPath, [
+          d.libPubspec(
+            'test_pkg',
+            '1.0.0',
+            deps: {'analysis_server_plugin': '^0.3.0'},
+          ),
+          d.dir('lib', [d.file('best_pkg.dart', 'int i = 0;')]),
+        ]).create();
+        await expectValidationDeprecated(
+          name,
+          warnings: [
+            _missingPluginEntrypointWarning,
+            allOf(contains('"best_pkg"'), contains('"test_pkg"')),
+          ],
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
Packages built with `analysis_server_plugin` must expose `lib/main.dart`, but the publish validator currently warns that this file should match the package name. This recognizes direct `analysis_server_plugin` dependencies, accepts the required entrypoint, and warns when it is missing while preserving the existing single-library naming check for other files.

Fixes #4845.
