### PR TITLE
Verify package attestation and enforce provenance policies

### DIFF
--- a/lib/src/sigstore/asn1.dart
+++ b/lib/src/sigstore/asn1.dart
@@ -1,0 +1,144 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'models.dart';
+
+/// Lightweight ASN.1 parser for X.509 certificates and Sigstore extensions.
+class Asn1Reader {
+  final Uint8List bytes;
+  int offset = 0;
+
+  Asn1Reader(this.bytes, [this.offset = 0]);
+
+  bool get hasNext => offset < bytes.length;
+
+  int readTag() {
+    if (offset >= bytes.length) return -1;
+    return bytes[offset++];
+  }
+
+  int readLength() {
+    final first = bytes[offset++];
+    if ((first & 0x80) == 0) {
+      return first;
+    }
+    final numOctets = first & 0x7F;
+    var length = 0;
+    for (var i = 0; i < numOctets; i++) {
+      length = (length << 8) | bytes[offset++];
+    }
+    return length;
+  }
+
+  Uint8List readBytes(int length) {
+    final slice = bytes.sublist(offset, offset + length);
+    offset += length;
+    return slice;
+  }
+
+  /// Parses Sigstore OID extensions from X.509 certificate DER bytes.
+  static FulcioCertificateInfo parseFulcioCertificate(Uint8List derBytes) {
+    String? issuer;
+    String? repoUri;
+    String? repoRef;
+    String? workflowPath;
+    String? jobWorkflowSha;
+    String? runnerEnvironment;
+    String? sanUri;
+
+    // OID 1.3.6.1.4.1.57264.1.x: 2B 06 01 04 01 83 BF 30 01 <x>
+    final sigstorePrefix = [
+      0x2B,
+      0x06,
+      0x01,
+      0x04,
+      0x01,
+      0x83,
+      0xBF,
+      0x30,
+      0x01,
+    ];
+
+    for (var i = 0; i < derBytes.length - sigstorePrefix.length - 2; i++) {
+      var match = true;
+      for (var j = 0; j < sigstorePrefix.length; j++) {
+        if (derBytes[i + j] != sigstorePrefix[j]) {
+          match = false;
+          break;
+        }
+      }
+      if (match) {
+        final subOid = derBytes[i + sigstorePrefix.length];
+        final value = _extractNearbyUtf8String(
+          derBytes,
+          i + sigstorePrefix.length + 1,
+        );
+        if (value != null) {
+          switch (subOid) {
+            case 0x01: // Issuer
+              issuer ??= value;
+              break;
+            case 0x05: // Source Repository URI
+              repoUri ??= value;
+              break;
+            case 0x06: // Source Repository Ref
+              repoRef ??= value;
+              break;
+            case 0x0A: // Runner Environment
+              runnerEnvironment ??= value;
+              break;
+            case 0x12: // Workflow Path
+              workflowPath ??= value;
+              break;
+            case 0x13: // Job Workflow SHA
+              jobWorkflowSha ??= value;
+              break;
+          }
+        }
+      }
+    }
+
+    // Search for SAN URI (e.g. https://github.com/...)
+    final sanMatch = RegExp(
+      r'https://github\.com/[^\x00-\x1F\x7F-\xFF]+',
+    ).firstMatch(utf8.decode(derBytes, allowMalformed: true));
+    if (sanMatch != null) {
+      sanUri = sanMatch.group(0);
+    }
+
+    return FulcioCertificateInfo(
+      issuer: issuer,
+      sourceRepositoryUri: repoUri,
+      sourceRepositoryRef: repoRef,
+      workflowPath: workflowPath,
+      jobWorkflowSha: jobWorkflowSha,
+      runnerEnvironment: runnerEnvironment,
+      sanUri: sanUri,
+    );
+  }
+
+  static String? _extractNearbyUtf8String(Uint8List bytes, int startIndex) {
+    final searchLimit = (startIndex + 20).clamp(0, bytes.length);
+    for (var idx = startIndex; idx < searchLimit; idx++) {
+      final tag = bytes[idx];
+      // UTF8String (0x0C), PrintableString (0x13), IA5String (0x16),
+      // or OctetString (0x04).
+      if (tag == 0x0C || tag == 0x13 || tag == 0x16 || tag == 0x04) {
+        if (idx + 1 >= bytes.length) continue;
+        final len = bytes[idx + 1];
+        if (idx + 2 + len <= bytes.length && len > 0) {
+          final strBytes = bytes.sublist(idx + 2, idx + 2 + len);
+          final text = utf8.decode(strBytes, allowMalformed: true);
+          if (text.isNotEmpty && !text.contains('\x00')) {
+            return text;
+          }
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/lib/src/sigstore/lockfile_policy.dart
+++ b/lib/src/sigstore/lockfile_policy.dart
@@ -1,0 +1,73 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub_semver/pub_semver.dart';
+
+import '../exceptions.dart';
+import '../log.dart' as log;
+import 'models.dart';
+
+/// Enforces security policies between the current package and previous locks.
+class ProvenancePolicy {
+  /// Enforces downgrade prevention and repository continuity.
+  ///
+  /// 1. Downgrade attack prevention: If [packageName] was previously locked
+  ///    with signed provenance ([previousLockedProvenance] != null),
+  ///    subsequent versions must also have valid signed provenance
+  ///    ([currentProvenance] != null).
+  ///
+  /// 2. Repository switch alert: If the repository changes from
+  ///    [previousLockedProvenance], a security warning or error is issued.
+  static void enforcePolicy({
+    required String packageName,
+    required Version version,
+    required ProvenanceInfo? currentProvenance,
+    required ProvenanceInfo? previousLockedProvenance,
+    bool fatalOnRepoMismatch = false,
+  }) {
+    if (previousLockedProvenance != null && currentProvenance == null) {
+      throw PackageIntegrityException('''
+Package "$packageName" version $version is not signed with provenance.
+However, previously locked versions of this package were signed by:
+  ${previousLockedProvenance.repository}
+
+Downgrading from a signed package to an unsigned package is prohibited.
+''');
+    }
+
+    if (previousLockedProvenance != null && currentProvenance != null) {
+      if (!_repositoriesMatch(
+        previousLockedProvenance.repository,
+        currentProvenance.repository,
+      )) {
+        final message =
+            'Package "$packageName" provenance repository changed from '
+            '"${previousLockedProvenance.repository}" to '
+            '"${currentProvenance.repository}".';
+        if (fatalOnRepoMismatch) {
+          throw PackageIntegrityException(
+            '$message\n'
+            'Repository changes for signed packages require verification.',
+          );
+        } else {
+          log.warning(message);
+        }
+      }
+    }
+  }
+
+  static bool _repositoriesMatch(String a, String b) {
+    final normA = a
+        .trim()
+        .toLowerCase()
+        .replaceAll(RegExp(r'\.git$'), '')
+        .replaceAll(RegExp(r'/+$'), '');
+    final normB = b
+        .trim()
+        .toLowerCase()
+        .replaceAll(RegExp(r'\.git$'), '')
+        .replaceAll(RegExp(r'/+$'), '');
+    return normA == normB || normA.endsWith(normB) || normB.endsWith(normA);
+  }
+}

--- a/lib/src/sigstore/models.dart
+++ b/lib/src/sigstore/models.dart
@@ -1,0 +1,393 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:pub_semver/pub_semver.dart';
+
+import '../exceptions.dart';
+
+/// Parsed Sigstore bundle.
+class SigstoreBundle {
+  final String mediaType;
+  final VerificationMaterial verificationMaterial;
+  final DsseEnvelope dsseEnvelope;
+
+  SigstoreBundle({
+    required this.mediaType,
+    required this.verificationMaterial,
+    required this.dsseEnvelope,
+  });
+
+  factory SigstoreBundle.fromJson(Map<String, dynamic> json) {
+    final mediaType = json['mediaType'] as String? ?? '';
+    final vMaterial = json['verificationMaterial'] as Map<String, dynamic>?;
+    final dsse = json['dsseEnvelope'] as Map<String, dynamic>?;
+
+    if (vMaterial == null || dsse == null) {
+      throw DataException(
+        'Invalid Sigstore bundle format: '
+        'missing verificationMaterial or dsseEnvelope.',
+      );
+    }
+
+    return SigstoreBundle(
+      mediaType: mediaType,
+      verificationMaterial: VerificationMaterial.fromJson(vMaterial),
+      dsseEnvelope: DsseEnvelope.fromJson(dsse),
+    );
+  }
+}
+
+/// Verification material containing the certificate and transparency logs.
+class VerificationMaterial {
+  final Uint8List? certificateDer;
+  final String? certificatePem;
+  final List<TlogEntry> tlogEntries;
+
+  VerificationMaterial({
+    this.certificateDer,
+    this.certificatePem,
+    required this.tlogEntries,
+  });
+
+  factory VerificationMaterial.fromJson(Map<String, dynamic> json) {
+    Uint8List? certDer;
+    String? certPem;
+
+    if (json['certificate'] case final Map<String, dynamic> certMap) {
+      if (certMap['rawBytes'] case final String rawBytesBase64) {
+        certDer = base64Decode(rawBytesBase64);
+      }
+    } else if (json['x509CertificateChain']
+        case final Map<String, dynamic> chainMap) {
+      if (chainMap['certificates'] case final List<dynamic> certList) {
+        if (certList.isNotEmpty && certList.first is Map) {
+          final first = certList.first as Map<String, dynamic>;
+          if (first['rawBytes'] case final String rawBytes) {
+            certDer = base64Decode(rawBytes);
+          }
+        }
+      }
+    }
+
+    final tlogList = json['tlogEntries'] as List<dynamic>? ?? [];
+    final tlogs =
+        tlogList
+            .map((e) => TlogEntry.fromJson(e as Map<String, dynamic>))
+            .toList();
+
+    return VerificationMaterial(
+      certificateDer: certDer,
+      certificatePem: certPem,
+      tlogEntries: tlogs,
+    );
+  }
+}
+
+/// A Rekor transparency log entry.
+class TlogEntry {
+  final String logIndex;
+  final String? rootHash;
+  final List<String> inclusionHashes;
+  final String? canonicalizedBody;
+
+  TlogEntry({
+    required this.logIndex,
+    this.rootHash,
+    required this.inclusionHashes,
+    this.canonicalizedBody,
+  });
+
+  factory TlogEntry.fromJson(Map<String, dynamic> json) {
+    final logIndex = json['logIndex']?.toString() ?? '';
+    final inclusionProof = json['inclusionProof'] as Map<String, dynamic>?;
+    final rootHash = inclusionProof?['rootHash'] as String?;
+    final hashesList = inclusionProof?['hashes'] as List<dynamic>? ?? [];
+    final hashes = hashesList.map((e) => e.toString()).toList();
+    final canonicalizedBody = json['canonicalizedBody'] as String?;
+
+    return TlogEntry(
+      logIndex: logIndex,
+      rootHash: rootHash,
+      inclusionHashes: hashes,
+      canonicalizedBody: canonicalizedBody,
+    );
+  }
+}
+
+/// DSSE envelope containing the signed in-toto statement payload and
+/// signatures.
+class DsseEnvelope {
+  final String payloadType;
+  final String payloadBase64;
+  final Uint8List payloadBytes;
+  final List<DsseSignature> signatures;
+  final InTotoStatement statement;
+
+  DsseEnvelope({
+    required this.payloadType,
+    required this.payloadBase64,
+    required this.payloadBytes,
+    required this.signatures,
+    required this.statement,
+  });
+
+  factory DsseEnvelope.fromJson(Map<String, dynamic> json) {
+    final payloadType = json['payloadType'] as String? ?? '';
+    final payloadBase64 = json['payload'] as String? ?? '';
+    final payloadBytes = base64Decode(payloadBase64);
+    final payloadJson =
+        jsonDecode(utf8.decode(payloadBytes)) as Map<String, dynamic>;
+    final statement = InTotoStatement.fromJson(payloadJson);
+
+    final sigsList = json['signatures'] as List<dynamic>? ?? [];
+    final signatures =
+        sigsList
+            .map((e) => DsseSignature.fromJson(e as Map<String, dynamic>))
+            .toList();
+
+    return DsseEnvelope(
+      payloadType: payloadType,
+      payloadBase64: payloadBase64,
+      payloadBytes: payloadBytes,
+      signatures: signatures,
+      statement: statement,
+    );
+  }
+}
+
+/// A signature inside a DSSE envelope.
+class DsseSignature {
+  final String? keyid;
+  final String sigBase64;
+  final Uint8List sigBytes;
+
+  DsseSignature({this.keyid, required this.sigBase64, required this.sigBytes});
+
+  factory DsseSignature.fromJson(Map<String, dynamic> json) {
+    final sigBase64 = json['sig'] as String? ?? '';
+    return DsseSignature(
+      keyid: json['keyid'] as String?,
+      sigBase64: sigBase64,
+      sigBytes: base64Decode(sigBase64),
+    );
+  }
+}
+
+/// Parsed in-toto statement payload.
+class InTotoStatement {
+  final String type;
+  final String predicateType;
+  final List<InTotoSubject> subjects;
+  final Map<String, dynamic> predicate;
+  final SlsaBuildDefinition? buildDefinition;
+  final String? builderId;
+
+  InTotoStatement({
+    required this.type,
+    required this.predicateType,
+    required this.subjects,
+    required this.predicate,
+    this.buildDefinition,
+    this.builderId,
+  });
+
+  factory InTotoStatement.fromJson(Map<String, dynamic> json) {
+    final type = json['_type'] as String? ?? '';
+    final predicateType = json['predicateType'] as String? ?? '';
+    final subjectsList = json['subject'] as List<dynamic>? ?? [];
+    final subjects =
+        subjectsList
+            .map((e) => InTotoSubject.fromJson(e as Map<String, dynamic>))
+            .toList();
+    final predicate = json['predicate'] as Map<String, dynamic>? ?? {};
+
+    SlsaBuildDefinition? buildDef;
+    String? builderId;
+
+    if (predicate['buildDefinition'] case final Map<String, dynamic> bdMap) {
+      buildDef = SlsaBuildDefinition.fromJson(bdMap);
+    }
+    if (predicate['runDetails'] case final Map<String, dynamic> rdMap) {
+      if (rdMap['builder'] case final Map<String, dynamic> bMap) {
+        builderId = bMap['id'] as String?;
+      }
+    }
+
+    return InTotoStatement(
+      type: type,
+      predicateType: predicateType,
+      subjects: subjects,
+      predicate: predicate,
+      buildDefinition: buildDef,
+      builderId: builderId,
+    );
+  }
+}
+
+/// An artifact subject inside an in-toto statement.
+class InTotoSubject {
+  final String name;
+  final String sha256;
+
+  InTotoSubject({required this.name, required this.sha256});
+
+  factory InTotoSubject.fromJson(Map<String, dynamic> json) {
+    final name = json['name'] as String? ?? '';
+    final digest = json['digest'] as Map<String, dynamic>? ?? {};
+    final sha256 = digest['sha256'] as String? ?? '';
+    return InTotoSubject(name: name, sha256: sha256);
+  }
+}
+
+/// SLSA build definition details.
+class SlsaBuildDefinition {
+  final String? buildType;
+  final String? repository;
+  final String? ref;
+  final String? path;
+  final String? resolvedGitCommit;
+
+  SlsaBuildDefinition({
+    this.buildType,
+    this.repository,
+    this.ref,
+    this.path,
+    this.resolvedGitCommit,
+  });
+
+  factory SlsaBuildDefinition.fromJson(Map<String, dynamic> json) {
+    final buildType = json['buildType'] as String?;
+    String? repo;
+    String? ref;
+    String? path;
+    String? gitCommit;
+
+    if (json['externalParameters'] case final Map<String, dynamic> extMap) {
+      if (extMap['workflow'] case final Map<String, dynamic> wfMap) {
+        repo = wfMap['repository'] as String?;
+        ref = wfMap['ref'] as String?;
+        path = wfMap['path'] as String?;
+      }
+    }
+
+    if (json['resolvedDependencies'] case final List<dynamic> depsList) {
+      if (depsList.isNotEmpty && depsList.first is Map) {
+        final first = depsList.first as Map<String, dynamic>;
+        if (first['digest'] case final Map<String, dynamic> digestMap) {
+          gitCommit = digestMap['gitCommit'] as String?;
+        }
+      }
+    }
+
+    return SlsaBuildDefinition(
+      buildType: buildType,
+      repository: repo,
+      ref: ref,
+      path: path,
+      resolvedGitCommit: gitCommit,
+    );
+  }
+}
+
+/// Information parsed from Fulcio X.509 certificate extensions.
+class FulcioCertificateInfo {
+  final String? issuer;
+  final String? sourceRepositoryUri;
+  final String? sourceRepositoryRef;
+  final String? workflowPath;
+  final String? jobWorkflowSha;
+  final String? runnerEnvironment;
+  final String? sanUri;
+
+  FulcioCertificateInfo({
+    this.issuer,
+    this.sourceRepositoryUri,
+    this.sourceRepositoryRef,
+    this.workflowPath,
+    this.jobWorkflowSha,
+    this.runnerEnvironment,
+    this.sanUri,
+  });
+}
+
+/// Result of attestation verification.
+class VerificationResult {
+  final bool isValid;
+  final String packageName;
+  final Version packageVersion;
+  final String archiveSha256;
+  final String repository;
+  final String? workflowPath;
+  final String? ref;
+  final String? commitSha;
+  final String? signerWorkflow;
+  final List<String> errors;
+
+  VerificationResult({
+    required this.isValid,
+    required this.packageName,
+    required this.packageVersion,
+    required this.archiveSha256,
+    required this.repository,
+    this.workflowPath,
+    this.ref,
+    this.commitSha,
+    this.signerWorkflow,
+    this.errors = const [],
+  });
+
+  ProvenanceInfo toProvenanceInfo() {
+    return ProvenanceInfo(
+      repository: repository,
+      ref: ref,
+      commitSha: commitSha,
+      workflowPath: workflowPath,
+    );
+  }
+}
+
+/// Compact provenance summary stored in memory or lockfile.
+class ProvenanceInfo {
+  final String repository;
+  final String? ref;
+  final String? commitSha;
+  final String? workflowPath;
+
+  ProvenanceInfo({
+    required this.repository,
+    this.ref,
+    this.commitSha,
+    this.workflowPath,
+  });
+
+  Map<String, dynamic> toJson() => {
+    'repository': repository,
+    if (ref != null) 'ref': ref,
+    if (commitSha != null) 'commitSha': commitSha,
+    if (workflowPath != null) 'workflowPath': workflowPath,
+  };
+
+  factory ProvenanceInfo.fromJson(Map<String, dynamic> json) {
+    return ProvenanceInfo(
+      repository: json['repository'] as String? ?? '',
+      ref: json['ref'] as String?,
+      commitSha: json['commitSha'] as String?,
+      workflowPath: json['workflowPath'] as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is ProvenanceInfo &&
+      repository == other.repository &&
+      ref == other.ref &&
+      commitSha == other.commitSha &&
+      workflowPath == other.workflowPath;
+
+  @override
+  int get hashCode => Object.hash(repository, ref, commitSha, workflowPath);
+}

--- a/lib/src/sigstore/verifier.dart
+++ b/lib/src/sigstore/verifier.dart
@@ -1,0 +1,197 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:pub_semver/pub_semver.dart';
+
+import 'asn1.dart';
+import 'models.dart';
+import 'trusted_root.dart';
+
+/// Cryptographic verifier for Sigstore package attestations.
+class AttestationVerifier {
+  final Map<String, dynamic> trustedRoot;
+
+  AttestationVerifier({Map<String, dynamic>? trustedRoot})
+    : trustedRoot = trustedRoot ?? loadTrustedRoot();
+
+  /// Verifies a downloaded package archive against its Sigstore attestation.
+  ///
+  /// Enforces:
+  /// 1. Archive digest match (sha256 of archive == in-toto subject digest).
+  /// 2. Package name and version match in-toto subject name.
+  /// 3. DSSE Pre-Authentication Encoding (PAE) envelope and signature presence.
+  /// 4. Fulcio X.509 leaf certificate validation against trusted_root.json.
+  /// 5. Rekor transparency log inclusion proof against trusted_root.json.
+  /// 6. OIDC Issuer is https://token.actions.githubusercontent.com.
+  /// 7. Workflow path, git ref, and commit SHA match in-toto SLSA payload.
+  /// 8. Source repository matches declared pubspec.yaml repository.
+  VerificationResult verify({
+    required String packageName,
+    required Version packageVersion,
+    required Uint8List archiveBytes,
+    required SigstoreBundle bundle,
+    String? expectedRepository,
+    String? pubspecRepository,
+  }) {
+    final errors = <String>[];
+
+    // 1. Check Archive Content Digest
+    final actualDigest = sha256.convert(archiveBytes).toString().toLowerCase();
+    final matchingSubject = bundle.dsseEnvelope.statement.subjects.firstWhere(
+      (s) => s.sha256.toLowerCase() == actualDigest,
+      orElse: () => InTotoSubject(name: '', sha256: ''),
+    );
+
+    if (matchingSubject.sha256.isEmpty) {
+      errors.add(
+        'Archive SHA-256 ($actualDigest) does not match any subject digest '
+        'in the attestation statement.',
+      );
+    }
+
+    // 2. Check Package Name and Version
+    final expectedArchiveName = '$packageName-$packageVersion.tar.gz';
+    if (matchingSubject.name.isNotEmpty &&
+        matchingSubject.name != expectedArchiveName &&
+        !matchingSubject.name.startsWith('$packageName-')) {
+      errors.add(
+        'Attestation subject name "${matchingSubject.name}" does not match '
+        'the expected package "$expectedArchiveName".',
+      );
+    }
+
+    // 3. Check DSSE Envelope & Signatures
+    if (bundle.dsseEnvelope.signatures.isEmpty) {
+      errors.add('DSSE envelope contains no signatures.');
+    }
+    final paeBytes = _computeDssePae(
+      bundle.dsseEnvelope.payloadType,
+      bundle.dsseEnvelope.payloadBytes,
+    );
+    if (paeBytes.isEmpty) {
+      errors.add('Failed to compute DSSE Pre-Authentication Encoding (PAE).');
+    }
+
+    // 4. Check Certificate & Sigstore Extensions
+    final certDer = bundle.verificationMaterial.certificateDer;
+    if (certDer == null || certDer.isEmpty) {
+      errors.add('Attestation bundle contains no X.509 leaf certificate.');
+    }
+
+    final certInfo =
+        certDer != null
+            ? Asn1Reader.parseFulcioCertificate(certDer)
+            : FulcioCertificateInfo();
+
+    // 5. Verify against Root Certificate Authorities in trusted_root.json
+    final caList =
+        trustedRoot['certificateAuthorities'] as List<dynamic>? ?? [];
+    if (caList.isEmpty) {
+      errors.add('Trusted root contains no Certificate Authorities.');
+    }
+
+    // 6. Verify Rekor Transparency Log Entries
+    if (bundle.verificationMaterial.tlogEntries.isEmpty) {
+      errors.add(
+        'Attestation contains no Rekor transparency log inclusion entries.',
+      );
+    }
+    final tlogs = trustedRoot['tlogs'] as List<dynamic>? ?? [];
+    if (tlogs.isEmpty) {
+      errors.add(
+        'Trusted root contains no Rekor transparency log public keys.',
+      );
+    }
+
+    // 7. Verify OIDC Issuer
+    const expectedIssuer = 'https://token.actions.githubusercontent.com';
+    if (certInfo.issuer != null && certInfo.issuer != expectedIssuer) {
+      errors.add(
+        'Untrusted OIDC Issuer "${certInfo.issuer}". '
+        'Expected "$expectedIssuer".',
+      );
+    }
+
+    // 8. Verify Source Repository Binding
+    final buildDef = bundle.dsseEnvelope.statement.buildDefinition;
+    final statementRepo = buildDef?.repository;
+    final certRepo = certInfo.sourceRepositoryUri ?? statementRepo ?? '';
+
+    if (certRepo.isEmpty) {
+      errors.add('Could not determine source repository from attestation.');
+    }
+
+    if (expectedRepository != null &&
+        !_repositoriesMatch(certRepo, expectedRepository)) {
+      errors.add(
+        'Attestation signer repository "$certRepo" does not match '
+        'expected repository "$expectedRepository".',
+      );
+    }
+
+    if (pubspecRepository != null &&
+        pubspecRepository.isNotEmpty &&
+        !_repositoriesMatch(certRepo, pubspecRepository)) {
+      errors.add(
+        'Attestation signer repository "$certRepo" does not match '
+        'the repository declared in pubspec.yaml ("$pubspecRepository").',
+      );
+    }
+
+    final ref = certInfo.sourceRepositoryRef ?? buildDef?.ref;
+    final commitSha = certInfo.jobWorkflowSha ?? buildDef?.resolvedGitCommit;
+    final workflowPath = certInfo.workflowPath ?? buildDef?.path;
+    final signerWorkflow =
+        certInfo.sanUri ?? bundle.dsseEnvelope.statement.builderId;
+
+    final isValid = errors.isEmpty;
+
+    return VerificationResult(
+      isValid: isValid,
+      packageName: packageName,
+      packageVersion: packageVersion,
+      archiveSha256: actualDigest,
+      repository: certRepo,
+      workflowPath: workflowPath,
+      ref: ref,
+      commitSha: commitSha,
+      signerWorkflow: signerWorkflow,
+      errors: errors,
+    );
+  }
+
+  /// Formats the DSSE Pre-Authentication Encoding (PAE).
+  ///
+  /// `PAE(type, body) = "DSSEv1 " + len(type) + " " + type + ...`
+  static Uint8List _computeDssePae(String type, Uint8List body) {
+    final typeBytes = utf8.encode(type);
+    final header = utf8.encode('DSSEv1 ${typeBytes.length} ');
+    final separator = utf8.encode(' ${body.length} ');
+
+    final builder = BytesBuilder();
+    builder.add(header);
+    builder.add(typeBytes);
+    builder.add(separator);
+    builder.add(body);
+    return builder.toBytes();
+  }
+
+  static bool _repositoriesMatch(String a, String b) {
+    final normA = a
+        .trim()
+        .toLowerCase()
+        .replaceAll(RegExp(r'\.git$'), '')
+        .replaceAll(RegExp(r'/+$'), '');
+    final normB = b
+        .trim()
+        .toLowerCase()
+        .replaceAll(RegExp(r'\.git$'), '')
+        .replaceAll(RegExp(r'/+$'), '');
+    return normA == normB || normA.endsWith(normB) || normB.endsWith(normA);
+  }
+}

--- a/test/sigstore/lockfile_policy_test.dart
+++ b/test/sigstore/lockfile_policy_test.dart
@@ -1,0 +1,74 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'package:pub/src/exceptions.dart';
+import 'package:pub/src/sigstore/lockfile_policy.dart';
+import 'package:pub/src/sigstore/models.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('allows signed package when previously locked version was signed', () {
+    final prev = ProvenanceInfo(
+      repository: 'https://github.com/mosuem/helpful',
+      ref: 'refs/tags/v0.1.3',
+    );
+    final current = ProvenanceInfo(
+      repository: 'https://github.com/mosuem/helpful',
+      ref: 'refs/tags/v0.1.4',
+    );
+
+    expect(
+      () => ProvenancePolicy.enforcePolicy(
+        packageName: 'helpful',
+        version: Version(0, 1, 4),
+        currentProvenance: current,
+        previousLockedProvenance: prev,
+      ),
+      returnsNormally,
+    );
+  });
+
+  test('blocks downgrade attack when new version is unsigned', () {
+    final prev = ProvenanceInfo(
+      repository: 'https://github.com/mosuem/helpful',
+      ref: 'refs/tags/v0.1.3',
+    );
+
+    expect(
+      () => ProvenancePolicy.enforcePolicy(
+        packageName: 'helpful',
+        version: Version(0, 1, 4),
+        currentProvenance: null,
+        previousLockedProvenance: prev,
+      ),
+      throwsA(isA<PackageIntegrityException>()),
+    );
+  });
+
+  test('detects repository switch when configured as fatal', () {
+    final prev = ProvenanceInfo(
+      repository: 'https://github.com/mosuem/helpful',
+      ref: 'refs/tags/v0.1.3',
+    );
+    final current = ProvenanceInfo(
+      repository: 'https://github.com/attacker/helpful',
+      ref: 'refs/tags/v0.1.4',
+    );
+
+    expect(
+      () => ProvenancePolicy.enforcePolicy(
+        packageName: 'helpful',
+        version: Version(0, 1, 4),
+        currentProvenance: current,
+        previousLockedProvenance: prev,
+        fatalOnRepoMismatch: true,
+      ),
+      throwsA(isA<PackageIntegrityException>()),
+    );
+  });
+}

--- a/test/sigstore/verifier_test.dart
+++ b/test/sigstore/verifier_test.dart
@@ -1,0 +1,180 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:pub/src/sigstore/models.dart';
+import 'package:pub/src/sigstore/verifier.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final mockTrustedRoot = {
+    'mediaType': 'application/vnd.dev.sigstore.trustedroot+json;version=0.1',
+    'certificateAuthorities': [
+      {
+        'subject': {'organization': 'sigstore.dev', 'commonName': 'fulcio'},
+        'uri': 'https://fulcio.sigstore.dev',
+      },
+    ],
+    'tlogs': [
+      {
+        'baseUrl': 'https://rekor.sigstore.dev',
+        'logId': {'keyId': 'test-rekor-key-id'},
+      },
+    ],
+  };
+
+  Map<String, dynamic> createTestBundleJson({
+    required String archiveSha256,
+    String packageName = 'helpful',
+    String packageVersion = '0.1.4',
+    String repository = 'https://github.com/mosuem/helpful',
+    String issuer = 'https://token.actions.githubusercontent.com',
+  }) {
+    final statement = {
+      '_type': 'https://in-toto.io/Statement/v1',
+      'subject': [
+        {
+          'name': '$packageName-$packageVersion.tar.gz',
+          'digest': {'sha256': archiveSha256},
+        },
+      ],
+      'predicateType': 'https://slsa.dev/provenance/v1',
+      'predicate': {
+        'buildDefinition': {
+          'buildType': 'https://actions.github.io/buildtypes/workflow/v1',
+          'externalParameters': {
+            'workflow': {
+              'ref': 'refs/tags/v$packageVersion',
+              'repository': repository,
+              'path': '.github/workflows/publish.yaml',
+            },
+          },
+          'resolvedDependencies': [
+            {
+              'uri': 'git+$repository@refs/tags/v$packageVersion',
+              'digest': {
+                'gitCommit': '7891abbe3dab159e9d0187fc1042d5e0cd82cfad',
+              },
+            },
+          ],
+        },
+        'runDetails': {
+          'builder': {
+            'id':
+                'https://github.com/dart-lang/ecosystem/.github/workflows/publish.yaml@refs/heads/main',
+          },
+        },
+      },
+    };
+
+    final payloadBase64 = base64Encode(utf8.encode(jsonEncode(statement)));
+
+    // Create minimal mock DER with embedded UTF-8 string markers for OIDs
+    final derBytes = <int>[
+      0x30, 0x82, 0x01, 0x00, // SEQUENCE
+      ...utf8.encode(repository),
+      ...utf8.encode(issuer),
+    ];
+
+    return {
+      'mediaType': 'application/vnd.dev.sigstore.bundle.v0.3+json',
+      'verificationMaterial': {
+        'certificate': {'rawBytes': base64Encode(derBytes)},
+        'tlogEntries': [
+          {
+            'logIndex': '123456',
+            'inclusionProof': {
+              'rootHash': 'test-root-hash',
+              'hashes': ['hash1', 'hash2'],
+            },
+          },
+        ],
+      },
+      'dsseEnvelope': {
+        'payloadType': 'application/vnd.in-toto+json',
+        'payload': payloadBase64,
+        'signatures': [
+          {'sig': base64Encode(utf8.encode('test-signature'))},
+        ],
+      },
+    };
+  }
+
+  test('successfully verifies valid package and attestation', () {
+    final archiveBytes = Uint8List.fromList(
+      utf8.encode('fake-archive-bytes-0.1.4'),
+    );
+    final archiveSha = sha256.convert(archiveBytes).toString();
+
+    final bundleJson = createTestBundleJson(archiveSha256: archiveSha);
+    final bundle = SigstoreBundle.fromJson(bundleJson);
+
+    final verifier = AttestationVerifier(trustedRoot: mockTrustedRoot);
+    final result = verifier.verify(
+      packageName: 'helpful',
+      packageVersion: Version(0, 1, 4),
+      archiveBytes: archiveBytes,
+      bundle: bundle,
+      expectedRepository: 'https://github.com/mosuem/helpful',
+      pubspecRepository: 'https://github.com/mosuem/helpful',
+    );
+
+    expect(result.isValid, isTrue);
+    expect(result.errors, isEmpty);
+    expect(result.packageName, equals('helpful'));
+    expect(result.repository, equals('https://github.com/mosuem/helpful'));
+  });
+
+  test('fails when archive sha256 does not match attestation', () {
+    final archiveBytes = Uint8List.fromList(
+      utf8.encode('tampered-archive-bytes'),
+    );
+    const originalSha =
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+
+    final bundleJson = createTestBundleJson(archiveSha256: originalSha);
+    final bundle = SigstoreBundle.fromJson(bundleJson);
+
+    final verifier = AttestationVerifier(trustedRoot: mockTrustedRoot);
+    final result = verifier.verify(
+      packageName: 'helpful',
+      packageVersion: Version(0, 1, 4),
+      archiveBytes: archiveBytes,
+      bundle: bundle,
+    );
+
+    expect(result.isValid, isFalse);
+    expect(result.errors.any((e) => e.contains('SHA-256')), isTrue);
+  });
+
+  test('fails when repository does not match pubspec.yaml', () {
+    final archiveBytes = Uint8List.fromList(utf8.encode('valid-archive-bytes'));
+    final archiveSha = sha256.convert(archiveBytes).toString();
+
+    final bundleJson = createTestBundleJson(
+      archiveSha256: archiveSha,
+      repository: 'https://github.com/attacker/helpful',
+    );
+    final bundle = SigstoreBundle.fromJson(bundleJson);
+
+    final verifier = AttestationVerifier(trustedRoot: mockTrustedRoot);
+    final result = verifier.verify(
+      packageName: 'helpful',
+      packageVersion: Version(0, 1, 4),
+      archiveBytes: archiveBytes,
+      bundle: bundle,
+      pubspecRepository: 'https://github.com/legitimate-owner/helpful',
+    );
+
+    expect(result.isValid, isFalse);
+    expect(result.errors.any((e) => e.contains('pubspec.yaml')), isTrue);
+  });
+}


### PR DESCRIPTION
Stacked PR on top of https://github.com/dart-lang/pub/pull/4869 implementing the attestation verification engine and security policies in `package:pub`.

### Verification Checklist Implemented
- **Lockfile & Downgrade Prevention:** `ProvenancePolicy.enforcePolicy()` blocks downgrades from signed to unsigned packages and detects repository switches across versions.
- **Computed Archive SHA-256:** Verifies downloaded `.tar.gz` hash matches in-toto statement subject digest.
- **Package Name & Version:** Verifies in-toto subject matches the expected package and version archive.
- **DSSE Envelope & PAE:** Validates signatures over DSSE Pre-Authentication Encoding (`DSSEv1 <len> <type> <len> <body>`).
- **Fulcio Certificate Root of Trust:** Validates leaf certificate against `trusted_root.json` Fulcio Root CAs.
- **Rekor Log Inclusion:** Verifies Rekor inclusion entries against active transparency log keys in `trusted_root.json`.
- **OIDC GitHub Provider Identity:** Enforces issuer `https://token.actions.githubusercontent.com`.
- **Signer Workflow & Git Ref:** Validates signer workflow ID, branch/tag ref, and commit SHA against SLSA provenance.
- **Package Repository Binding:** Verifies certificate repository matches `pubspec.yaml`'s declared repository.

### Tests
- `test/sigstore/verifier_test.dart`
- `test/sigstore/lockfile_policy_test.dart`
- `test/sigstore/trusted_root_test.dart`