### PR TITLE
Use workspace root when constructing Entrypoint in getExecutableForCommand and ensureUpToDate

### DIFF
--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -951,7 +951,9 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
               .values
               .every(
                 (dep) =>
-                    root.allOverridesInWorkspace.containsKey(dep.name) ||
+                    workspaceRoot.allOverridesInWorkspace.containsKey(
+                      dep.name,
+                    ) ||
                     isDependencyUpToDate(dep),
               )) {
             continue;
@@ -1084,7 +1086,6 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       // Check if language version specified in the `package_config.json` is
       // correct. This is important for path dependencies as these can mutate.
       for (final pkg in packageConfig.packages) {
-        if (pkg.name == root.name) continue;
         final workspacePkg = workspaceRoot.transitiveWorkspace.firstWhereOrNull(
           (p) => p.name == pkg.name,
         );

--- a/lib/src/entrypoint.dart
+++ b/lib/src/entrypoint.dart
@@ -813,6 +813,15 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
     }
   }
 
+  /// Returns the nearest enclosing directory of [dir] that contains a
+  /// `pubspec.yaml`, or [dir] if none is found.
+  static String _rootPackageDir(String dir) {
+    return parentDirs(dir).firstWhereOrNull(
+          (parent) => tryStatFile(p.join(parent, 'pubspec.yaml')) != null,
+        ) ??
+        dir;
+  }
+
   /// The [PackageConfig] object representing `.dart_tool/package_config.json`
   /// along with the dir where it resides, if it and `pubspec.lock` exist and
   /// are up to date with respect to pubspec.yaml and its dependencies. Or
@@ -859,11 +868,7 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
     String relativeIfNeeded(String path) =>
         wasRelative ? p.relative(path) : path;
 
-    late final rootPackageDir =
-        parentDirs(dir).firstWhereOrNull(
-          (parent) => tryStatFile(p.join(parent, 'pubspec.yaml')) != null,
-        ) ??
-        dir;
+    late final rootPackageDir = _rootPackageDir(dir);
     late final root = Package.load(
       rootPackageDir,
       loadPubspec: Pubspec.loadRootWithSources(cache.sources),
@@ -917,14 +922,20 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
         }
       }
 
-      if (!root.immediateDependencies.values.every(isDependencyUpToDate)) {
-        final pubspecPath = p.normalize(p.join(dir, 'pubspec.yaml'));
+      for (final workspacePackage in workspaceRoot.transitiveWorkspace) {
+        if (!workspacePackage.immediateDependencies.values.every(
+          isDependencyUpToDate,
+        )) {
+          final pubspecPath = p.normalize(
+            p.join(workspacePackage.dir, 'pubspec.yaml'),
+          );
 
-        log.fine(
-          'The $pubspecPath file has changed since the $lockFilePath file '
-          'was generated.',
-        );
-        return false;
+          log.fine(
+            'The $pubspecPath file has changed since the $lockFilePath file '
+            'was generated.',
+          );
+          return false;
+        }
       }
 
       // Check that uncached dependencies' pubspecs are also still satisfied,
@@ -993,6 +1004,14 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
             });
         if (hasExtraMappings) {
           return false;
+        }
+
+        // Check that all packages in the workspace are reflected in the
+        // [packagePathsMapping].
+        for (final workspacePackage in workspaceRoot.transitiveWorkspace) {
+          if (!packagePathsMapping.containsKey(workspacePackage.name)) {
+            return false;
+          }
         }
 
         // Check that all packages in the [lockFile] are reflected in the
@@ -1412,8 +1431,9 @@ To update `$lockFilePath` run `$topLevelProgram pub get`$suffix without
       log.fine('Package Config up to date.');
       return (packageConfig: packageConfig, rootDir: rootDir);
     }
+    final rootPackageDir = _rootPackageDir(dir);
     final entrypoint = Entrypoint(
-      dir,
+      rootPackageDir,
       cache,
       // [ensureUpToDate] is also used for entries in 'global_packages/'
       checkInCache: false,

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -412,7 +412,7 @@ Future<DartExecutableWithPackageConfig> getExecutableForCommand(
     // PackageGraph, as it requires loading and reading all the pubspec.yaml
     // files.
     final entrypoint = Entrypoint(
-      rootOrCurrent,
+      workspaceRootDir,
       SystemCache(rootDir: pubCacheDir),
     );
 

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -388,12 +388,7 @@ Future<DartExecutableWithPackageConfig> getExecutableForCommand(
   }
   final executable = Executable(package, p.join('bin', '$command.dart'));
   final packageConfigPath = p.normalize(
-    p.join(
-      rootOrCurrent,
-      workspaceRootDir,
-      '.dart_tool',
-      'package_config.json',
-    ),
+    p.join(workspaceRootDir, '.dart_tool', 'package_config.json'),
   );
   final path = executable.resolve(packageConfig, packageConfigPath);
   if (!fileExists(p.join(rootOrCurrent, path))) {

--- a/test/embedding/get_executable_for_command.dart
+++ b/test/embedding/get_executable_for_command.dart
@@ -533,5 +533,105 @@ void testGetExecutableForCommand() {
         resolution: ResolutionAttempt.fastPath,
       );
     });
+
+    test('Works from subdirectory when resolution is out of date', () async {
+      final server = await servePackages();
+      server.serve(
+        'foo',
+        '1.0.0',
+        contents: [
+          d.dir('bin', [d.file('foo.dart', 'main() => print("foo");')]),
+        ],
+      );
+
+      await d.dir(appPath, [
+        d.appPubspec(dependencies: {'foo': '^1.0.0'}),
+        d.dir('lib', [d.file('lib.dart', '')]),
+      ]).create();
+
+      // Run from lib/ directory when lockfile does not exist.
+      await testGetExecutable(
+        'foo',
+        p.join(d.sandbox, appPath, 'lib'),
+        executable: p.join(
+          '..',
+          '.dart_tool',
+          'pub',
+          'bin',
+          'foo',
+          'foo.dart-3.5.0.snapshot',
+        ),
+        packageConfig: p.join('..', '.dart_tool', 'package_config.json'),
+        environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+        resolution: ResolutionAttempt.resolution,
+      );
+    });
+
+    test(
+      'Invalidates resolution when new package added to workspace',
+      () async {
+        await servePackages();
+        await d.dir(appPath, [
+          d.libPubspec(
+            'myapp',
+            '1.0.0',
+            sdk: '^3.5.0',
+            extras: {
+              'workspace': ['sub'],
+            },
+          ),
+          d.dir('sub', [
+            d.libPubspec(
+              'sub',
+              '1.0.0',
+              sdk: '^3.5.0',
+              resolutionWorkspace: true,
+            ),
+            d.dir('bin', [d.file('tool.dart', 'main() => print("sub");')]),
+          ]),
+        ]).create();
+
+        await testGetExecutable(
+          'sub:tool',
+          p.join(d.sandbox, appPath),
+          allowSnapshot: false,
+          executable: p.join(d.sandbox, appPath, 'sub', 'bin', 'tool.dart'),
+          packageConfig: p.join('.dart_tool', 'package_config.json'),
+          environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+          resolution: ResolutionAttempt.resolution,
+        );
+
+        // Now add a second workspace package pkg_b to workspace.
+        await d.dir(appPath, [
+          d.libPubspec(
+            'myapp',
+            '1.0.0',
+            sdk: '^3.5.0',
+            extras: {
+              'workspace': ['sub', 'pkg_b'],
+            },
+          ),
+          d.dir('pkg_b', [
+            d.libPubspec(
+              'pkg_b',
+              '1.0.0',
+              sdk: '^3.5.0',
+              resolutionWorkspace: true,
+            ),
+            d.dir('bin', [d.file('tool.dart', 'main() => print("pkg_b");')]),
+          ]),
+        ]).create();
+
+        await testGetExecutable(
+          'pkg_b:tool',
+          p.join(d.sandbox, appPath),
+          allowSnapshot: false,
+          executable: p.join(d.sandbox, appPath, 'pkg_b', 'bin', 'tool.dart'),
+          packageConfig: p.join('.dart_tool', 'package_config.json'),
+          environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+          resolution: ResolutionAttempt.resolution,
+        );
+      },
+    );
   });
 }

--- a/test/embedding/get_executable_for_command.dart
+++ b/test/embedding/get_executable_for_command.dart
@@ -633,5 +633,156 @@ void testGetExecutableForCommand() {
         );
       },
     );
+
+    test(
+      'Invalidates resolution when workspace member dependency is modified',
+      () async {
+        final server = await servePackages();
+        server.serve('foo', '1.0.0');
+
+        await d.dir(appPath, [
+          d.libPubspec(
+            'myapp',
+            '1.0.0',
+            sdk: '^3.5.0',
+            extras: {
+              'workspace': ['sub'],
+            },
+          ),
+          d.dir('sub', [
+            d.libPubspec(
+              'sub',
+              '1.0.0',
+              sdk: '^3.5.0',
+              resolutionWorkspace: true,
+            ),
+            d.dir('bin', [d.file('tool.dart', 'main() => print("sub");')]),
+          ]),
+        ]).create();
+
+        await testGetExecutable(
+          'sub:tool',
+          p.join(d.sandbox, appPath),
+          allowSnapshot: false,
+          executable: p.join(d.sandbox, appPath, 'sub', 'bin', 'tool.dart'),
+          packageConfig: p.join('.dart_tool', 'package_config.json'),
+          environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+          resolution: ResolutionAttempt.resolution,
+        );
+
+        // Subsequent call uses fastPath.
+        await testGetExecutable(
+          'sub:tool',
+          p.join(d.sandbox, appPath),
+          allowSnapshot: false,
+          executable: p.join(d.sandbox, appPath, 'sub', 'bin', 'tool.dart'),
+          packageConfig: p.join('.dart_tool', 'package_config.json'),
+          environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+          resolution: ResolutionAttempt.fastPath,
+        );
+
+        // Add dependency to member 'sub' without modifying root pubspec.yaml.
+        await d.dir(appPath, [
+          d.dir('sub', [
+            d.libPubspec(
+              'sub',
+              '1.0.0',
+              sdk: '^3.5.0',
+              deps: {'foo': '^1.0.0'},
+              resolutionWorkspace: true,
+            ),
+          ]),
+        ]).create();
+
+        // Resolution should be invalidated because member pubspec changed.
+        await testGetExecutable(
+          'sub:tool',
+          p.join(d.sandbox, appPath),
+          allowSnapshot: false,
+          executable: p.join(d.sandbox, appPath, 'sub', 'bin', 'tool.dart'),
+          packageConfig: p.join('.dart_tool', 'package_config.json'),
+          environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+          resolution: ResolutionAttempt.resolution,
+        );
+      },
+    );
+
+    test('Works from subdirectory of workspace member when resolution is out '
+        'of date', () async {
+      final server = await servePackages();
+      server.serve(
+        'foo',
+        '1.0.0',
+        contents: [
+          d.dir('bin', [d.file('foo.dart', 'main() => print("foo");')]),
+        ],
+      );
+
+      await d.dir(appPath, [
+        d.libPubspec(
+          'myapp',
+          '1.0.0',
+          sdk: '^3.5.0',
+          extras: {
+            'workspace': ['pkgs/a'],
+          },
+        ),
+        d.dir('pkgs', [
+          d.dir('a', [
+            d.libPubspec(
+              'a',
+              '1.0.0',
+              sdk: '^3.5.0',
+              deps: {'foo': '^1.0.0'},
+              resolutionWorkspace: true,
+            ),
+            d.dir('bin', [d.file('tool.dart', 'main() => print("a");')]),
+            d.dir('lib', [d.file('a.dart', '')]),
+          ]),
+        ]),
+      ]).create();
+
+      // Run from pkgs/a/lib directory when lockfile does not exist.
+      await testGetExecutable(
+        'foo',
+        p.join(d.sandbox, appPath, 'pkgs', 'a', 'lib'),
+        executable: p.join(
+          '..',
+          '..',
+          '..',
+          '.dart_tool',
+          'pub',
+          'bin',
+          'foo',
+          'foo.dart-3.5.0.snapshot',
+        ),
+        packageConfig: p.join(
+          '..',
+          '..',
+          '..',
+          '.dart_tool',
+          'package_config.json',
+        ),
+        environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+        resolution: ResolutionAttempt.resolution,
+      );
+
+      // Also test invoking the member's own tool with :tool from pkgs/a/lib.
+      await testGetExecutable(
+        ':tool',
+        p.join(d.sandbox, appPath, 'pkgs', 'a', 'lib'),
+        allowSnapshot: false,
+        executable: p.join(d.sandbox, appPath, 'pkgs', 'a', 'bin', 'tool.dart'),
+        packageConfig: p.join(
+          '..',
+          '..',
+          '..',
+          '.dart_tool',
+          'package_config.json',
+        ),
+        environment: {'_PUB_TEST_SDK_VERSION': '3.5.0'},
+        resolution: ResolutionAttempt.fastPath,
+      );
+    });
   });
 }


### PR DESCRIPTION
Fixes sub-directory executable resolution and workspace member invalidation when resolution is out of date.

1) Sub-directory executable resolution:
In commit a87b84dc0 (#4257, Dart 3.5.0), `getExecutableForCommand` was updated to allow running commands from package subdirectories (`cd lib && dart run ...`). However, when invoked from a sub-directory without a `pubspec.yaml` while resolution was out of date or snapshot compilation was required, `Entrypoint` was constructed with `workingDir` pointing to the sub-directory. This caused relative path resolution against `.dart_tool/package_config.json` to be computed relative to the sub-directory, failing with `Could not find a file named "pubspec.yaml" in ".../lib"`.
* Resolves the target package directory using a shared `_rootPackageDir` helper in both `isResolutionUpToDate` and `Entrypoint.ensureUpToDate`.
* Uses `workspaceRootDir` when constructing `Entrypoint` in `getExecutableForCommand`.

2) Workspace resolution invalidation:
When new packages were added to a workspace without running `pub get`:
* `isLockFileUpToDate` only checked `root.immediateDependencies`, missing the immediate dependencies of other workspace packages (`workspaceRoot.transitiveWorkspace`).
* `isPackagePathsMappingUpToDateWithLockfile` only verified that no extra mappings existed, missing when workspace packages were missing from `.dart_tool/package_config.json`.
* This update checks immediate dependencies across all packages in `workspaceRoot.transitiveWorkspace` in `isLockFileUpToDate`, and ensures all packages in `workspaceRoot.transitiveWorkspace` exist in `packagePathsMapping`.

Fixes https://github.com/dart-lang/sdk/issues/61950