### PR TITLE
global: recreate binstubs owned by inactive packages

### DIFF
--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -963,6 +963,11 @@ Try reactivating the package.
       previousPackage = _binStubProperty(contents, 'Package');
       if (previousPackage == null) {
         log.fine('Could not parse binstub $binStubPath:\n$contents');
+      } else if (!fileExists(_getLockFilePath(previousPackage))) {
+        log.fine(
+          'Binstub $binStubPath refers to inactive package $previousPackage.',
+        );
+        previousPackage = null;
       } else if (!overwrite) {
         return previousPackage;
       }

--- a/test/global/binstubs/name_collision_test.dart
+++ b/test/global/binstubs/name_collision_test.dart
@@ -60,4 +60,27 @@ void main() {
       ]),
     ]).validate();
   });
+
+  test('overwrites a binstub owned by an inactive package', () async {
+    await d.dir('bar', [
+      d.pubspec({
+        'name': 'bar',
+        'executables': {'bar': 'bar'},
+      }),
+      d.dir('bin', [d.file('bar.dart', "main() => print('ok');")]),
+    ]).create();
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('bar'), '# Package: pub')]),
+    ]).create();
+
+    await runPub(
+      args: ['global', 'activate', '-spath', '../bar'],
+      output: contains('Installed executable bar.'),
+    );
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('bar'), contains('bar:bar'))]),
+    ]).validate();
+  });
 }


### PR DESCRIPTION
Faulty historical binstubs can name an inactive package, such as `pub`, as their owner. A later `dart pub global activate` then treats that stale metadata as a command collision and requires `--overwrite`.

This treats binstubs attributed to packages without an active global package lockfile as orphaned and recreates them. Binstubs owned by active packages keep the existing collision protection.

Fixes #4235.
