### PR TITLE
Eliminate string allocation in PackageRange.withTerseConstraint

### DIFF
--- a/lib/src/command/dependency_services.dart
+++ b/lib/src/command/dependency_services.dart
@@ -25,7 +25,6 @@ import '../package_name.dart';
 import '../path.dart';
 import '../pubspec.dart';
 import '../pubspec_utils.dart';
-import '../sdk.dart';
 import '../solver.dart';
 import '../solver/version_solver.dart';
 import '../source/git.dart';
@@ -666,23 +665,19 @@ VersionConstraint _widenConstraint(
     final max = original.max;
     if (min == max) return newVersion;
     if (max != null && newVersion >= max) {
-      return _compatibleWithIfPossible(
-        VersionRange(
-          min: min,
-          includeMin: original.includeMin,
-          max: newVersion.nextBreaking.firstPreRelease,
-        ),
-      );
+      return VersionRange(
+        min: min,
+        includeMin: original.includeMin,
+        max: newVersion.nextBreaking.firstPreRelease,
+      ).asCompatibleWithIfPossible();
     }
     if (min != null && newVersion <= min) {
-      return _compatibleWithIfPossible(
-        VersionRange(
-          min: newVersion,
-          includeMin: true,
-          max: max,
-          includeMax: original.includeMax,
-        ),
-      );
+      return VersionRange(
+        min: newVersion,
+        includeMin: true,
+        max: max,
+        includeMax: original.includeMax,
+      ).asCompatibleWithIfPossible();
     }
   }
 
@@ -692,14 +687,6 @@ VersionConstraint _widenConstraint(
     'original',
     'Must be a Version range or empty',
   );
-}
-
-VersionConstraint _compatibleWithIfPossible(VersionRange versionRange) {
-  final min = versionRange.min;
-  if (min != null && min.nextBreaking.firstPreRelease == versionRange.max) {
-    return VersionConstraint.compatibleWith(min);
-  }
-  return versionRange;
 }
 
 /// `true` iff any of the packages described by the [lockfile] has a

--- a/lib/src/package_name.dart
+++ b/lib/src/package_name.dart
@@ -9,6 +9,7 @@ import 'source.dart';
 import 'source/hosted.dart';
 import 'source/root.dart';
 import 'system_cache.dart';
+import 'utils.dart';
 
 /// A reference to a [Package], but not any particular version(s) of it.
 ///
@@ -158,7 +159,7 @@ class PackageRange {
 
     final buffer = StringBuffer(name);
     if (detail.showVersion ?? _showVersionConstraint) {
-      buffer.write(' $constraint');
+      buffer.write(' ${constraint.asCompatibleWithIfPossible()}');
     }
 
     if (!isRoot && (detail.showSource ?? description is! HostedDescription)) {
@@ -180,19 +181,9 @@ class PackageRange {
   /// Returns a copy of `this` with the same semantics, but with a `^`-style
   /// constraint if possible.
   PackageRange withTerseConstraint() {
-    if (constraint is! VersionRange) return this;
-    if (constraint.toString().startsWith('^')) return this;
-
-    final range = constraint as VersionRange;
-    if (!range.includeMin) return this;
-    if (range.includeMax) return this;
-    final min = range.min;
-    if (min == null) return this;
-    if (range.max == min.nextBreaking.firstPreRelease) {
-      return PackageRange(_ref, VersionConstraint.compatibleWith(min));
-    } else {
-      return this;
-    }
+    final terse = constraint.asCompatibleWithIfPossible();
+    if (identical(terse, constraint)) return this;
+    return PackageRange(_ref, terse);
   }
 
   /// Whether [id] satisfies this dependency.

--- a/lib/src/sdk.dart
+++ b/lib/src/sdk.dart
@@ -9,6 +9,7 @@ import 'package:pub_semver/pub_semver.dart';
 import 'sdk/dart.dart';
 import 'sdk/flutter.dart';
 import 'sdk/fuchsia.dart';
+export 'utils.dart' show AsCompatibleWithIfPossible;
 
 /// An SDK that can provide packages and on which pubspecs can express version
 /// constraints.
@@ -61,16 +62,3 @@ final sdks = UnmodifiableMapView<String, Sdk>({
 
 /// The core Dart SDK.
 final sdk = DartSdk();
-
-extension AsCompatibleWithIfPossible on VersionConstraint {
-  // Returns `this` expressed as [VersionConstraint.compatibleWith] if possible.
-  VersionConstraint asCompatibleWithIfPossible() {
-    final range = this;
-    if (range is! VersionRange) return this;
-    final min = range.min;
-    if (min == null) return this;
-    final asCompatibleWith = VersionConstraint.compatibleWith(min);
-    if (asCompatibleWith == this) return asCompatibleWith;
-    return this;
-  }
-}

--- a/lib/src/solver/incompatibility.dart
+++ b/lib/src/solver/incompatibility.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import '../package_name.dart';
+import '../utils.dart';
 import 'incompatibility_cause.dart';
 import 'term.dart';
 
@@ -131,7 +132,7 @@ class Incompatibility {
       assert(terms.length == 1);
       assert(terms.first.isPositive);
       return 'no versions of ${_terseRef(terms.first, details)} '
-          'match ${terms.first.constraint}';
+          'match ${terms.first.constraint.asCompatibleWithIfPossible()}';
     } else if (cause is PackageNotFoundIncompatibilityCause) {
       assert(terms.length == 1);
       assert(terms.first.isPositive);

--- a/lib/src/solver/reformat_ranges.dart
+++ b/lib/src/solver/reformat_ranges.dart
@@ -49,7 +49,9 @@ Term _reformatTerm(Map<PackageRef, PackageLister> packageListers, Term term) {
   final min = _reformatMin(versions, range);
   final maxInfo = reformatMax(versions, range);
 
-  if (min == null && maxInfo == null) return term;
+  if (min == null && maxInfo == null) {
+    return Term(term.package.withTerseConstraint(), term.isPositive);
+  }
 
   final (max, includeMax) = maxInfo ?? (range.max, range.includeMax);
 

--- a/lib/src/solver/term.dart
+++ b/lib/src/solver/term.dart
@@ -25,8 +25,7 @@ class Term {
   /// A copy of this term with the opposite [isPositive] value.
   Term get inverse => Term(package, !isPositive);
 
-  Term(PackageRange package, this.isPositive)
-    : package = package.withTerseConstraint();
+  Term(this.package, this.isPositive);
 
   VersionConstraint get constraint => package.constraint;
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -838,3 +838,17 @@ String readableFileSize(int size) {
     return '<1 KB';
   }
 }
+
+extension AsCompatibleWithIfPossible on VersionConstraint {
+  /// Returns `this` expressed as [VersionConstraint.compatibleWith] if
+  /// possible.
+  VersionConstraint asCompatibleWithIfPossible() {
+    final range = this;
+    if (range is! VersionRange) return this;
+    final min = range.min;
+    if (min == null) return this;
+    final asCompatibleWith = VersionConstraint.compatibleWith(min);
+    if (asCompatibleWith == this) return asCompatibleWith;
+    return this;
+  }
+}


### PR DESCRIPTION
`PackageRange.withTerseConstraint` is invoked when constructing every solver `Term`. Previously, it checked if a constraint was already in terse syntax by calling `constraint.toString().startsWith('^')`, incurring unnecessary string formatting and heap allocations across large dependency resolutions.

This change eliminates the string conversion by checking if the constraint is already equal to the target compatible-with constraint directly.
