### PR TITLE
Short-circuit package version selection when candidate has 0 or 1 matching versions

### DIFF
--- a/lib/src/solver/version_solver.dart
+++ b/lib/src/solver/version_solver.dart
@@ -392,11 +392,24 @@ class VersionSolver {
       return candidate.name;
     }
 
-    /// Prefer packages with as few remaining versions as possible, so that if a
-    /// conflict is necessary it's forced quickly.
-    final package = await minByAsync(unsatisfied, (PackageRange package) async {
-      return await _packageLister(package).countVersions(package.constraint);
-    });
+    // Prefer packages with as few remaining versions as possible, so that if a
+    // conflict is necessary it's forced quickly.
+    PackageRange? bestPackage;
+    var bestCount = 1000000000;
+    for (final candidate in unsatisfied) {
+      final count = await _packageLister(
+        candidate,
+      ).countVersions(candidate.constraint);
+      if (count < bestCount) {
+        bestCount = count;
+        bestPackage = candidate;
+        // If a package has 0 matching versions, a conflict is inevitable and
+        // this is the minimum possible count. Break early to force the conflict
+        // immediately without checking remaining candidates.
+        if (count == 0) break;
+      }
+    }
+    final package = bestPackage;
     if (package == null) {
       return null; // when unsatisfied.isEmpty
     }


### PR DESCRIPTION
In `_choosePackageVersion`, the version solver selects the unsatisfied package with the fewest remaining matching versions. Previously, `minByAsync` evaluated the version count for all unsatisfied packages on every decision step.

A package with `0` matching versions will immediately force a conflict, and a package with `1` matching version has only a single forced choice. In both cases (`count <= 1`), there is no benefit in checking remaining unsatisfied candidates. Short-circuiting the loop as soon as a candidate has `count <= 1` avoids redundant version count evaluations.
