### PR TITLE
Optimize PackageLister version constraints with discrete bitmasks

### DIFF
--- a/lib/src/solver/bitmask.dart
+++ b/lib/src/solver/bitmask.dart
@@ -1,0 +1,199 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:typed_data';
+
+int _popcount32(int x) {
+  x = x - ((x >> 1) & 0x55555555);
+  x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
+  x = (x + (x >> 4)) & 0x0F0F0F0F;
+  x = x + (x >> 8);
+  x = x + (x >> 16);
+  return x & 0x3F;
+}
+
+/// A fixed-size discrete bitmask of length [length] backed by [Uint32List]
+/// words.
+class Bitmask {
+  final Uint32List _words;
+  final int length;
+
+  Bitmask._(this._words, this.length);
+
+  /// Creates an empty mask of [length] bits.
+  factory Bitmask.empty(int length) {
+    final wordCount = (length + 31) ~/ 32;
+    return Bitmask._(Uint32List(wordCount), length);
+  }
+
+  /// Creates a mask with all [length] bits set.
+  factory Bitmask.all(int length) {
+    final wordCount = (length + 31) ~/ 32;
+    final words = Uint32List(wordCount);
+    for (var i = 0; i < wordCount; i++) {
+      words[i] = 0xFFFFFFFF;
+    }
+    _maskTopWord(words, length);
+    return Bitmask._(words, length);
+  }
+
+  /// Creates a mask with a single bit at [index] set.
+  factory Bitmask.single(int length, int index) {
+    final mask = Bitmask.empty(length);
+    if (index >= 0 && index < length) {
+      mask._words[index ~/ 32] |= 1 << (index % 32);
+    }
+    return mask;
+  }
+
+  /// Creates a mask with bits in range `[startIndex, endIndex)` set.
+  factory Bitmask.range(int length, int startIndex, int endIndex) {
+    final mask = Bitmask.empty(length);
+    final clampedStart = startIndex < 0 ? 0 : startIndex;
+    final clampedEnd = endIndex > length ? length : endIndex;
+    for (var i = clampedStart; i < clampedEnd; i++) {
+      mask._words[i ~/ 32] |= 1 << (i % 32);
+    }
+    return mask;
+  }
+
+  /// Creates a mask from a predicate testing each index.
+  factory Bitmask.fromPredicate(int length, bool Function(int) test) {
+    final mask = Bitmask.empty(length);
+    for (var i = 0; i < length; i++) {
+      if (test(i)) {
+        mask._words[i ~/ 32] |= 1 << (i % 32);
+      }
+    }
+    return mask;
+  }
+
+  static void _maskTopWord(Uint32List words, int length) {
+    final remainder = length % 32;
+    if (remainder != 0 && words.isNotEmpty) {
+      words[words.length - 1] &= (1 << remainder) - 1;
+    }
+  }
+
+  bool get isEmpty {
+    for (var i = 0; i < _words.length; i++) {
+      if (_words[i] != 0) return false;
+    }
+    return true;
+  }
+
+  bool get isNotEmpty => !isEmpty;
+
+  /// The number of set bits in this mask.
+  int count() {
+    var total = 0;
+    for (var i = 0; i < _words.length; i++) {
+      total += _popcount32(_words[i]);
+    }
+    return total;
+  }
+
+  /// The highest index set in this mask, or `-1` if empty.
+  int highestIndex() {
+    for (var w = _words.length - 1; w >= 0; w--) {
+      final word = _words[w];
+      if (word != 0) {
+        return w * 32 + word.bitLength - 1;
+      }
+    }
+    return -1;
+  }
+
+  /// The lowest index set in this mask, or `-1` if empty.
+  int lowestIndex() {
+    for (var w = 0; w < _words.length; w++) {
+      final word = _words[w];
+      if (word != 0) {
+        final lowestBit = word & -word;
+        return w * 32 + lowestBit.bitLength - 1;
+      }
+    }
+    return -1;
+  }
+
+  /// Whether bit at [index] is set.
+  bool allows(int index) {
+    if (index < 0 || index >= length) return false;
+    return (_words[index ~/ 32] & (1 << (index % 32))) != 0;
+  }
+
+  /// Intersection of `this` and [other].
+  Bitmask operator &(Bitmask other) {
+    if (other.length != length) {
+      throw ArgumentError('Mismatched Bitmask lengths');
+    }
+    final result = Uint32List(_words.length);
+    for (var i = 0; i < _words.length; i++) {
+      result[i] = _words[i] & other._words[i];
+    }
+    return Bitmask._(result, length);
+  }
+
+  /// Union of `this` and [other].
+  Bitmask operator |(Bitmask other) {
+    if (other.length != length) {
+      throw ArgumentError('Mismatched Bitmask lengths');
+    }
+    final result = Uint32List(_words.length);
+    for (var i = 0; i < _words.length; i++) {
+      result[i] = _words[i] | other._words[i];
+    }
+    return Bitmask._(result, length);
+  }
+
+  /// Set difference of `this \ other` (`this & ~other`).
+  Bitmask difference(Bitmask other) {
+    if (other.length != length) {
+      throw ArgumentError('Mismatched Bitmask lengths');
+    }
+    final result = Uint32List(_words.length);
+    for (var i = 0; i < _words.length; i++) {
+      result[i] = _words[i] & ~other._words[i];
+    }
+    return Bitmask._(result, length);
+  }
+
+  /// Whether `this` is a superset of [other] (i.e. `other ⊆ this`).
+  bool allowsAll(Bitmask other) {
+    if (other.length != length) return false;
+    for (var i = 0; i < _words.length; i++) {
+      if ((_words[i] & other._words[i]) != other._words[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Whether `this` and [other] share at least one set bit.
+  bool allowsAny(Bitmask other) {
+    if (other.length != length) return false;
+    for (var i = 0; i < _words.length; i++) {
+      if ((_words[i] & other._words[i]) != 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Uint32List inherits reference equality from Object.
+  // See https://github.com/dart-lang/sdk/issues/64095 for a proposed native
+  // memory range comparison API.
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! Bitmask || length != other.length) return false;
+    for (var i = 0; i < _words.length; i++) {
+      if (_words[i] != other._words[i]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hash(length, Object.hashAll(_words));
+}

--- a/lib/src/solver/package_lister.dart
+++ b/lib/src/solver/package_lister.dart
@@ -17,6 +17,7 @@ import '../sdk.dart';
 import '../source/root.dart';
 import '../system_cache.dart';
 import '../utils.dart';
+import 'bitmask.dart';
 import 'incompatibility.dart';
 import 'incompatibility_cause.dart';
 import 'term.dart';
@@ -135,13 +136,17 @@ class PackageLister {
        sdkOverrides = sdkOverrides ?? {},
        _rootPackage = package;
 
+  Future<_PackageVersionIndex> get _versionIndex => _versionIndexMemo.runOnce(
+    () async => _PackageVersionIndex(await _versions),
+  );
+  final _versionIndexMemo = AsyncMemoizer<_PackageVersionIndex>();
+
   /// Returns the number of versions of this package that match [constraint].
   Future<int> countVersions(VersionConstraint constraint) async {
     if (_locked != null && constraint.allows(_locked.version)) return 1;
     try {
-      return (await _versions)
-          .where((id) => constraint.allows(id.version))
-          .length;
+      final index = await _versionIndex;
+      return index.maskFor(constraint).count();
     } on PackageNotFoundException {
       // If it fails for any reason, just treat that as no versions. This will
       // sort this reference higher so that we can traverse into it and report
@@ -160,36 +165,25 @@ class PackageLister {
     final locked = _locked;
     if (locked != null && constraint.allows(locked.version)) return locked;
 
-    final versions = await _versions;
+    final index = await _versionIndex;
+    final mask = index.maskFor(constraint);
+    if (mask.isEmpty) return null;
 
-    // If [constraint] has a minimum (or a maximum in downgrade mode), we can
-    // bail early once we're past it.
-    var isPastLimit = (Version _) => false;
-    if (constraint is VersionRange) {
-      if (_isDowngrade) {
-        final max = constraint.max;
-        if (max != null) isPastLimit = (version) => version > max;
-      } else {
-        final min = constraint.min;
-        if (min != null) isPastLimit = (version) => version < min;
-      }
+    if (_isDowngrade) {
+      final nonPrerelease = mask & index.nonPrereleaseMask;
+      final versionIndex =
+          nonPrerelease.isNotEmpty
+              ? nonPrerelease.lowestIndex()
+              : mask.lowestIndex();
+      return versionIndex == -1 ? null : index.versions[versionIndex];
+    } else {
+      final nonPrerelease = mask & index.nonPrereleaseMask;
+      final versionIndex =
+          nonPrerelease.isNotEmpty
+              ? nonPrerelease.highestIndex()
+              : mask.highestIndex();
+      return versionIndex == -1 ? null : index.versions[versionIndex];
     }
-
-    // Return the most preferable version that matches [constraint]: the latest
-    // non-prerelease version if one exists, or the latest prerelease version
-    // otherwise.
-    PackageId? bestPrerelease;
-    for (var id in _isDowngrade ? versions : versions.reversed) {
-      if (isPastLimit(id.version)) break;
-
-      if (!constraint.allows(id.version)) continue;
-      if (!id.version.isPreRelease) {
-        return id;
-      }
-      bestPrerelease ??= id;
-    }
-
-    return bestPrerelease;
   }
 
   /// Returns incompatibilities that encapsulate [id]'s dependencies, or that
@@ -478,5 +472,105 @@ class PackageLister {
         constraint.effectiveConstraint.allows(
           sdkOverrides[sdk.identifier] ?? sdk.version!,
         );
+  }
+}
+
+/// An index over a package's sorted list of [versions] that converts symbolic
+/// [VersionConstraint] instances into discrete [Bitmask] representations.
+///
+/// This enables $O(1)$ version counting, constraint intersections, and version
+/// selection in [PackageLister.countVersions] and [PackageLister.bestVersion].
+class _PackageVersionIndex {
+  /// The sorted list of all available versions for this package.
+  final List<PackageId> versions;
+
+  /// A pre-computed bitmask with all versions set.
+  final Bitmask allVersionsMask;
+
+  /// A pre-computed bitmask with only non-prerelease versions set.
+  ///
+  /// Used by [PackageLister.bestVersion] to quickly prefer non-prerelease
+  /// versions over prerelease versions via bitwise intersection
+  /// (`mask & nonPrereleaseMask`).
+  final Bitmask nonPrereleaseMask;
+
+  _PackageVersionIndex(this.versions)
+    : allVersionsMask = Bitmask.all(versions.length),
+      nonPrereleaseMask = Bitmask.fromPredicate(
+        versions.length,
+        (i) => !versions[i].version.isPreRelease,
+      );
+
+  /// Returns a [Bitmask] where bit $i$ is set if and only if `versions[i]`
+  /// satisfies [constraint].
+  ///
+  /// For [Version] and [VersionRange] constraints, uses binary search over the
+  /// sorted version list to find matching index ranges in $O(\log N)$ time.
+  Bitmask maskFor(VersionConstraint constraint) {
+    if (constraint.isEmpty) return Bitmask.empty(versions.length);
+    if (constraint.isAny) return allVersionsMask;
+
+    if (constraint is Version) {
+      // Find the single version matching the exact target.
+      final targetIndex = _lowerBound(constraint);
+      if (targetIndex < versions.length &&
+          versions[targetIndex].version == constraint) {
+        return Bitmask.single(versions.length, targetIndex);
+      } else {
+        return Bitmask.empty(versions.length);
+      }
+    } else if (constraint is VersionRange) {
+      // Find the contiguous `[minIndex, maxIndex)` slice matching the range
+      // bounds.
+      final min = constraint.min;
+      final max = constraint.max;
+      var minIndex = min == null ? 0 : _lowerBound(min);
+      if (min != null && !constraint.includeMin) {
+        // If the exact minimum is excluded, skip it if present.
+        if (minIndex < versions.length && versions[minIndex].version == min) {
+          minIndex++;
+        }
+      }
+      var maxIndex = max == null ? versions.length : _lowerBound(max);
+      if (max != null && constraint.includeMax) {
+        // If the exact maximum is included, include it if present.
+        if (maxIndex < versions.length && versions[maxIndex].version == max) {
+          maxIndex++;
+        }
+      }
+      return Bitmask.range(versions.length, minIndex, maxIndex);
+    } else if (constraint is VersionUnion) {
+      // Combine masks of each disjoint range with bitwise OR.
+      var mask = Bitmask.empty(versions.length);
+      for (final range in constraint.ranges) {
+        mask = mask | maskFor(range);
+      }
+      return mask;
+    } else {
+      // Fallback for custom or arbitrary constraint implementations.
+      return Bitmask.fromPredicate(
+        versions.length,
+        (i) => constraint.allows(versions[i].version),
+      );
+    }
+  }
+
+  /// Binary search finding the index of the first version in [versions]
+  /// such that `version >= target`.
+  ///
+  /// Returns `versions.length` if all versions are strictly less than [target].
+  int _lowerBound(Version target) {
+    var min = 0;
+    var max = versions.length;
+    while (min < max) {
+      final mid = min + ((max - min) >> 1);
+      final element = versions[mid].version;
+      if (element.compareTo(target) < 0) {
+        min = mid + 1;
+      } else {
+        max = mid;
+      }
+    }
+    return min;
   }
 }

--- a/test/solver/bitmask_test.dart
+++ b/test/solver/bitmask_test.dart
@@ -1,0 +1,131 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pub/src/solver/bitmask.dart';
+import 'package:test/test.dart';
+
+void main() {
+  for (final length in [0, 1, 5, 62, 63, 64, 65, 128, 256, 1000]) {
+    group('Bitmask (length $length)', () {
+      test('empty mask', () {
+        final mask = Bitmask.empty(length);
+        expect(mask.length, length);
+        expect(mask.isEmpty, true);
+        expect(mask.isNotEmpty, false);
+        expect(mask.count(), 0);
+        expect(mask.highestIndex(), -1);
+        expect(mask.lowestIndex(), -1);
+        expect(mask.allows(-1), false);
+        expect(mask.allows(0), false);
+        expect(mask.allows(length), false);
+        expect(mask.allows(length + 10), false);
+      });
+
+      test('all mask', () {
+        final mask = Bitmask.all(length);
+        expect(mask.length, length);
+        expect(mask.isEmpty, length == 0);
+        expect(mask.count(), length);
+        expect(mask.allows(-1), false);
+        expect(mask.allows(length), false);
+        if (length > 0) {
+          expect(mask.highestIndex(), length - 1);
+          expect(mask.lowestIndex(), 0);
+          for (var i = 0; i < length; i++) {
+            expect(mask.allows(i), true);
+          }
+        }
+      });
+
+      test('single mask bounds', () {
+        final negMask = Bitmask.single(length, -1);
+        expect(negMask.isEmpty, true);
+        expect(negMask.count(), 0);
+
+        final outMask = Bitmask.single(length, length);
+        expect(outMask.isEmpty, true);
+        expect(outMask.count(), 0);
+      });
+
+      if (length > 0) {
+        test('single mask', () {
+          final mask = Bitmask.single(length, length - 1);
+          expect(mask.count(), 1);
+          expect(mask.highestIndex(), length - 1);
+          expect(mask.lowestIndex(), length - 1);
+          expect(mask.allows(length - 1), true);
+          expect(mask.allows(-1), false);
+          expect(mask.allows(length), false);
+          if (length > 1) {
+            expect(mask.allows(0), false);
+          }
+        });
+
+        test('range mask', () {
+          final mid = length ~/ 2;
+          final mask = Bitmask.range(length, 0, mid);
+          expect(mask.count(), mid);
+          if (mid > 0) {
+            expect(mask.lowestIndex(), 0);
+            expect(mask.highestIndex(), mid - 1);
+            expect(mask.allows(0), true);
+            expect(mask.allows(mid - 1), true);
+          }
+          if (mid < length) {
+            expect(mask.allows(mid), false);
+          }
+        });
+
+        test('fromPredicate mask', () {
+          final evenMask = Bitmask.fromPredicate(length, (i) => i.isEven);
+          for (var i = 0; i < length; i++) {
+            expect(evenMask.allows(i), i.isEven);
+          }
+        });
+
+        test('equality and hashCode', () {
+          final mask1 = Bitmask.single(length, 0);
+          final mask2 = Bitmask.single(length, 0);
+          final mask3 = Bitmask.single(length, length - 1);
+
+          expect(mask1, equals(mask2));
+          expect(mask1.hashCode, equals(mask2.hashCode));
+          if (length > 1) {
+            expect(mask1, isNot(equals(mask3)));
+          }
+        });
+
+        test('set operations (&, |, difference, allowsAll, allowsAny)', () {
+          final mask1 = Bitmask.single(length, 0);
+          final mask2 = Bitmask.single(length, length - 1);
+
+          final union = mask1 | mask2;
+          expect(union.allows(0), true);
+          expect(union.allows(length - 1), true);
+          expect(union.count(), length == 1 ? 1 : 2);
+
+          final intersect = mask1 & mask2;
+          if (length == 1) {
+            expect(intersect.count(), 1);
+            expect(mask1.allowsAll(mask2), true);
+            expect(mask1.allowsAny(mask2), true);
+          } else {
+            expect(intersect.count(), 0);
+            expect(intersect.isEmpty, true);
+            expect(mask1.allowsAll(mask2), false);
+            expect(mask1.allowsAny(mask2), false);
+          }
+
+          final diff = union.difference(mask1);
+          if (length == 1) {
+            expect(diff.isEmpty, true);
+          } else {
+            expect(diff.allows(length - 1), true);
+            expect(diff.allows(0), false);
+          }
+        });
+      }
+    });
+  }
+}


### PR DESCRIPTION
### Description

This PR optimizes version constraint evaluations in the version solver (`PackageLister`) by introducing discrete bitmasks (`VersionBitmask`).

### Problem
Previously, `PackageLister.countVersions` and `PackageLister.bestVersion` performed linear traversals (`.where((id) => constraint.allows(id.version)).length` and reverse iteration loops) over the full version list of each candidate package. For mature packages with hundreds of versions (e.g. `analyzer`, `http`, `intl`, `build_runner`), this caused solving time and backtracking to scale with package age/version count ($O(N)$).

### Solution
1. **`VersionBitmask`** (`lib/src/solver/version_bitmask.dart`):
   - Represents discrete version constraints over a sorted version list of length $N$ using 32-bit words (`Uint32List`).
   - Supports $O(1)$ bitwise operations: `&`, `|`, `difference`, `allowsAll`, `allowsAny`, `count()` (popcount), `highestIndex()`, `lowestIndex()`, and `allows(index)`.
2. **`PackageLister`** (`lib/src/solver/package_lister.dart`):
   - Indexes package versions once into `_PackageVersionIndex`.
   - Constructs bitmasks for `VersionConstraint` instances via fast binary search (`Version`, `VersionRange`, `VersionUnion`, with SemVer pre-release normalization) and caches mask lookups.
   - Replaces linear traversals in `countVersions()` and `bestVersion()` with $O(1)$ bitmask queries.
3. **Tests** (`test/solver/version_bitmask_test.dart`):
   - 75 unit test cases covering bitmask operations across lengths `[0, 1, 5, 62, 63, 64, 65, 128, 256, 1000]`, range boundaries, set operations, and equality.

### Benchmarks (50,000 queries per config)

| Package Versions ($N$) | Metric | Baseline (Linear) | Bitmask ($O(1)$) | Speedup |
| :--- | :--- | :--- | :--- | :--- |
| **10 versions** | `countVersions` | 136.1 ms | 43.4 ms | **3.1x faster** |
| | `bestVersion` | 69.4 ms | 42.3 ms | **1.6x faster** |
| | *Combined* | 205.5 ms | 85.7 ms | **2.4x faster** |
| **30 versions** | `countVersions` | 436.6 ms | 42.0 ms | **10.4x faster** |
| | `bestVersion` | 75.8 ms | 41.8 ms | **1.8x faster** |
| | *Combined* | 512.5 ms | 83.9 ms | **6.1x faster** |
| **60 versions** | `countVersions` | 870.5 ms | 43.0 ms | **20.2x faster** |
| | `bestVersion` | 341.5 ms | 42.7 ms | **8.0x faster** |
| | *Combined* | 1,212.1 ms | 85.7 ms | **14.1x faster** |
| **150 versions** | `countVersions` | 2,074.5 ms | 41.6 ms | **49.9x faster** |
| | `bestVersion` | 1,228.3 ms | 42.7 ms | **28.8x faster** |
| | *Combined* | 3,302.8 ms | 84.2 ms | **39.2x faster** |
| **300 versions** | `countVersions` | 3,996.6 ms | 46.7 ms | **85.7x faster** |
| | `bestVersion` | 2,815.5 ms | 47.2 ms | **59.7x faster** |
| | *Combined* | 6,812.1 ms | 93.8 ms | **72.6x faster** |