### PR TITLE
global: classify faulty binstubs

### DIFF
--- a/lib/src/command/global_deactivate.dart
+++ b/lib/src/command/global_deactivate.dart
@@ -29,7 +29,7 @@ class GlobalDeactivateCommand extends PubCommand {
       usageException('Unexpected $arguments ${toSentence(unexpected)}.');
     }
 
-    if (!globals.deactivate(argResults.rest.first)) {
+    if (!await globals.deactivate(argResults.rest.first)) {
       dataError('No active package ${log.bold(argResults.rest.first)}.');
     }
   }

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -180,6 +180,7 @@ class GlobalPackages {
         packageRef.withConstraint(VersionConstraint.any),
         executables,
         overwriteBinStubs: overwriteBinStubs,
+        mutationContext: _BinStubMutationContext.userActivation,
       );
     });
   }
@@ -226,6 +227,7 @@ class GlobalPackages {
         range,
         executables,
         overwriteBinStubs: overwriteBinStubs,
+        mutationContext: _BinStubMutationContext.userActivation,
       ),
     );
   }
@@ -261,14 +263,19 @@ Follow progress in https://github.com/dart-lang/sdk/issues/60889.
     List<String>? executables, {
     required bool overwriteBinStubs,
   }) => _withGlobalPackagesLock(
-    () =>
-        _activatePath(path, executables, overwriteBinStubs: overwriteBinStubs),
+    () => _activatePath(
+      path,
+      executables,
+      overwriteBinStubs: overwriteBinStubs,
+      mutationContext: _BinStubMutationContext.userActivation,
+    ),
   );
 
   Future<void> _activatePath(
     String path,
     List<String>? executables, {
     required bool overwriteBinStubs,
+    required _BinStubMutationContext mutationContext,
   }) async {
     final entrypoint = Entrypoint(path, cache);
 
@@ -311,6 +318,7 @@ Follow progress in https://github.com/dart-lang/sdk/issues/60889.
       activatedPackage,
       executables,
       overwriteBinStubs: overwriteBinStubs,
+      mutationContext: mutationContext,
     );
     log.message('Activated ${_formatPackage(id)}.');
   }
@@ -322,6 +330,7 @@ Follow progress in https://github.com/dart-lang/sdk/issues/60889.
     PackageRange dep,
     List<String>? executables, {
     required bool overwriteBinStubs,
+    required _BinStubMutationContext mutationContext,
     bool silent = false,
   }) async {
     final name = dep.name;
@@ -433,6 +442,7 @@ To recompile executables, first run `$topLevelProgram pub global deactivate $nam
       cache.load(entrypoint.lockFile.packages[dep.name]!),
       executables,
       overwriteBinStubs: overwriteBinStubs,
+      mutationContext: mutationContext,
     );
     if (!silent) log.message('Activated ${_formatPackage(id)}.');
   }
@@ -763,31 +773,34 @@ Try reactivating the package.
 
   Future<(List<String> successes, List<String> failures)>
   _repairActivatedPackages() async {
-    final executables = <String, List<String>>{};
+    final binStubs = <String, List<_BinStub>>{};
     if (dirExists(_binStubDir)) {
       for (var entry in listDir(_binStubDir)) {
-        try {
-          final binstub = readTextFile(entry);
-          final package = _binStubProperty(binstub, 'Package');
-          if (package == null) {
-            throw ApplicationException("No 'Package' property.");
-          }
-
-          final executable = _binStubProperty(binstub, 'Executable');
-          if (executable == null) {
-            throw ApplicationException("No 'Executable' property.");
-          }
-
-          executables.putIfAbsent(package, () => []).add(executable);
-        } catch (error, stackTrace) {
-          log.error(
-            'Error reading binstub for '
-            '"${p.basenameWithoutExtension(entry)}"',
-            error,
-            stackTrace,
-          );
-
-          tryDeleteEntry(entry);
+        final binStub = _classifyBinStub(entry);
+        switch (binStub.status) {
+          case _BinStubStatus.active:
+          case _BinStubStatus.orphaned:
+            binStubs.putIfAbsent(binStub.package!, () => []).add(binStub);
+          case _BinStubStatus.malformedPub:
+            log.error(
+              'Error reading binstub for '
+              '"${p.basenameWithoutExtension(entry)}"',
+              ApplicationException(binStub.problem!),
+            );
+            tryDeleteEntry(entry);
+          case _BinStubStatus.foreign:
+            log.error(
+              'Error reading binstub for '
+              '"${p.basenameWithoutExtension(entry)}"',
+              ApplicationException('Not a pub-generated binstub.'),
+            );
+          case _BinStubStatus.unreadable:
+            log.error(
+              'Error reading binstub for '
+              '"${p.basenameWithoutExtension(entry)}"',
+              binStub.error,
+              binStub.stackTrace,
+            );
         }
       }
     }
@@ -802,7 +815,12 @@ Try reactivating the package.
           log.message('Reactivating ${log.bold(id.name)} ${id.version}...');
 
           final entrypoint = await find(id.name);
-          final packageExecutables = executables.remove(id.name) ?? [];
+          final packageExecutables =
+              binStubs
+                  .remove(id.name)
+                  ?.map((binStub) => binStub.executable!)
+                  .toList() ??
+              [];
 
           if (entrypoint.isCached) {
             deleteEntry(_packageDir(id.name));
@@ -810,6 +828,7 @@ Try reactivating the package.
               id.toRange(),
               packageExecutables,
               overwriteBinStubs: true,
+              mutationContext: _BinStubMutationContext.repair,
               silent: true,
             );
           } else {
@@ -817,6 +836,7 @@ Try reactivating the package.
               entrypoint.workspaceRoot.dir,
               packageExecutables,
               overwriteBinStubs: true,
+              mutationContext: _BinStubMutationContext.repair,
             );
           }
           successes.add(id.name);
@@ -837,15 +857,18 @@ Try reactivating the package.
       }
     }
 
-    if (executables.isNotEmpty) {
+    if (binStubs.isNotEmpty) {
       final message = StringBuffer(
         'Binstubs exist for non-activated '
         'packages:\n',
       );
-      executables.forEach((package, executableNames) {
-        for (var executable in executableNames) {
-          deleteEntry(p.join(_binStubDir, executable));
+      binStubs.forEach((package, packageBinStubs) {
+        for (var binStub in packageBinStubs) {
+          deleteEntry(binStub.path);
         }
+        final executableNames = packageBinStubs.map(
+          (binStub) => binStub.executable!,
+        );
 
         message.writeln(
           '  From ${log.bold(package)}: '
@@ -865,22 +888,21 @@ Try reactivating the package.
   void _refreshBinStubs(Entrypoint entrypoint, exec.Executable executable) {
     if (!dirExists(_binStubDir)) return;
     for (var file in listDir(_binStubDir, includeDirs: false)) {
-      final contents = readTextFile(file);
-      final binStubPackage = _binStubProperty(contents, 'Package');
-      final binStubScript = _binStubProperty(contents, 'Script');
-      if (binStubPackage == null || binStubScript == null) {
-        log.fine('Could not parse binstub $file:\n$contents');
+      final binStub = _classifyBinStub(file);
+      if (binStub.status != _BinStubStatus.active) {
+        _logBinStubProblem(binStub);
         continue;
       }
-      if (binStubPackage == executable.package &&
-          binStubScript ==
+      if (binStub.package == executable.package &&
+          binStub.script ==
               p.basenameWithoutExtension(executable.relativePath)) {
         log.fine('Replacing old binstub $file');
         _createBinStub(
           activatedPackage(entrypoint),
           p.basenameWithoutExtension(file),
-          binStubScript,
+          binStub.script!,
           overwrite: true,
+          mutationContext: _BinStubMutationContext.userActivation,
           isRefreshingBinstub: true,
           snapshot:
               entrypoint.isCachedGlobal
@@ -916,6 +938,7 @@ Try reactivating the package.
     Package package,
     List<String>? executables, {
     required bool overwriteBinStubs,
+    required _BinStubMutationContext mutationContext,
     bool suggestIfNotOnPath = true,
   }) {
     // Remove any previously activated binstubs for this package, in case the
@@ -930,18 +953,19 @@ Try reactivating the package.
     ensureDir(_binStubDir);
 
     final installed = <String>[];
-    final collided = <String, String>{};
+    final collided = <String, _BinStub>{};
     final allExecutables = package.pubspec.executables.keys.sorted();
     for (var executable in allExecutables) {
       if (executables != null && !executables.contains(executable)) continue;
 
       final script = package.pubspec.executables[executable]!;
 
-      final previousPackage = _createBinStub(
+      final previousBinStub = _createBinStub(
         package,
         executable,
         script,
         overwrite: overwriteBinStubs,
+        mutationContext: mutationContext,
         isRefreshingBinstub: false,
         snapshot:
             entrypoint.isCachedGlobal
@@ -950,10 +974,16 @@ Try reactivating the package.
                 )
                 : null,
       );
-      if (previousPackage != null) {
-        collided[executable] = previousPackage;
+      if (previousBinStub != null) {
+        collided[executable] = previousBinStub;
 
-        if (!overwriteBinStubs) continue;
+        if (!_canOverwriteBinStub(
+          previousBinStub,
+          overwrite: overwriteBinStubs,
+          mutationContext: mutationContext,
+        )) {
+          continue;
+        }
       }
 
       installed.add(executable);
@@ -967,24 +997,51 @@ Try reactivating the package.
     // Show errors for any collisions.
     if (collided.isNotEmpty) {
       for (var command in collided.keys.sorted()) {
-        if (overwriteBinStubs) {
-          log.warning(
-            'Replaced ${log.bold(command)} previously installed from '
-            '${log.bold(collided[command].toString())}.',
-          );
+        final previousBinStub = collided[command]!;
+        final previousPackage = previousBinStub.package;
+        if (_canOverwriteBinStub(
+          previousBinStub,
+          overwrite: overwriteBinStubs,
+          mutationContext: mutationContext,
+        )) {
+          if (previousPackage == null) {
+            log.warning(
+              'Replaced ${log.bold(command)}, which was not installed by pub.',
+            );
+          } else {
+            log.warning(
+              'Replaced ${log.bold(command)} previously installed from '
+              '${log.bold(previousPackage)}.',
+            );
+          }
         } else {
-          log.warning(
-            'Executable ${log.bold(command)} was already installed '
-            'from ${log.bold(collided[command].toString())}.',
-          );
+          if (previousPackage == null) {
+            log.warning(
+              'Executable ${log.bold(command)} already exists and was not '
+              'installed by pub.',
+            );
+          } else {
+            log.warning(
+              'Executable ${log.bold(command)} was already installed '
+              'from ${log.bold(previousPackage)}.',
+            );
+          }
         }
       }
 
-      if (!overwriteBinStubs) {
-        log.warning(
-          'Deactivate the other package(s) or activate '
-          '${log.bold(package.name)} using --overwrite.',
-        );
+      if (mutationContext == _BinStubMutationContext.userActivation &&
+          !overwriteBinStubs) {
+        if (collided.values.any((binStub) => binStub.package == null)) {
+          log.warning(
+            'Remove the conflicting executable(s) or activate '
+            '${log.bold(package.name)} using --overwrite.',
+          );
+        } else {
+          log.warning(
+            'Deactivate the other package(s) or activate '
+            '${log.bold(package.name)} using --overwrite.',
+          );
+        }
       }
     }
 
@@ -1029,32 +1086,45 @@ Try reactivating the package.
   /// If [snapshot] is `null`, the binstub will always run `pub global run`
   /// (used for path-activated packages where snapshots would become stale).
   ///
-  /// If a collision occurs, returns the name of the package that owns the
-  /// existing binstub. Otherwise returns `null`.
-  String? _createBinStub(
+  _BinStub? _createBinStub(
     Package package,
     String executable,
     String script, {
     required bool overwrite,
+    required _BinStubMutationContext mutationContext,
     required String? snapshot,
     required bool isRefreshingBinstub,
   }) {
     var binStubPath = p.join(_binStubDir, executable);
     if (platform.isWindows) binStubPath += '.bat';
 
-    String? previousPackage;
+    _BinStub? previousBinStub;
     if (!isRefreshingBinstub && fileExists(binStubPath)) {
-      final contents = readTextFile(binStubPath);
-      previousPackage = _binStubProperty(contents, 'Package');
-      if (previousPackage == null) {
-        log.fine('Could not parse binstub $binStubPath:\n$contents');
-      } else if (!fileExists(_getLockFilePath(previousPackage))) {
-        log.fine(
-          'Binstub $binStubPath refers to inactive package $previousPackage.',
-        );
-        previousPackage = null;
-      } else if (!overwrite) {
-        return previousPackage;
+      final binStub = _classifyBinStub(binStubPath);
+      switch (binStub.status) {
+        case _BinStubStatus.active:
+          previousBinStub = binStub;
+          if (!_canOverwriteBinStub(
+            binStub,
+            overwrite: overwrite,
+            mutationContext: mutationContext,
+          )) {
+            return previousBinStub;
+          }
+        case _BinStubStatus.orphaned:
+        case _BinStubStatus.malformedPub:
+          _logBinStubProblem(binStub);
+        case _BinStubStatus.foreign:
+        case _BinStubStatus.unreadable:
+          _logBinStubProblem(binStub);
+          previousBinStub = binStub;
+          if (!_canOverwriteBinStub(
+            binStub,
+            overwrite: overwrite,
+            mutationContext: mutationContext,
+          )) {
+            return previousBinStub;
+          }
       }
     }
     // When running tests we want the binstub to invoke the current pub, not the
@@ -1163,7 +1233,20 @@ ${header}dart $pubInvocation global run $runPubGlobal "\$@"
       deleteEntry(tempDir);
     }
 
-    return previousPackage;
+    return previousBinStub;
+  }
+
+  bool _canOverwriteBinStub(
+    _BinStub binStub, {
+    required bool overwrite,
+    required _BinStubMutationContext mutationContext,
+  }) {
+    if (!overwrite) return false;
+    return switch (binStub.status) {
+      _BinStubStatus.foreign || _BinStubStatus.unreadable =>
+        mutationContext == _BinStubMutationContext.userActivation,
+      _ => true,
+    };
   }
 
   /// Deletes all existing binstubs for [package].
@@ -1171,14 +1254,14 @@ ${header}dart $pubInvocation global run $runPubGlobal "\$@"
     if (!dirExists(_binStubDir)) return;
 
     for (var file in listDir(_binStubDir, includeDirs: false)) {
-      final contents = readTextFile(file);
-      final binStubPackage = _binStubProperty(contents, 'Package');
-      if (binStubPackage == null) {
-        log.fine('Could not parse binstub $file:\n$contents');
+      final binStub = _classifyBinStub(file);
+      if (binStub.status != _BinStubStatus.active &&
+          binStub.status != _BinStubStatus.orphaned) {
+        _logBinStubProblem(binStub);
         continue;
       }
 
-      if (binStubPackage == package) {
+      if (binStub.package == package) {
         log.fine('Deleting old binstub $file');
         deleteEntry(file);
       }
@@ -1239,13 +1322,146 @@ ${header}dart $pubInvocation global run $runPubGlobal "\$@"
     }
   }
 
-  /// Returns the value of the property named [name] in the bin stub script
-  /// [source].
-  String? _binStubProperty(String source, String name) {
-    final pattern = RegExp(RegExp.escape(name) + r': ([a-zA-Z0-9_-]+)');
-    final match = pattern.firstMatch(source);
-    return match == null ? null : match[1];
+  _BinStub _classifyBinStub(String path) {
+    final String contents;
+    try {
+      contents = File(path).readAsStringSync(encoding: const SystemEncoding());
+    } on Object catch (error, stackTrace) {
+      return _BinStub(
+        path,
+        _BinStubStatus.unreadable,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+
+    final lines = contents.split(RegExp(r'\r?\n'));
+    final unixMarkerPattern = RegExp(
+      r'^# This file was created by pub v[^\r\n]+\.$',
+    );
+    final windowsMarkerPattern = RegExp(
+      r'^rem This file was created by pub v[^\r\n]+\.$',
+      caseSensitive: false,
+    );
+    var markerIndex = -1;
+    String? prefix;
+    if (lines.isNotEmpty && unixMarkerPattern.hasMatch(lines.first)) {
+      markerIndex = 0;
+      prefix = '#';
+    } else if (lines.length > 1 &&
+        lines.first == '#!/usr/bin/env sh' &&
+        unixMarkerPattern.hasMatch(lines[1])) {
+      markerIndex = 1;
+      prefix = '#';
+    } else if (lines.length > 1 &&
+        lines.first.toLowerCase() == '@echo off' &&
+        windowsMarkerPattern.hasMatch(lines[1])) {
+      markerIndex = 1;
+      prefix = 'rem';
+    }
+    if (markerIndex == -1) {
+      return _BinStub(path, _BinStubStatus.foreign);
+    }
+
+    final propertyPattern = RegExp(
+      '^${RegExp.escape(prefix!)} ([a-zA-Z][a-zA-Z0-9_-]*): (.*)\$',
+      caseSensitive: false,
+    );
+    final properties = <String, String>{};
+    String? problem;
+    for (var i = markerIndex + 1; i < lines.length; i++) {
+      final match = propertyPattern.firstMatch(lines[i]);
+      if (match == null) break;
+      final name = match[1]!.toLowerCase();
+      if (properties.containsKey(name)) {
+        problem = "Duplicate '$name' property.";
+        break;
+      }
+      properties[name] = match[2]!;
+    }
+
+    final package = properties['package'];
+    final executable = properties['executable'];
+    final script = properties['script'];
+    if (problem == null && package == null) {
+      problem = "Missing 'Package' property.";
+    } else if (problem == null && !packageNameRegExp.hasMatch(package!)) {
+      problem = "Invalid 'Package' property.";
+    } else if (problem == null && executable == null) {
+      problem = "Missing 'Executable' property.";
+    } else if (problem == null &&
+        !RegExp(r'^[a-zA-Z0-9_-]+$').hasMatch(executable!)) {
+      problem = "Invalid 'Executable' property.";
+    } else if (problem == null &&
+        executable != p.basenameWithoutExtension(path)) {
+      problem = "The 'Executable' property does not match the file name.";
+    } else if (problem == null && script == null) {
+      problem = "Missing 'Script' property.";
+    } else if (problem == null &&
+        (script!.isEmpty || script.contains(RegExp(r'[/\\]')))) {
+      problem = "Invalid 'Script' property.";
+    }
+
+    if (problem != null) {
+      return _BinStub(path, _BinStubStatus.malformedPub, problem: problem);
+    }
+
+    return _BinStub(
+      path,
+      fileExists(_getLockFilePath(package!))
+          ? _BinStubStatus.active
+          : _BinStubStatus.orphaned,
+      package: package,
+      executable: executable,
+      script: script,
+    );
   }
+
+  void _logBinStubProblem(_BinStub binStub) {
+    switch (binStub.status) {
+      case _BinStubStatus.active:
+        return;
+      case _BinStubStatus.orphaned:
+        log.fine(
+          'Binstub ${binStub.path} refers to inactive package '
+          '${binStub.package}.',
+        );
+      case _BinStubStatus.malformedPub:
+        log.fine(
+          'Could not parse pub binstub ${binStub.path}: ${binStub.problem}',
+        );
+      case _BinStubStatus.foreign:
+        log.fine('Binstub ${binStub.path} was not created by pub.');
+      case _BinStubStatus.unreadable:
+        log.fine('Could not read binstub ${binStub.path}: ${binStub.error}');
+    }
+  }
+}
+
+enum _BinStubMutationContext { userActivation, repair }
+
+enum _BinStubStatus { active, orphaned, malformedPub, foreign, unreadable }
+
+class _BinStub {
+  final String path;
+  final _BinStubStatus status;
+  final String? package;
+  final String? executable;
+  final String? script;
+  final String? problem;
+  final Object? error;
+  final StackTrace? stackTrace;
+
+  const _BinStub(
+    this.path,
+    this.status, {
+    this.package,
+    this.executable,
+    this.script,
+    this.problem,
+    this.error,
+    this.stackTrace,
+  });
 }
 
 /// The package that was activated.

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -963,6 +963,11 @@ Try reactivating the package.
       previousPackage = _binStubProperty(contents, 'Package');
       if (previousPackage == null) {
         log.fine('Could not parse binstub $binStubPath:\n$contents');
+      } else if (!fileExists(_getLockFilePath(previousPackage))) {
+        log.fine(
+          'Binstub $binStubPath refers to inactive package $previousPackage.',
+        );
+        previousPackage = null;
       } else if (!overwrite) {
         return previousPackage;
       }

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -71,12 +71,63 @@ class GlobalPackages {
   /// The directory where binstubs for global package executables are stored.
   String get _binStubDir => p.join(cache.rootDir, 'bin');
 
+  /// Kept beside the cache so cache deletion cannot replace the locked inode.
+  /// The parent directory of the cache must be writable.
+  String get _globalPackagesLockPath {
+    final cacheRoot = canonicalize(cache.rootDir);
+    return p.join(
+      p.dirname(cacheRoot),
+      '${p.basename(cacheRoot)}.global_packages.lock',
+    );
+  }
+
   /// Creates a new global package registry backed by the given directory on
   /// the user's file system.
   ///
   /// The directory may not physically exist yet. If not, this will create it
   /// when needed.
   GlobalPackages(this.cache);
+
+  Future<T> _withGlobalPackagesLock<T>(FutureOr<T> Function() action) async {
+    final lockPath = _globalPackagesLockPath;
+    final lockDirectory = p.dirname(lockPath);
+    final RandomAccessFile lockFile;
+    try {
+      ensureDir(lockDirectory);
+      lockFile = await File(lockPath).open(mode: FileMode.append);
+    } on FileSystemException catch (error, stackTrace) {
+      final reason = error.osError?.message ?? error.message;
+      throw WrappedException(
+        'Unable to open the global package lock at "$lockPath".\n'
+        'The canonical pub cache parent directory "$lockDirectory" must be '
+        'writable.\n'
+        'Move the pub cache under a writable parent or make this directory '
+        'writable.\n'
+        'Reason: $reason',
+        error,
+        stackTrace,
+      );
+    }
+    var isLocked = false;
+    try {
+      try {
+        await lockFile.lock();
+      } on FileSystemException {
+        await log.spinner(
+          'Waiting to acquire the global package mutation lock',
+          () => lockFile.lock(FileLock.blockingExclusive),
+        );
+      }
+      isLocked = true;
+      return await action();
+    } finally {
+      try {
+        if (isLocked) await lockFile.unlock();
+      } finally {
+        await lockFile.close();
+      }
+    }
+  }
 
   /// Caches the package located in the Git repository [repo] and makes it the
   /// active global version.
@@ -96,39 +147,41 @@ class GlobalPackages {
     String? ref,
     String? tagPattern,
   }) async {
-    final name = await cache.git.getPackageNameFromRepo(
-      repo,
-      ref,
-      path,
-      cache,
-      relativeTo: p.current,
-      tagPattern: tagPattern,
-    );
-
-    // TODO(nweiz): Add some special handling for git repos that contain path
-    // dependencies. Their executables shouldn't be cached, and there should
-    // be a mechanism for redoing dependency resolution if a path pubspec has
-    // changed (see also issue 20499).
-    PackageRef packageRef;
-    try {
-      packageRef = cache.git.parseRef(
-        name,
-        {
-          'url': repo,
-          if (path != null) 'path': path,
-          if (ref != null) 'ref': ref,
-        },
-        containingDescription: ResolvedRootDescription.fromDir(p.current),
-        languageVersion: LanguageVersion.fromVersion(sdk.version),
+    await _withGlobalPackagesLock(() async {
+      final name = await cache.git.getPackageNameFromRepo(
+        repo,
+        ref,
+        path,
+        cache,
+        relativeTo: p.current,
+        tagPattern: tagPattern,
       );
-    } on FormatException catch (e) {
-      throw ApplicationException(e.message);
-    }
-    await _installInCache(
-      packageRef.withConstraint(VersionConstraint.any),
-      executables,
-      overwriteBinStubs: overwriteBinStubs,
-    );
+
+      // TODO(nweiz): Add some special handling for git repos that contain path
+      // dependencies. Their executables shouldn't be cached, and there should
+      // be a mechanism for redoing dependency resolution if a path pubspec has
+      // changed (see also issue 20499).
+      PackageRef packageRef;
+      try {
+        packageRef = cache.git.parseRef(
+          name,
+          {
+            'url': repo,
+            if (path != null) 'path': path,
+            if (ref != null) 'ref': ref,
+          },
+          containingDescription: ResolvedRootDescription.fromDir(p.current),
+          languageVersion: LanguageVersion.fromVersion(sdk.version),
+        );
+      } on FormatException catch (e) {
+        throw ApplicationException(e.message);
+      }
+      await _installInCache(
+        packageRef.withConstraint(VersionConstraint.any),
+        executables,
+        overwriteBinStubs: overwriteBinStubs,
+      );
+    });
   }
 
   Package packageForConstraint(PackageRange dep, String dir) {
@@ -168,10 +221,12 @@ class GlobalPackages {
     required bool overwriteBinStubs,
     String? url,
   }) async {
-    await _installInCache(
-      range,
-      executables,
-      overwriteBinStubs: overwriteBinStubs,
+    await _withGlobalPackagesLock(
+      () => _installInCache(
+        range,
+        executables,
+        overwriteBinStubs: overwriteBinStubs,
+      ),
     );
   }
 
@@ -202,6 +257,15 @@ Follow progress in https://github.com/dart-lang/sdk/issues/60889.
   /// existing binstubs in other packages will be overwritten by this one's.
   /// Otherwise, the previous ones will be preserved.
   Future<void> activatePath(
+    String path,
+    List<String>? executables, {
+    required bool overwriteBinStubs,
+  }) => _withGlobalPackagesLock(
+    () =>
+        _activatePath(path, executables, overwriteBinStubs: overwriteBinStubs),
+  );
+
+  Future<void> _activatePath(
     String path,
     List<String>? executables, {
     required bool overwriteBinStubs,
@@ -424,7 +488,10 @@ Consider `$topLevelProgram pub global deactivate $name`''');
   /// Deactivates a previously-activated package named [name].
   ///
   /// Returns `false` if no package with [name] was currently active.
-  bool deactivate(String name) {
+  Future<bool> deactivate(String name) =>
+      _withGlobalPackagesLock(() => _deactivate(name));
+
+  bool _deactivate(String name) {
     final dir = p.join(_directory, name);
     if (!dirExists(_directory)) {
       return false;
@@ -539,87 +606,101 @@ try:
       executable,
       args,
       enableAsserts: enableAsserts,
-      recompile: (exectuable) async {
-        final root = entrypoint.workspaceRoot;
-        final name = exectuable.package;
-
-        // When recompiling we re-resolve it and download its dependencies. This
-        // is mainly to protect from the case where the sdk was updated, and
-        // that causes some incompatibilities. (could be the new sdk is outside
-        // some package's environment constraint range, or that the sdk came
-        // with incompatible versions of sdk packages).
-        //
-        // We use --enforce-lockfile semantics, because we want upgrading
-        // globally activated packages to be conscious, and not a part of
-        // running them.
-        SolveResult result;
-        try {
-          result = await log.spinner(
-            'Resolving dependencies',
-            () => resolveVersions(
-              SolveType.get,
-              cache,
-              root,
-              lockFile: entrypoint.lockFile,
+      recompile:
+          (executableToRecompile) => _withGlobalPackagesLock(
+            () => _recompileExecutable(
+              entrypoint,
+              executable,
+              executableToRecompile,
+              recompile,
             ),
-          );
-        } on SolveFailure catch (e) {
-          log.error(e.message);
-          fail('''The package `$name` as currently activated cannot resolve.
+          ),
+      vmArgs: vmArgs,
+      alwaysUseSubprocess: alwaysUseSubprocess,
+    );
+  }
+
+  Future<void> _recompileExecutable(
+    Entrypoint entrypoint,
+    exec.Executable executable,
+    exec.Executable executableToRecompile,
+    Future<void> Function(exec.Executable) recompile,
+  ) async {
+    final root = entrypoint.workspaceRoot;
+    final name = executableToRecompile.package;
+
+    // When recompiling we re-resolve it and download its dependencies. This is
+    // mainly to protect from the case where the sdk was updated, and that
+    // causes some incompatibilities. (could be the new sdk is outside some
+    // package's environment constraint range, or that the sdk came with
+    // incompatible versions of sdk packages).
+    //
+    // We use --enforce-lockfile semantics, because we want upgrading globally
+    // activated packages to be conscious, and not a part of running them.
+    SolveResult result;
+    try {
+      result = await log.spinner(
+        'Resolving dependencies',
+        () => resolveVersions(
+          SolveType.get,
+          cache,
+          root,
+          lockFile: entrypoint.lockFile,
+        ),
+      );
+    } on SolveFailure catch (e) {
+      log.error(e.message);
+      fail('''The package `$name` as currently activated cannot resolve.
 
 Try reactivating the package.
 `$topLevelProgram pub global activate $name`          
 ''');
-        }
-        // We want the entrypoint to be rooted at 'dep' not the dummy-package.
-        result.packages.removeWhere((id) => id.name == 'pub global activate');
+    }
+    // We want the entrypoint to be rooted at 'dep' not the dummy-package.
+    result.packages.removeWhere((id) => id.name == 'pub global activate');
 
-        final newLockFile = await result.downloadCachedPackages(cache);
-        final report = SolveReport(
-          SolveType.get,
-          entrypoint.workspaceRoot.dir,
-          entrypoint.workspaceRoot.pubspec,
-          entrypoint.workspaceRoot.allOverridesInWorkspace,
-          entrypoint.lockFile,
-          newLockFile,
-          result.availableVersions,
-          cache,
-          dryRun: true,
-          enforceLockfile: true,
-          quiet: false,
-        );
-        await report.show(summary: true);
+    final newLockFile = await result.downloadCachedPackages(cache);
+    final report = SolveReport(
+      SolveType.get,
+      entrypoint.workspaceRoot.dir,
+      entrypoint.workspaceRoot.pubspec,
+      entrypoint.workspaceRoot.allOverridesInWorkspace,
+      entrypoint.lockFile,
+      newLockFile,
+      result.availableVersions,
+      cache,
+      dryRun: true,
+      enforceLockfile: true,
+      quiet: false,
+    );
+    await report.show(summary: true);
 
-        final sameVersions = entrypoint.lockFile.samePackageIds(newLockFile);
+    final sameVersions = entrypoint.lockFile.samePackageIds(newLockFile);
 
-        if (!sameVersions) {
-          if (newLockFile.packages.values.any((p) {
-            return p.source is SdkSource &&
-                p.version != entrypoint.lockFile.packages[p.name]?.version;
-          })) {
-            // More specific error message for the case of a version match with
-            // an sdk package.
-            dataError('''
+    if (!sameVersions) {
+      if (newLockFile.packages.values.any((p) {
+        return p.source is SdkSource &&
+            p.version != entrypoint.lockFile.packages[p.name]?.version;
+      })) {
+        // More specific error message for the case of a version match with an
+        // sdk package.
+        dataError('''
 The current activation of `$name` is not compatible with your current SDK.
 
 Try reactivating the package.
 `$topLevelProgram pub global activate $name`
 ''');
-          } else {
-            dataError('''
+      } else {
+        dataError('''
 The current activation of `$name` cannot resolve to the same set of dependencies.
 
 Try reactivating the package.
 `$topLevelProgram pub global activate $name`
 ''');
-          }
-        }
-        await recompile(exectuable);
-        _refreshBinStubs(entrypoint, executable);
-      },
-      vmArgs: vmArgs,
-      alwaysUseSubprocess: alwaysUseSubprocess,
-    );
+      }
+    }
+    await recompile(executableToRecompile);
+    _refreshBinStubs(entrypoint, executable);
   }
 
   /// Gets the path to the lock file for an activated cached package with
@@ -677,7 +758,11 @@ Try reactivating the package.
   /// Returns a pair of two lists of strings. The first indicates which packages
   /// were successfully re-activated; the second indicates which failed.
   Future<(List<String> successes, List<String> failures)>
-  repairActivatedPackages() async {
+  repairActivatedPackages() =>
+      _withGlobalPackagesLock(_repairActivatedPackages);
+
+  Future<(List<String> successes, List<String> failures)>
+  _repairActivatedPackages() async {
     final executables = <String, List<String>>{};
     if (dirExists(_binStubDir)) {
       for (var entry in listDir(_binStubDir)) {
@@ -728,7 +813,7 @@ Try reactivating the package.
               silent: true,
             );
           } else {
-            await activatePath(
+            await _activatePath(
               entrypoint.workspaceRoot.dir,
               packageExecutables,
               overwriteBinStubs: true,

--- a/test/cache/repair/handles_corrupted_binstub_test.dart
+++ b/test/cache/repair/handles_corrupted_binstub_test.dart
@@ -5,13 +5,32 @@
 @TestOn('vm')
 library;
 
+import 'dart:io';
+
+import 'package:pub/src/path.dart';
 import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
 
+const _foreignBinStub = '''
+#!/usr/bin/env sh
+# Package: foo
+# Executable: script
+# Script: script
+echo not-pub
+''';
+
+const _malformedPubBinStub = '''
+# This file was created by pub v0.1.2-3.
+# Package: ../foo
+# Version: 1.0.0
+# Executable: script
+# Script: script
+''';
+
 void main() {
-  test('handles a corrupted binstub script', () async {
+  test('preserves a foreign binstub and continues repairing', () async {
     final server = await servePackages();
     server.serve(
       'foo',
@@ -24,12 +43,62 @@ void main() {
     await runPub(args: ['global', 'activate', 'foo']);
 
     await d.dir(cachePath, [
-      d.dir('bin', [d.file(binStubName('script'), 'junk')]),
+      d.dir('bin', [d.file(binStubName('script'), _foreignBinStub)]),
     ]).create();
 
     await runPub(
       args: ['cache', 'repair', '--all'],
+      output: contains('Reactivated 1 package.'),
       error: contains('Error reading binstub for "script":'),
     );
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('script'), _foreignBinStub)]),
+    ]).validate();
   });
+
+  test('removes a malformed pub binstub', () async {
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('script'), _malformedPubBinStub)]),
+    ]).create();
+
+    await runPub(
+      args: ['cache', 'repair', '--all'],
+      error: allOf([
+        contains('Error reading binstub for "script":'),
+        contains("Invalid 'Package' property."),
+      ]),
+    );
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.nothing(binStubName('script'))]),
+    ]).validate();
+  });
+
+  test(
+    'preserves a binstub that cannot be decoded',
+    () async {
+      await d.dir(cachePath, [
+        d.dir('bin', [d.file(binStubName('script'), 'placeholder')]),
+      ]).create();
+      final binStubPath = p.join(
+        d.sandbox,
+        cachePath,
+        'bin',
+        binStubName('script'),
+      );
+      File(binStubPath).writeAsBytesSync([0xff]);
+
+      await runPub(
+        args: ['cache', 'repair', '--all'],
+        error: contains('Error reading binstub for "script":'),
+      );
+
+      expect(File(binStubPath).readAsBytesSync(), [0xff]);
+    },
+    skip:
+        Platform.isWindows
+            ? '0xff is valid in Windows system encodings.'
+            : false,
+  );
 }

--- a/test/cache/repair/handles_orphaned_binstub_test.dart
+++ b/test/cache/repair/handles_orphaned_binstub_test.dart
@@ -11,19 +11,19 @@ import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
 
 const _orphanedBinstub = '''
-#!/usr/bin/env sh
-# This file was created by pub v0.1.2-3.
-# Package: foo
-# Version: 1.0.0
-# Executable: foo-script
-# Script: script
-dart "/path/to/.pub-cache/global_packages/foo/bin/script.dart.snapshot" "\$@"
+@echo off
+rem This file was created by pub v0.1.2-3.
+rem Package: foo
+rem Version: 1.0.0
+rem Executable: foo-script
+rem Script: script
+dart "/path/to/.pub-cache/global_packages/foo/bin/script.dart.snapshot" %*
 ''';
 
 void main() {
   test('handles an orphaned binstub script', () async {
     await d.dir(cachePath, [
-      d.dir('bin', [d.file(binStubName('script'), _orphanedBinstub)]),
+      d.dir('bin', [d.file(binStubName('foo-script'), _orphanedBinstub)]),
     ]).create();
 
     await runPub(
@@ -33,5 +33,9 @@ void main() {
         contains('From foo: foo-script'),
       ]),
     );
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.nothing(binStubName('foo-script'))]),
+    ]).validate();
   });
 }

--- a/test/global/activate/serializes_mutations_test.dart
+++ b/test/global/activate/serializes_mutations_test.dart
@@ -1,0 +1,247 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:pub/src/io.dart'
+    show canonicalize, deleteEntry, dirExists, readTextFile, writeTextFile;
+import 'package:pub/src/path.dart';
+import 'package:shelf/shelf.dart' as shelf;
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+Future<PubProcess> _startPubWaitingForGlobalLock({
+  required Iterable<String> args,
+  FutureOr<void> Function()? whileWaiting,
+}) async {
+  final cacheRoot = canonicalize(pathInCache(''));
+  Directory(cacheRoot).createSync(recursive: true);
+  final lockFile = File(
+    '$cacheRoot.global_packages.lock',
+  ).openSync(mode: FileMode.append);
+  var lockFileClosed = false;
+  lockFile.lockSync();
+  addTearDown(() {
+    if (lockFileClosed) return;
+    lockFile.unlockSync();
+    lockFile.closeSync();
+  });
+
+  final process = await startPub(args: args);
+  await expectLater(
+    process.stdout,
+    emitsThrough('Waiting to acquire the global package mutation lock...'),
+  );
+  if (whileWaiting != null) await whileWaiting();
+
+  lockFile.unlockSync();
+  lockFile.closeSync();
+  lockFileClosed = true;
+  return process;
+}
+
+void main() {
+  test('holds the global package lock while activating', () async {
+    final server = await servePackages();
+    server.serve(
+      'foo',
+      '1.0.0',
+      pubspec: {
+        'executables': {'foo': null},
+      },
+      contents: [
+        d.dir('bin', [d.file('foo.dart', "main() => print('ok');")]),
+      ],
+    );
+
+    final archiveSha256 = await server.peekArchiveSha256('foo', '1.0.0');
+    final requestReceived = Completer<void>();
+    final sendResponse = Completer<void>();
+    addTearDown(() {
+      if (!sendResponse.isCompleted) sendResponse.complete();
+    });
+    server.handle('/api/packages/foo', (request) async {
+      requestReceived.complete();
+      await sendResponse.future;
+      return shelf.Response.ok(
+        jsonEncode({
+          'name': 'foo',
+          'uploaders': ['nweiz@google.com'],
+          'versions': [
+            {
+              'pubspec': {
+                'name': 'foo',
+                'version': '1.0.0',
+                'environment': {'sdk': '^3.0.0'},
+                'executables': {'foo': null},
+              },
+              'version': '1.0.0',
+              'archive_url': '${server.url}/packages/foo/versions/1.0.0.tar.gz',
+              'archive_sha256': archiveSha256,
+            },
+          ],
+        }),
+        headers: {HttpHeaders.contentTypeHeader: server.contentType},
+      );
+    });
+
+    final configuredCacheRoot = p.normalize(pathInCache(''));
+    Directory(configuredCacheRoot).createSync(recursive: true);
+    var pubCache = configuredCacheRoot;
+    if (!Platform.isWindows) {
+      pubCache = p.join(d.sandbox, 'cache-link');
+      Link(pubCache).createSync(configuredCacheRoot);
+    }
+
+    final pub = await startPub(
+      args: ['global', 'activate', 'foo'],
+      environment: {'PUB_CACHE': pubCache},
+    );
+    await requestReceived.future;
+
+    final cacheRoot = canonicalize(configuredCacheRoot);
+    final lockPath = '$cacheRoot.global_packages.lock';
+    final lockedProbe = File(lockPath).openSync(mode: FileMode.append);
+    try {
+      expect(lockedProbe.lockSync, throwsA(isA<FileSystemException>()));
+    } finally {
+      lockedProbe.closeSync();
+    }
+
+    sendResponse.complete();
+    await pub.shouldExit();
+
+    final releasedProbe = File(lockPath).openSync(mode: FileMode.append);
+    try {
+      releasedProbe.lockSync();
+      releasedProbe.unlockSync();
+    } finally {
+      releasedProbe.closeSync();
+    }
+  });
+
+  test('git activation waits for the global package lock', () async {
+    ensureGit();
+    await d.git('foo.git', [
+      d.libPubspec('foo', '1.0.0'),
+      d.dir('bin', [d.file('foo.dart', "main() => print('ok');")]),
+    ]).create();
+
+    final pub = await _startPubWaitingForGlobalLock(
+      args: ['global', 'activate', '-sgit', '../foo.git'],
+    );
+    await pub.shouldExit();
+    await runPub(args: ['global', 'run', 'foo'], output: 'ok');
+  });
+
+  test('deactivation waits for the global package lock', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0');
+    await runPub(args: ['global', 'activate', 'foo']);
+
+    final activePackageDir = p.join(pathInCache('global_packages'), 'foo');
+    final pub = await _startPubWaitingForGlobalLock(
+      args: ['global', 'deactivate', 'foo'],
+      whileWaiting: () => expect(dirExists(activePackageDir), isTrue),
+    );
+    await pub.shouldExit();
+    expect(dirExists(activePackageDir), isFalse);
+  });
+
+  test(
+    'recompile and binstub refresh wait for the global package lock',
+    () async {
+      final server = await servePackages();
+      server.serve(
+        'foo',
+        '1.0.0',
+        pubspec: {
+          'executables': {'script': null},
+        },
+        contents: [
+          d.dir('bin', [d.file('script.dart', "main() => print('ok');")]),
+        ],
+      );
+      await runPub(args: ['global', 'activate', 'foo']);
+
+      await d.dir(cachePath, [
+        d.dir('global_packages', [
+          d.dir('foo', [
+            d.dir('bin', [
+              d.outOfDateSnapshot('script.dart-$versionSuffix.snapshot-1'),
+            ]),
+          ]),
+        ]),
+      ]).create();
+      final snapshotPath = p.join(
+        d.dir(cachePath).io.path,
+        'global_packages',
+        'foo',
+        'bin',
+        'script.dart-$versionSuffix.snapshot',
+      );
+      deleteEntry(snapshotPath);
+
+      final binStubPath = p.join(
+        d.dir(cachePath).io.path,
+        'bin',
+        binStubName('script'),
+      );
+      writeTextFile(binStubPath, '${readTextFile(binStubPath)}\nstale');
+
+      final pub = await _startPubWaitingForGlobalLock(
+        args: ['global', 'run', 'foo:script'],
+        whileWaiting:
+            () => expect(readTextFile(binStubPath), contains('stale')),
+      );
+      await pub.shouldExit();
+
+      expect(File(snapshotPath).existsSync(), isTrue);
+      expect(readTextFile(binStubPath), isNot(contains('stale')));
+    },
+  );
+
+  test('cache repair waits for the global package lock', () async {
+    final server = await servePackages();
+    server.serve('foo', '1.0.0');
+    await runPub(args: ['global', 'activate', 'foo']);
+
+    final activePackageDir = p.join(pathInCache('global_packages'), 'foo');
+    final pub = await _startPubWaitingForGlobalLock(
+      args: ['cache', 'repair', '--all'],
+      whileWaiting: () => expect(dirExists(activePackageDir), isTrue),
+    );
+    await pub.shouldExit();
+    expect(dirExists(activePackageDir), isTrue);
+  });
+
+  test('cache repair does not reacquire the lock for path packages', () async {
+    await d.dir('foo', [
+      d.pubspec({
+        'name': 'foo',
+        'executables': {'foo': null},
+      }),
+      d.dir('bin', [d.file('foo.dart', "main() => print('ok');")]),
+    ]).create();
+
+    await runPub(args: ['global', 'activate', '--source', 'path', '../foo']);
+    await runPub(
+      args: ['cache', 'repair', '--all'],
+      output: contains('Reactivated 1 package.'),
+    );
+
+    await d.dir(cachePath, [
+      d.dir('bin', [
+        d.file(binStubName('foo'), contains('global run foo:foo')),
+      ]),
+    ]).validate();
+  });
+}

--- a/test/global/binstubs/name_collision_test.dart
+++ b/test/global/binstubs/name_collision_test.dart
@@ -60,4 +60,27 @@ void main() {
       ]),
     ]).validate();
   });
+
+  test('overwrites a binstub owned by an inactive package', () async {
+    await d.dir('bar', [
+      d.pubspec({
+        'name': 'bar',
+        'executables': {'bar': 'bar'},
+      }),
+      d.dir('bin', [d.file('bar.dart', "main() => print('ok');")]),
+    ]).create();
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('bar'), '# Package: pub')]),
+    ]).create();
+
+    await runPub(
+      args: ['global', 'activate', '-spath', '../bar'],
+      output: contains('Installed executable bar.'),
+    );
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('bar'), contains('bar:bar'))]),
+    ]).validate();
+  });
 }

--- a/test/global/binstubs/name_collision_test.dart
+++ b/test/global/binstubs/name_collision_test.dart
@@ -5,10 +5,50 @@
 @TestOn('vm')
 library;
 
+import 'dart:io';
+
+import 'package:pub/src/path.dart';
 import 'package:test/test.dart';
 
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
+
+const _inactivePubBinStub = '''
+# This file was created by pub v0.1.2-3.
+# Package: pub
+# Version: 1.0.0
+# Executable: bar
+# Script: bar
+# Note: café
+''';
+
+const _foreignBinStub = '''
+#!/usr/bin/env sh
+echo before-marker
+# This file was created by pub v0.1.2-3.
+# Package: pub
+# Executable: bar
+# Script: bar
+echo not-pub
+''';
+
+const _malformedPubBinStub = '''
+# This file was created by pub v0.1.2-3.
+# Package: pub
+# Package: other
+# Version: 1.0.0
+# Executable: bar
+# Script: bar
+''';
+
+const _crossFamilyBinStub = '''
+#!/usr/bin/env sh
+rem This file was created by pub v0.1.2-3.
+rem Package: pub
+rem Version: 1.0.0
+rem Executable: bar
+rem Script: bar
+''';
 
 void main() {
   test('does not overwrite an existing binstub', () async {
@@ -71,12 +111,87 @@ void main() {
     ]).create();
 
     await d.dir(cachePath, [
-      d.dir('bin', [d.file(binStubName('bar'), '# Package: pub')]),
+      d.dir('bin', [d.file(binStubName('bar'), _inactivePubBinStub)]),
+    ]).create();
+    File(
+      p.join(d.sandbox, cachePath, 'bin', binStubName('bar')),
+    ).writeAsStringSync(_inactivePubBinStub, encoding: const SystemEncoding());
+
+    await runPub(
+      args: ['global', 'activate', '-spath', '../bar'],
+      output: contains('Installed executable bar.'),
+    );
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('bar'), contains('bar:bar'))]),
+    ]).validate();
+  });
+
+  test('preserves a foreign file containing binstub properties', () async {
+    await d.dir('bar', [
+      d.pubspec({
+        'name': 'bar',
+        'executables': {'bar': 'bar'},
+      }),
+      d.dir('bin', [d.file('bar.dart', "main() => print('ok');")]),
+    ]).create();
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('bar'), _crossFamilyBinStub)]),
+    ]).create();
+
+    await runPub(
+      args: ['global', 'activate', '-spath', '../bar'],
+      error: contains(
+        'Executable bar already exists and was not installed by pub.',
+      ),
+    );
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('bar'), _crossFamilyBinStub)]),
+    ]).validate();
+  });
+
+  test('overwrites a malformed pub binstub', () async {
+    await d.dir('bar', [
+      d.pubspec({
+        'name': 'bar',
+        'executables': {'bar': 'bar'},
+      }),
+      d.dir('bin', [d.file('bar.dart', "main() => print('ok');")]),
+    ]).create();
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('bar'), _malformedPubBinStub)]),
     ]).create();
 
     await runPub(
       args: ['global', 'activate', '-spath', '../bar'],
       output: contains('Installed executable bar.'),
+    );
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('bar'), contains('bar:bar'))]),
+    ]).validate();
+  });
+
+  test('overwrites a foreign file with --overwrite', () async {
+    await d.dir('bar', [
+      d.pubspec({
+        'name': 'bar',
+        'executables': {'bar': 'bar'},
+      }),
+      d.dir('bin', [d.file('bar.dart', "main() => print('ok');")]),
+    ]).create();
+
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('bar'), _foreignBinStub)]),
+    ]).create();
+
+    await runPub(
+      args: ['global', 'activate', '-spath', '../bar', '--overwrite'],
+      output: contains('Installed executable bar.'),
+      error: contains('Replaced bar, which was not installed by pub.'),
     );
 
     await d.dir(cachePath, [

--- a/test/global/binstubs/outdated_binstub_runs_pub_global_test.dart
+++ b/test/global/binstubs/outdated_binstub_runs_pub_global_test.dart
@@ -15,6 +15,14 @@ import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
 import 'utils.dart';
 
+const _foreignBinStub = '''
+#!/usr/bin/env sh
+# Package: foo
+# Executable: foo-script2
+# Script: script
+echo not-pub
+''';
+
 /// The contents of the binstub for [executable], or `null` if it doesn't exist.
 String? binStub(String executable) {
   final f = File(p.join(d.sandbox, cachePath, 'bin', binStubName(executable)));
@@ -88,6 +96,7 @@ void main() {
             d.dir('bin', [d.outOfDateSnapshot('script.dart-3.0.0.snapshot')]),
           ]),
         ]),
+        d.dir('bin', [d.file(binStubName('foo-script2'), _foreignBinStub)]),
       ]).create();
 
       final process = await TestProcess.start(
@@ -100,7 +109,7 @@ void main() {
 
       expect(binStub('foo-script'), contains('script.dart-3.1.2+3.snapshot'));
 
-      expect(binStub('foo-script2'), contains('script.dart-3.1.2+3.snapshot'));
+      expect(binStub('foo-script2'), _foreignBinStub);
 
       expect(
         binStub('foo-script-not-installed'),

--- a/test/global/binstubs/removes_when_deactivated_test.dart
+++ b/test/global/binstubs/removes_when_deactivated_test.dart
@@ -10,6 +10,14 @@ import 'package:test/test.dart';
 import '../../descriptor.dart' as d;
 import '../../test_pub.dart';
 
+const _foreignBinStub = '''
+#!/usr/bin/env sh
+# Package: foo
+# Executable: one
+# Script: one
+echo not-pub
+''';
+
 void main() {
   test('removes binstubs when the package is deactivated', () async {
     final server = await servePackages();
@@ -28,11 +36,14 @@ void main() {
     );
 
     await runPub(args: ['global', 'activate', 'foo']);
+    await d.dir(cachePath, [
+      d.dir('bin', [d.file(binStubName('one'), _foreignBinStub)]),
+    ]).create();
     await runPub(args: ['global', 'deactivate', 'foo']);
 
     await d.dir(cachePath, [
       d.dir('bin', [
-        d.nothing(binStubName('one')),
+        d.file(binStubName('one'), _foreignBinStub),
         d.nothing(binStubName('two')),
       ]),
     ]).validate();


### PR DESCRIPTION
Binstub maintenance currently identifies Pub ownership from loose `Package:`, `Executable:`, and `Script:` matches. A malformed or foreign file can therefore drive deletion, refresh, or repair, while decode errors can abort the operation.

This classifies each binstub from Pub's historical generated marker and one anchored metadata block before any mutation. Activation can reclaim orphaned or malformed Pub stubs, deletion and refresh only touch valid matching stubs, and repair removes malformed Pub stubs while preserving foreign or unreadable files. Repair's internal overwrite path cannot replace files without Pub provenance.

This completes the faulty-binstub handling tracked in #4235.

Depends on #4861 and should merge after it.
