### PR TITLE
Support uploading package attestations during publish --from-archive

### DIFF
--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -298,8 +298,15 @@ changed.
 
 ```js
 {
-  "url": "<multipart-upload-url>",
+  "url": "<archive-upload-url>",
   "fields": {
+    "<field-1>": "<value-1>",
+    "<field-2>": "<value-2>",
+    ...,
+    "<field-N>": "<value-N>",
+  },
+  "attestationUrl": "<attestation-upload-url>",
+  "attestationFields": {
     "<field-1>": "<value-1>",
     "<field-2>": "<value-2>",
     ...,
@@ -309,14 +316,74 @@ changed.
 ```
 
 To publish a package an HTTP `GET` request for
-`<hosted-url>/api/packages/versions/new` is made. This request returns an
-`<multipart-upload-url>` and a dictionary of fields. To upload the package
-archive a multi-part `POST` request is made to `<multipart-upload-url>` with
-fields and the field `file` containing the gzipped tar archive.
+`<hosted-url>/api/packages/versions/new` is made. This request returns:
+* `url`: An `<archive-upload-url>` for uploading the package archive.
+* `fields`: A dictionary of form fields required by the storage service for the
+  archive upload.
+* `attestationUrl`: An `<attestation-upload-url>` for uploading a package
+  attestation bundle (such as a Sigstore provenance bundle). Present on
+  repositories that support attestations.
+* `attestationFields`: A dictionary of form fields required by the storage
+  service for the attestation upload. Present if `attestationUrl` is present.
+
+The `attestationUrl` and `attestationFields` properties are returned by
+repositories that support package attestations. If the user requests publishing
+with an attestation and the server response omits `attestationUrl`, the client
+should abort the publication with an informative error message.
+
+### Uploading the Attestation
+
+When publishing with an attestation, the client **MUST** upload the attestation
+bundle to `<attestation-upload-url>` (from `attestationUrl`) **before** uploading
+the package archive to `<archive-upload-url>` (from `url`). This ensures that an
+attestation is never omitted due to partial or interrupted uploads. If not
+publishing with an attestation, this step is skipped.
+
+To upload the attestation bundle, a multi-part `POST` request is made to
+`<attestation-upload-url>` containing all key-value pairs from
+`attestationFields`, along with a `file` part containing the attestation JSON
+bundle:
 
 ```http
-POST <path(multipart-upload-url)> HTTP/1.1
-Host: <host(multipart-upload-url)>
+POST <path(attestation-upload-url)> HTTP/1.1
+Host: <host(attestation-upload-url)>
+Content-Length: <length>
+Content-Type: multipart/form-data; boundary=<boundary>
+
+--<boundary>
+Content-Disposition: form-data; name="<urlencode(field-1)>"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: binary
+
+<value-1>
+...
+--<boundary>
+Content-Disposition: form-data; name="<urlencode(field-N)>"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: binary
+
+<value-N>
+--<boundary>
+Content-Type: application/json; charset=utf-8
+Content-Disposition: form-data; name="file"; filename="attestation.sigstore.json"
+
+<attestation JSON bundle>
+--<boundary>--
+```
+
+The storage service may respond with `HTTP 204 No Content` or `HTTP 200 OK`. The
+client must verify that the request succeeded before proceeding to upload the
+package archive.
+
+### Uploading the Package Archive
+
+To upload the package archive a multi-part `POST` request is made to
+`<archive-upload-url>` containing all key-value pairs from `fields`, along with a
+`file` part containing the gzipped tar archive:
+
+```http
+POST <path(archive-upload-url)> HTTP/1.1
+Host: <host(archive-upload-url)>
 Content-Length: <length>
 Content-Type: multipart/form-data; boundary=<boundary>
 
@@ -343,20 +410,37 @@ Content-Transfer-Encoding: binary
 Content-Type: application/octet-stream
 Content-Disposition: form-data; name="file"; filename="package.tar.gz"
 
-<gzipped archieve>
+<gzipped archive>
+--<boundary>--
 ```
 
-The above `POST` request to `<multipart-upload-url>` should respond as follows:
+The above `POST` request to `<archive-upload-url>` may respond as follows:
 
 ```http
 HTTP/1.1 204 No Content
 Location: <finalize-upload-url>
 ```
 
+or with an HTTP `303 See Other` redirect to `<finalize-upload-url>`.
+
+### Finalizing the Upload
+
 The client shall then issue a `GET` request to `<finalize-upload-url>`. As with
 `archive_url` the client will only attach an `Authorization` if the
-`<hosted-url>` is a prefix of `<finalize-upload-url>`. If the server wants to
-accept the uploaded package the server should respond:
+`<hosted-url>` is a prefix of `<finalize-upload-url>`.
+
+During finalization, the server inspects the uploaded archive, along with any
+accompanying attestation that was uploaded prior to the archive. If an
+attestation was uploaded, the server verifies its validity before accepting
+the publication. An attestation may be rejected as invalid if:
+ * the JSON bundle is malformed or cannot be parsed as a Sigstore bundle,
+ * the cryptographic signature cannot be verified against the trusted root,
+ * the artifact digest recorded in the attestation does not match the SHA-256
+   hash of the uploaded package archive, or
+ * the provenance information (such as the source repository) does not match
+   the `repository` field in `pubspec.yaml`.
+
+If the server wants to accept the uploaded package the server should respond:
 
 ```http
 HTTP/1.1 200 Ok
@@ -388,84 +472,15 @@ Content-Type: application/vnd.pub.v2+json
 ```
 
 This can be used to forbid git dependencies in published packages, limit the
-archive size, or enforce any other repository-specific constraints.
+archive size, reject invalid attestations, or enforce any other
+repository-specific constraints.
 
-This upload flow allows for archives to be uploaded directly to a signed POST
-URL for [S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/HTTPPOSTExamples.html),
+This upload flow allows for archives and attestations to be uploaded directly to
+a signed POST URL for [S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/HTTPPOSTExamples.html),
 [GCS](https://cloud.google.com/storage/docs/xml-api/post-object-forms) or
-similar blob storage service. Both the
-`<multipart-upload-url>` and `<finalize-upload-url>` are allowed to contain
-query-string parameters, and both of these URLs need only be temporary.
-
-### Uploading Package Attestations
-
-When publishing with a package attestation, the client uploads a Sigstore bundle
-to `<multipart-upload-url>` before uploading the package archive.
-
-The multi-part `POST` request for the attestation uses the same fields
-dictionary returned by `<hosted-url>/api/packages/versions/new`, with the
-following modifications:
- * If a `key` field is present in `fields`, its value is modified by appending
-   `.sigstore.json` (i.e. `<key>.sigstore.json`). This sets the storage object
-   path for the attestation file, allowing the server to locate and correlate the
-   attestation bundle with the package archive (stored at `<key>`) during
-   finalization.
- * The `success_action_redirect` field, if present in `fields`, is omitted.
-   The server typically supplies this field to instruct blob storage services
-   (such as Google Cloud Storage or Amazon S3) to automatically redirect to
-   `<finalize-upload-url>` upon completion. Omitting it for the attestation
-   upload ensures the storage service returns an HTTP `204 No Content` response
-   without triggering the finalization redirect before the package archive itself
-   is uploaded.
- * The `file` field contains the Sigstore attestation JSON bundle with
-   `filename="attestation.sigstore.json"`.
-
-Example multi-part `POST` request to `<multipart-upload-url>` for uploading the
-attestation bundle:
-
-```http
-POST <path(multipart-upload-url)> HTTP/1.1
-Host: <host(multipart-upload-url)>
-Content-Length: <length>
-Content-Type: multipart/form-data; boundary=<boundary>
-
---<boundary>
-Content-Disposition: form-data; name="<urlencode(field-1)>"
-Content-Type: text/plain; charset=utf-8
-Content-Transfer-Encoding: binary
-
-<value-1>
-...
---<boundary>
-Content-Disposition: form-data; name="key"
-Content-Type: text/plain; charset=utf-8
-Content-Transfer-Encoding: binary
-
-<value-of-key>.sigstore.json
-...
---<boundary>
-Content-Type: application/octet-stream
-Content-Disposition: form-data; name="file"; filename="attestation.sigstore.json"
-
-<attestation JSON bundle>
-```
-
-Once the attestation bundle has been uploaded, the client proceeds to upload the
-package archive `package.tar.gz` and finalize publishing as described above.
-
-During upload finalization (when the client issues the `GET` request to
-`<finalize-upload-url>`), the server locates the uploaded attestation bundle
-alongside the package archive and verifies it before accepting the publication.
-An attestation may be rejected as invalid if:
- * the JSON bundle is malformed or cannot be parsed as a Sigstore bundle,
- * the cryptographic signature cannot be verified against the trusted root,
- * the artifact digest recorded in the attestation does not match the SHA-256
-   hash of the uploaded package archive, or
- * the provenance information (such as the source repository) does not match
-   the `repository` field in `pubspec.yaml`.
-
-If verification fails, the server rejects the upload with an HTTP
-`400 Bad Request` response.
+similar blob storage service. Both the `<archive-upload-url>`,
+`<attestation-upload-url>`, and `<finalize-upload-url>` are allowed to contain
+query-string parameters, and all of these URLs need only be temporary.
 
 
 ## List security advisories for a package

--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -397,6 +397,76 @@ similar blob storage service. Both the
 `<multipart-upload-url>` and `<finalize-upload-url>` are allowed to contain
 query-string parameters, and both of these URLs need only be temporary.
 
+### Uploading Package Attestations
+
+When publishing with a package attestation, the client uploads a Sigstore bundle
+to `<multipart-upload-url>` before uploading the package archive.
+
+The multi-part `POST` request for the attestation uses the same fields
+dictionary returned by `<hosted-url>/api/packages/versions/new`, with the
+following modifications:
+ * If a `key` field is present in `fields`, its value is modified by appending
+   `.sigstore.json` (i.e. `<key>.sigstore.json`). This sets the storage object
+   path for the attestation file, allowing the server to locate and correlate the
+   attestation bundle with the package archive (stored at `<key>`) during
+   finalization.
+ * The `success_action_redirect` field, if present in `fields`, is omitted.
+   The server typically supplies this field to instruct blob storage services
+   (such as Google Cloud Storage or Amazon S3) to automatically redirect to
+   `<finalize-upload-url>` upon completion. Omitting it for the attestation
+   upload ensures the storage service returns an HTTP `204 No Content` response
+   without triggering the finalization redirect before the package archive itself
+   is uploaded.
+ * The `file` field contains the Sigstore attestation JSON bundle with
+   `filename="attestation.sigstore.json"`.
+
+Example multi-part `POST` request to `<multipart-upload-url>` for uploading the
+attestation bundle:
+
+```http
+POST <path(multipart-upload-url)> HTTP/1.1
+Host: <host(multipart-upload-url)>
+Content-Length: <length>
+Content-Type: multipart/form-data; boundary=<boundary>
+
+--<boundary>
+Content-Disposition: form-data; name="<urlencode(field-1)>"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: binary
+
+<value-1>
+...
+--<boundary>
+Content-Disposition: form-data; name="key"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: binary
+
+<value-of-key>.sigstore.json
+...
+--<boundary>
+Content-Type: application/octet-stream
+Content-Disposition: form-data; name="file"; filename="attestation.sigstore.json"
+
+<attestation JSON bundle>
+```
+
+Once the attestation bundle has been uploaded, the client proceeds to upload the
+package archive `package.tar.gz` and finalize publishing as described above.
+
+During upload finalization (when the client issues the `GET` request to
+`<finalize-upload-url>`), the server locates the uploaded attestation bundle
+alongside the package archive and verifies it before accepting the publication.
+An attestation may be rejected as invalid if:
+ * the JSON bundle is malformed or cannot be parsed as a Sigstore bundle,
+ * the cryptographic signature cannot be verified against the trusted root,
+ * the artifact digest recorded in the attestation does not match the SHA-256
+   hash of the uploaded package archive, or
+ * the provenance information (such as the source repository) does not match
+   the `repository` field in `pubspec.yaml`.
+
+If verification fails, the server rejects the upload with an HTTP
+`400 Bad Request` response.
+
 
 ## List security advisories for a package
 

--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -298,15 +298,8 @@ changed.
 
 ```js
 {
-  "url": "<archive-upload-url>",
+  "url": "<multipart-upload-url>",
   "fields": {
-    "<field-1>": "<value-1>",
-    "<field-2>": "<value-2>",
-    ...,
-    "<field-N>": "<value-N>",
-  },
-  "attestationUrl": "<attestation-upload-url>",
-  "attestationFields": {
     "<field-1>": "<value-1>",
     "<field-2>": "<value-2>",
     ...,
@@ -316,74 +309,14 @@ changed.
 ```
 
 To publish a package an HTTP `GET` request for
-`<hosted-url>/api/packages/versions/new` is made. This request returns:
-* `url`: An `<archive-upload-url>` for uploading the package archive.
-* `fields`: A dictionary of form fields required by the storage service for the
-  archive upload.
-* `attestationUrl`: An `<attestation-upload-url>` for uploading a package
-  attestation bundle (such as a Sigstore provenance bundle). Present on
-  repositories that support attestations.
-* `attestationFields`: A dictionary of form fields required by the storage
-  service for the attestation upload. Present if `attestationUrl` is present.
-
-The `attestationUrl` and `attestationFields` properties are returned by
-repositories that support package attestations. If the user requests publishing
-with an attestation and the server response omits `attestationUrl`, the client
-should abort the publication with an informative error message.
-
-### Uploading the Attestation
-
-When publishing with an attestation, the client **MUST** upload the attestation
-bundle to `<attestation-upload-url>` (from `attestationUrl`) **before** uploading
-the package archive to `<archive-upload-url>` (from `url`). This ensures that an
-attestation is never omitted due to partial or interrupted uploads. If not
-publishing with an attestation, this step is skipped.
-
-To upload the attestation bundle, a multi-part `POST` request is made to
-`<attestation-upload-url>` containing all key-value pairs from
-`attestationFields`, along with a `file` part containing the attestation JSON
-bundle:
+`<hosted-url>/api/packages/versions/new` is made. This request returns an
+`<multipart-upload-url>` and a dictionary of fields. To upload the package
+archive a multi-part `POST` request is made to `<multipart-upload-url>` with
+fields and the field `file` containing the gzipped tar archive:
 
 ```http
-POST <path(attestation-upload-url)> HTTP/1.1
-Host: <host(attestation-upload-url)>
-Content-Length: <length>
-Content-Type: multipart/form-data; boundary=<boundary>
-
---<boundary>
-Content-Disposition: form-data; name="<urlencode(field-1)>"
-Content-Type: text/plain; charset=utf-8
-Content-Transfer-Encoding: binary
-
-<value-1>
-...
---<boundary>
-Content-Disposition: form-data; name="<urlencode(field-N)>"
-Content-Type: text/plain; charset=utf-8
-Content-Transfer-Encoding: binary
-
-<value-N>
---<boundary>
-Content-Type: application/json; charset=utf-8
-Content-Disposition: form-data; name="file"; filename="attestation.sigstore.json"
-
-<attestation JSON bundle>
---<boundary>--
-```
-
-The storage service may respond with `HTTP 204 No Content` or `HTTP 200 OK`. The
-client must verify that the request succeeded before proceeding to upload the
-package archive.
-
-### Uploading the Package Archive
-
-To upload the package archive a multi-part `POST` request is made to
-`<archive-upload-url>` containing all key-value pairs from `fields`, along with a
-`file` part containing the gzipped tar archive:
-
-```http
-POST <path(archive-upload-url)> HTTP/1.1
-Host: <host(archive-upload-url)>
+POST <path(multipart-upload-url)> HTTP/1.1
+Host: <host(multipart-upload-url)>
 Content-Length: <length>
 Content-Type: multipart/form-data; boundary=<boundary>
 
@@ -414,7 +347,7 @@ Content-Disposition: form-data; name="file"; filename="package.tar.gz"
 --<boundary>--
 ```
 
-The above `POST` request to `<archive-upload-url>` may respond as follows:
+The above `POST` request to `<multipart-upload-url>` may respond as follows:
 
 ```http
 HTTP/1.1 204 No Content
@@ -425,14 +358,31 @@ or with an HTTP `303 See Other` redirect to `<finalize-upload-url>`.
 
 ### Finalizing the Upload
 
-The client shall then issue a `GET` request to `<finalize-upload-url>`. As with
-`archive_url` the client will only attach an `Authorization` if the
+To finalize the publication, the client issues a request to `<finalize-upload-url>`.
+As with `archive_url` the client will only attach an `Authorization` if the
 `<hosted-url>` is a prefix of `<finalize-upload-url>`.
 
+* When publishing **without** an attestation, the client issues an HTTP `GET`
+  request to `<finalize-upload-url>`.
+* When publishing **with** an attestation (such as a Sigstore provenance bundle),
+  the client issues an HTTP `POST` request to `<finalize-upload-url>` with
+  `Content-Type: application/json` and a JSON payload containing the attestation:
+
+```json
+{
+  "attestation": <attestation JSON bundle>
+}
+```
+
+If a package repository does not support publishing with attestations, it should
+respond with `HTTP 405 Method Not Allowed` to `POST` requests at
+`<finalize-upload-url>`. In response to a `405`, the client aborts with an
+informative error message.
+
 During finalization, the server inspects the uploaded archive, along with any
-accompanying attestation that was uploaded prior to the archive. If an
-attestation was uploaded, the server verifies its validity before accepting
-the publication. An attestation may be rejected as invalid if:
+accompanying attestation sent in the finalize request body. If an attestation is
+present, the server verifies its validity before accepting the publication. An
+attestation may be rejected as invalid if:
  * the JSON bundle is malformed or cannot be parsed as a Sigstore bundle,
  * the cryptographic signature cannot be verified against the trusted root,
  * the artifact digest recorded in the attestation does not match the SHA-256
@@ -445,6 +395,7 @@ If the server wants to accept the uploaded package the server should respond:
 ```http
 HTTP/1.1 200 Ok
 Content-Type: application/vnd.pub.v2+json
+
 {
   "success": {
     "message": "<message>",
@@ -452,12 +403,12 @@ Content-Type: application/vnd.pub.v2+json
 }
 ```
 
-The server is allowed to consider the publishing incomplete until the `GET`
-request for `<finalize-upload-url>` has been issued. Once this request has
-succeeded the package is considered successfully published. If the server has
-caches that need to expire before newly published packages become available,
-or it has other out-of-band approvals that need to be given it's reasonable to
-inform the user about this in the `<message>`.
+The server is allowed to consider the publishing incomplete until the request
+for `<finalize-upload-url>` has been issued. Once this request has succeeded
+the package is considered successfully published. If the server has caches that
+need to expire before newly published packages become available, or it has
+other out-of-band approvals that need to be given it's reasonable to inform the
+user about this in the `<message>`.
 
 If the server does not want to accept the uploaded package, it can respond:
 ```http
@@ -475,12 +426,12 @@ This can be used to forbid git dependencies in published packages, limit the
 archive size, reject invalid attestations, or enforce any other
 repository-specific constraints.
 
-This upload flow allows for archives and attestations to be uploaded directly to
-a signed POST URL for [S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/HTTPPOSTExamples.html),
+This upload flow allows for archives to be uploaded directly to a signed POST
+URL for [S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/HTTPPOSTExamples.html),
 [GCS](https://cloud.google.com/storage/docs/xml-api/post-object-forms) or
-similar blob storage service. Both the `<archive-upload-url>`,
-`<attestation-upload-url>`, and `<finalize-upload-url>` are allowed to contain
-query-string parameters, and all of these URLs need only be temporary.
+similar blob storage service. Both the
+`<multipart-upload-url>` and `<finalize-upload-url>` are allowed to contain
+query-string parameters, and both of these URLs need only be temporary.
 
 
 ## List security advisories for a package

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -78,6 +78,7 @@ class LishCommand extends PubCommand {
 
   late final String? _fromArchive = argResults.option('from-archive');
   late final String? _toArchive = argResults.option('to-archive');
+  late final String? _withAttestation = argResults.option('with-attestation');
 
   LishCommand() {
     argParser.addFlag(
@@ -118,6 +119,14 @@ class LishCommand extends PubCommand {
       valueHelp: '[archive.tar.gz]',
       hide: true,
     );
+    argParser.addOption(
+      'with-attestation',
+      help:
+          'The path to a Sigstore attestation bundle JSON file to upload '
+          'with the package archive.',
+      valueHelp: '[attestation.sigstore.json]',
+      hide: true,
+    );
 
     argParser.addOption(
       'directory',
@@ -135,8 +144,9 @@ class LishCommand extends PubCommand {
   Future<void> _publishUsingClient(
     List<int> packageBytes,
     http.Client client,
-    Uri host,
-  ) async {
+    Uri host, {
+    Uint8List? attestationBytes,
+  }) async {
     Uri? cloudStorageUrl;
 
     try {
@@ -185,7 +195,32 @@ class LishCommand extends PubCommand {
                 filename: 'package.tar.gz',
               ),
             );
-            return await client.fetch(request);
+            final response = await client.fetch(request);
+
+            if (attestationBytes != null) {
+              final baseKey = fields['key'] as String?;
+              final attestationFields = Map<String, String>.from(
+                request.fields,
+              );
+              if (baseKey != null) {
+                attestationFields['key'] = '$baseKey.sigstore.json';
+              }
+              attestationFields.remove('success_action_redirect');
+              final attRequest =
+                  http.MultipartRequest('POST', cloudStorageUrl!)
+                    ..fields.addAll(attestationFields)
+                    ..files.add(
+                      http.MultipartFile.fromBytes(
+                        'file',
+                        attestationBytes,
+                        filename: 'attestation.sigstore.json',
+                      ),
+                    )
+                    ..followRedirects = false;
+              await client.fetch(attRequest);
+            }
+
+            return response;
           },
         );
 
@@ -233,7 +268,11 @@ class LishCommand extends PubCommand {
     }
   }
 
-  Future<void> _publish(List<int> packageBytes, Uri host) async {
+  Future<void> _publish(
+    List<int> packageBytes,
+    Uri host, {
+    Uint8List? attestationBytes,
+  }) async {
     try {
       final officialPubServers = {
         'https://pub.dev',
@@ -261,12 +300,22 @@ class LishCommand extends PubCommand {
         // This allows us to use `dart pub token add` to inject a token for use
         // with the official servers.
         await oauth2.withClient((client) {
-          return _publishUsingClient(packageBytes, client, host);
+          return _publishUsingClient(
+            packageBytes,
+            client,
+            host,
+            attestationBytes: attestationBytes,
+          );
         });
       } else {
         // For third party servers using bearer authentication client
         await withAuthenticatedClient(cache, host, (client) {
-          return _publishUsingClient(packageBytes, client, host);
+          return _publishUsingClient(
+            packageBytes,
+            client,
+            host,
+            attestationBytes: attestationBytes,
+          );
         });
       }
     } on PubHttpResponseException catch (error) {
@@ -302,6 +351,10 @@ the \$PUB_HOSTED_URL environment variable.''');
 
     if (_toArchive != null && force) {
       usageException('Cannot use both --to-archive and --force.');
+    if (_withAttestation != null && _fromArchive == null) {
+      usageException(
+        '`--with-attestation` can only be used with `--from-archive`.',
+      );
     }
 
     if (argResults.wasParsed('ignore-warnings') && !dryRun) {
@@ -418,12 +471,29 @@ the \$PUB_HOSTED_URL environment variable.''');
       );
     }
     final host = computeHost(pubspec);
+    Uint8List? attestationBytes;
+    if (_withAttestation != null) {
+      final repository = pubspec.fields['repository']?.toString();
+      if (repository == null || !repository.contains('github.com')) {
+        dataError(
+          'A GitHub repository must be specified in the "repository" field of '
+          'pubspec.yaml when publishing with an attestation.',
+        );
+      }
+      try {
+        attestationBytes = readBinaryFile(_withAttestation);
+      } on FileSystemException catch (e) {
+        dataError('Failed reading attestation file "$_withAttestation": $e');
+      }
+    }
+
     log.message('Publishing ${pubspec.name} ${pubspec.version} to $host.');
     return _Publication(
       packageBytes: packageBytes,
       warningCount: 0,
       hintCount: 0,
       pubspec: pubspec,
+      attestationBytes: attestationBytes,
     );
   }
 
@@ -508,7 +578,11 @@ the \$PUB_HOSTED_URL environment variable.''');
       final host = computeHost(publication.pubspec);
       await _confirmUpload(publication, host);
 
-      await _publish(publication.packageBytes, host);
+      await _publish(
+        publication.packageBytes,
+        host,
+        attestationBytes: publication.attestationBytes,
+      );
     } else {
       if (dryRun) {
         log.message('Would have written to $_toArchive.');
@@ -541,6 +615,7 @@ class _Publication {
   int hintCount;
 
   Pubspec pubspec;
+  Uint8List? attestationBytes;
 
   String get warningsCountMessage {
     final hintText =
@@ -554,5 +629,6 @@ class _Publication {
     required this.warningCount,
     required this.hintCount,
     required this.pubspec,
+    this.attestationBytes,
   });
 }

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -188,30 +188,27 @@ class LishCommand extends PubCommand {
             invalidServerResponse(parametersResponse);
           }
 
-          await retryForHttp(
-            'uploading attestation',
-            () async {
-              final attRequest = http.MultipartRequest(
-                'POST',
-                attestationStorageUrl,
-              );
-              attestationFields.forEach((key, value) {
-                if (value is! String) invalidServerResponse(parametersResponse);
-                attRequest.fields[key as String] = value;
-              });
-              attRequest.files.add(
-                http.MultipartFile.fromBytes(
-                  'file',
-                  attestationBytes,
-                  filename: 'attestation.sigstore.json',
-                ),
-              );
-              attRequest.followRedirects = false;
-              final attResponse = await client.fetch(attRequest);
-              attResponse.throwIfNotOk();
-              return attResponse;
-            },
-          );
+          await retryForHttp('uploading attestation', () async {
+            final attRequest = http.MultipartRequest(
+              'POST',
+              attestationStorageUrl,
+            );
+            attestationFields.forEach((key, value) {
+              if (value is! String) invalidServerResponse(parametersResponse);
+              attRequest.fields[key as String] = value;
+            });
+            attRequest.files.add(
+              http.MultipartFile.fromBytes(
+                'file',
+                attestationBytes,
+                filename: 'attestation.sigstore.json',
+              ),
+            );
+            attRequest.followRedirects = false;
+            final attResponse = await client.fetch(attRequest);
+            attResponse.throwIfNotOk();
+            return attResponse;
+          });
         }
 
         /// 3. Upload package
@@ -244,8 +241,7 @@ class LishCommand extends PubCommand {
                 filename: 'package.tar.gz',
               ),
             );
-            final response = await client.fetch(request);
-            return response;
+            return await client.fetch(request);
           },
         );
 
@@ -501,10 +497,17 @@ the \$PUB_HOSTED_URL environment variable.''');
     Uint8List? attestationBytes;
     if (_withAttestation != null) {
       final repository = pubspec.fields['repository']?.toString();
-      if (repository == null || !repository.contains('github.com')) {
+      if (repository == null) {
         dataError(
           'A GitHub repository must be specified in the "repository" field of '
           'pubspec.yaml when publishing with an attestation.',
+        );
+      }
+      if (!repository.contains('github.com')) {
+        dataError(
+          'A GitHub repository must be specified in the "repository" field of '
+          'pubspec.yaml when publishing with an attestation. The repository '
+          '"$repository" is not a GitHub repository.',
         );
       }
       try {
@@ -638,11 +641,11 @@ the \$PUB_HOSTED_URL environment variable.''');
 
 class _Publication {
   Uint8List packageBytes;
+  Uint8List? attestationBytes;
   int warningCount;
   int hintCount;
 
   Pubspec pubspec;
-  Uint8List? attestationBytes;
 
   String get warningsCountMessage {
     final hintText =

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -165,7 +165,56 @@ class LishCommand extends PubCommand {
         );
         final parameters = parseJsonResponse(parametersResponse);
 
-        /// 2. Upload package
+        /// 2. Upload attestation (if provided)
+        if (attestationBytes != null) {
+          final attestationUrl = parameters['attestationUrl'];
+          if (attestationUrl == null) {
+            dataError(
+              'The package repository $host does not support uploading '
+              'package attestations.',
+            );
+          }
+          if (attestationUrl is! String) {
+            invalidServerResponse(parametersResponse);
+          }
+          final attestationStorageUrl = Uri.parse(attestationUrl);
+
+          final attestationFields = _expectField(
+            parameters,
+            'attestationFields',
+            parametersResponse,
+          );
+          if (attestationFields is! Map) {
+            invalidServerResponse(parametersResponse);
+          }
+
+          await retryForHttp(
+            'uploading attestation',
+            () async {
+              final attRequest = http.MultipartRequest(
+                'POST',
+                attestationStorageUrl,
+              );
+              attestationFields.forEach((key, value) {
+                if (value is! String) invalidServerResponse(parametersResponse);
+                attRequest.fields[key as String] = value;
+              });
+              attRequest.files.add(
+                http.MultipartFile.fromBytes(
+                  'file',
+                  attestationBytes,
+                  filename: 'attestation.sigstore.json',
+                ),
+              );
+              attRequest.followRedirects = false;
+              final attResponse = await client.fetch(attRequest);
+              attResponse.throwIfNotOk();
+              return attResponse;
+            },
+          );
+        }
+
+        /// 3. Upload package
         final url = _expectField(parameters, 'url', parametersResponse);
         if (url is! String) invalidServerResponse(parametersResponse);
         cloudStorageUrl = Uri.parse(url);
@@ -186,37 +235,6 @@ class LishCommand extends PubCommand {
               if (value is! String) invalidServerResponse(parametersResponse);
               request.fields[key as String] = value;
             });
-
-            if (attestationBytes != null) {
-              // Upload the Sigstore attestation bundle alongside the package
-              // archive using the same signed Cloud Storage upload credentials.
-              // We store it at `<baseKey>.sigstore.json` so the backend can
-              // correlate it with the package archive during finalization.
-              final baseKey = fields['key'] as String?;
-              final attestationFields = Map<String, String>.from(
-                request.fields,
-              );
-              if (baseKey != null) {
-                attestationFields['key'] = '$baseKey.sigstore.json';
-              }
-              // Remove `success_action_redirect` so Cloud Storage does not
-              // issue a 303 redirect to the finalization URL prematurely. Only
-              // the subsequent package archive upload triggers the finalization
-              // redirect.
-              attestationFields.remove('success_action_redirect');
-              final attRequest =
-                  http.MultipartRequest('POST', cloudStorageUrl!)
-                    ..fields.addAll(attestationFields)
-                    ..files.add(
-                      http.MultipartFile.fromBytes(
-                        'file',
-                        attestationBytes,
-                        filename: 'attestation.sigstore.json',
-                      ),
-                    )
-                    ..followRedirects = false;
-              await client.fetch(attRequest);
-            }
 
             request.followRedirects = false;
             request.files.add(

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -187,17 +187,11 @@ class LishCommand extends PubCommand {
               request.fields[key as String] = value;
             });
 
-            request.followRedirects = false;
-            request.files.add(
-              http.MultipartFile.fromBytes(
-                'file',
-                packageBytes,
-                filename: 'package.tar.gz',
-              ),
-            );
-            final response = await client.fetch(request);
-
             if (attestationBytes != null) {
+              // Upload the Sigstore attestation bundle alongside the package
+              // archive using the same signed Cloud Storage upload credentials.
+              // We store it at `<baseKey>.sigstore.json` so the backend can
+              // correlate it with the package archive during finalization.
               final baseKey = fields['key'] as String?;
               final attestationFields = Map<String, String>.from(
                 request.fields,
@@ -205,6 +199,10 @@ class LishCommand extends PubCommand {
               if (baseKey != null) {
                 attestationFields['key'] = '$baseKey.sigstore.json';
               }
+              // Remove `success_action_redirect` so Cloud Storage does not
+              // issue a 303 redirect to the finalization URL prematurely. Only
+              // the subsequent package archive upload triggers the finalization
+              // redirect.
               attestationFields.remove('success_action_redirect');
               final attRequest =
                   http.MultipartRequest('POST', cloudStorageUrl!)
@@ -220,6 +218,15 @@ class LishCommand extends PubCommand {
               await client.fetch(attRequest);
             }
 
+            request.followRedirects = false;
+            request.files.add(
+              http.MultipartFile.fromBytes(
+                'file',
+                packageBytes,
+                filename: 'package.tar.gz',
+              ),
+            );
+            final response = await client.fetch(request);
             return response;
           },
         );
@@ -351,6 +358,8 @@ the \$PUB_HOSTED_URL environment variable.''');
 
     if (_toArchive != null && force) {
       usageException('Cannot use both --to-archive and --force.');
+    }
+
     if (_withAttestation != null && _fromArchive == null) {
       usageException(
         '`--with-attestation` can only be used with `--from-archive`.',

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -165,53 +165,7 @@ class LishCommand extends PubCommand {
         );
         final parameters = parseJsonResponse(parametersResponse);
 
-        /// 2. Upload attestation (if provided)
-        if (attestationBytes != null) {
-          final attestationUrl = parameters['attestationUrl'];
-          if (attestationUrl == null) {
-            dataError(
-              'The package repository $host does not support uploading '
-              'package attestations.',
-            );
-          }
-          if (attestationUrl is! String) {
-            invalidServerResponse(parametersResponse);
-          }
-          final attestationStorageUrl = Uri.parse(attestationUrl);
-
-          final attestationFields = _expectField(
-            parameters,
-            'attestationFields',
-            parametersResponse,
-          );
-          if (attestationFields is! Map) {
-            invalidServerResponse(parametersResponse);
-          }
-
-          await retryForHttp('uploading attestation', () async {
-            final attRequest = http.MultipartRequest(
-              'POST',
-              attestationStorageUrl,
-            );
-            attestationFields.forEach((key, value) {
-              if (value is! String) invalidServerResponse(parametersResponse);
-              attRequest.fields[key as String] = value;
-            });
-            attRequest.files.add(
-              http.MultipartFile.fromBytes(
-                'file',
-                attestationBytes,
-                filename: 'attestation.sigstore.json',
-              ),
-            );
-            attRequest.followRedirects = false;
-            final attResponse = await client.fetch(attRequest);
-            attResponse.throwIfNotOk();
-            return attResponse;
-          });
-        }
-
-        /// 3. Upload package
+        /// 2. Upload package
         final url = _expectField(parameters, 'url', parametersResponse);
         if (url is! String) invalidServerResponse(parametersResponse);
         cloudStorageUrl = Uri.parse(url);
@@ -251,8 +205,18 @@ class LishCommand extends PubCommand {
         final finalizeResponse = await retryForHttp(
           'finalizing publish',
           () async {
-            final request = http.Request('GET', Uri.parse(location));
+            final request = http.Request(
+              attestationBytes != null ? 'POST' : 'GET',
+              Uri.parse(location),
+            );
             request.attachPubApiHeaders();
+            if (attestationBytes != null) {
+              request.headers[HttpHeaders.contentTypeHeader] =
+                  'application/json';
+              request.body = jsonEncode({
+                'attestation': jsonDecode(utf8.decode(attestationBytes)),
+              });
+            }
             return await client.fetch(request);
           },
         );
@@ -281,6 +245,11 @@ class LishCommand extends PubCommand {
       if (url == cloudStorageUrl) {
         handleGCSError(error.response);
         fail(log.red('Failed to upload the package.'));
+      } else if (error.response.statusCode == 405 && attestationBytes != null) {
+        dataError(
+          'The package repository $host does not support publishing '
+          'with attestations.',
+        );
       } else if (Uri.parse(url.origin) == Uri.parse(host.origin)) {
         handleJsonError(error.response);
       } else {
@@ -514,6 +483,21 @@ the \$PUB_HOSTED_URL environment variable.''');
         attestationBytes = readBinaryFile(_withAttestation);
       } on FileSystemException catch (e) {
         dataError('Failed reading attestation file "$_withAttestation": $e');
+      }
+      if (attestationBytes.isEmpty) {
+        dataError('The attestation file "$_withAttestation" is empty.');
+      }
+      try {
+        final decoded = jsonDecode(utf8.decode(attestationBytes));
+        if (decoded is! Map<String, dynamic>) {
+          dataError(
+            'The attestation file "$_withAttestation" must contain a JSON object.',
+          );
+        }
+      } on FormatException catch (e) {
+        dataError(
+          'The attestation file "$_withAttestation" is not valid JSON: ${e.message}',
+        );
       }
     }
 

--- a/lib/src/command/lish.dart
+++ b/lib/src/command/lish.dart
@@ -466,17 +466,10 @@ the \$PUB_HOSTED_URL environment variable.''');
     Uint8List? attestationBytes;
     if (_withAttestation != null) {
       final repository = pubspec.fields['repository']?.toString();
-      if (repository == null) {
+      if (repository == null || repository.trim().isEmpty) {
         dataError(
-          'A GitHub repository must be specified in the "repository" field of '
+          'A repository must be specified in the "repository" field of '
           'pubspec.yaml when publishing with an attestation.',
-        );
-      }
-      if (!repository.contains('github.com')) {
-        dataError(
-          'A GitHub repository must be specified in the "repository" field of '
-          'pubspec.yaml when publishing with an attestation. The repository '
-          '"$repository" is not a GitHub repository.',
         );
       }
       try {

--- a/test/lish/publishing_to_and_from_archive_test.dart
+++ b/test/lish/publishing_to_and_from_archive_test.dart
@@ -71,4 +71,104 @@ void main() {
     expect(File(d.path('archive.tar.gz')).existsSync(), isTrue);
     await runPub(args: ['cache', 'preload', p.join('..', 'archive.tar.gz')]);
   });
+
+  test('Can publish from archive with attestation bundle', () async {
+    final server = await servePackages();
+    await d
+        .validPackage(
+          pubspecExtras: {
+            'repository': 'https://github.com/dart-lang/test_pkg',
+          },
+        )
+        .create();
+    await d.credentialsFile(server, 'access-token').create();
+    await runPub(
+      args: ['lish', '--to-archive', p.join('..', 'archive.tar.gz')],
+    );
+
+    final bundlePath = p.join(d.sandbox, 'bundle.sigstore.json');
+    File(bundlePath).writeAsStringSync('{"mediaType": "sigstore"}');
+
+    server.expect('GET', '/create', (request) {
+      return Response.ok(
+        jsonEncode({
+          'success': {
+            'message': 'Package test_pkg 1.0.0 with attestation uploaded!',
+          },
+        }),
+      );
+    });
+
+    final pub = await startPublish(
+      server,
+      args: [
+        '--from-archive',
+        'archive.tar.gz',
+        '--with-attestation',
+        bundlePath,
+      ],
+      workingDirectory: d.sandbox,
+    );
+
+    expect(pub.stdout, emitsThrough('Publishing from archive: archive.tar.gz'));
+    await confirmPublish(pub);
+
+    handleUploadForm(server);
+    server.handle('/upload', (request) async {
+      await request.read().drain<void>();
+      return Response.found(Uri.parse(server.url).resolve('/create'));
+    });
+
+    expect(pub.stdout, emitsThrough(startsWith('Uploading...')));
+    expect(
+      pub.stdout,
+      emits(
+        'Message from server: '
+        'Package test_pkg 1.0.0 with attestation uploaded!',
+      ),
+    );
+    await pub.shouldExit(SUCCESS);
+  });
+
+  test(
+    'Fails when publishing with attestation without github repo in pubspec',
+    () async {
+      await d.validPackage().create();
+      await runPub(
+        args: ['lish', '--to-archive', p.join('..', 'archive.tar.gz')],
+      );
+
+      final bundlePath = p.join(d.sandbox, 'bundle.sigstore.json');
+      File(bundlePath).writeAsStringSync('{}');
+
+      await runPub(
+        args: [
+          'lish',
+          '--from-archive',
+          p.join(d.sandbox, 'archive.tar.gz'),
+          '--with-attestation',
+          bundlePath,
+        ],
+        error: contains(
+          'A GitHub repository must be specified in the "repository" field',
+        ),
+        exitCode: DATA,
+        workingDirectory: d.sandbox,
+      );
+    },
+  );
+
+  test(
+    'Fails when --with-attestation is used without --from-archive',
+    () async {
+      await d.validPackage().create();
+      await runPub(
+        args: ['lish', '--with-attestation', 'bundle.json'],
+        error: contains(
+          '`--with-attestation` can only be used with `--from-archive`.',
+        ),
+        exitCode: USAGE,
+      );
+    },
+  );
 }

--- a/test/lish/publishing_to_and_from_archive_test.dart
+++ b/test/lish/publishing_to_and_from_archive_test.dart
@@ -113,7 +113,11 @@ void main() {
     expect(pub.stdout, emitsThrough('Publishing from archive: archive.tar.gz'));
     await confirmPublish(pub);
 
-    handleUploadForm(server);
+    handleUploadForm(server, withAttestation: true);
+    server.handle('/upload-attestation', (request) async {
+      await request.read().drain<void>();
+      return Response(204);
+    });
     server.handle('/upload', (request) async {
       await request.read().drain<void>();
       return Response.found(Uri.parse(server.url).resolve('/create'));
@@ -129,6 +133,58 @@ void main() {
     );
     await pub.shouldExit(SUCCESS);
   });
+
+  test(
+    'Fails when publishing with attestation to a server that does not '
+    'support it',
+    () async {
+      final server = await servePackages();
+      await d
+          .validPackage(
+            pubspecExtras: {
+              'repository': 'https://github.com/dart-lang/test_pkg',
+            },
+          )
+          .create();
+      await d.credentialsFile(server, 'access-token').create();
+      await runPub(
+        args: ['lish', '--to-archive', p.join('..', 'archive.tar.gz')],
+      );
+
+      final bundlePath = p.join(d.sandbox, 'bundle.sigstore.json');
+      File(bundlePath).writeAsStringSync('{"mediaType": "sigstore"}');
+
+      final pub = await startPublish(
+        server,
+        args: [
+          '--from-archive',
+          'archive.tar.gz',
+          '--with-attestation',
+          bundlePath,
+        ],
+        workingDirectory: d.sandbox,
+      );
+
+      expect(
+        pub.stdout,
+        emitsThrough('Publishing from archive: archive.tar.gz'),
+      );
+      await confirmPublish(pub);
+
+      handleUploadForm(server);
+
+      expect(pub.stdout, emitsThrough(startsWith('Uploading...')));
+      await pub.shouldExit(DATA);
+      expect(
+        pub.stderr,
+        emitsThrough(
+          contains(
+            'does not support uploading package attestations',
+          ),
+        ),
+      );
+    },
+  );
 
   test(
     'Fails when publishing with attestation without github repo in pubspec',

--- a/test/lish/publishing_to_and_from_archive_test.dart
+++ b/test/lish/publishing_to_and_from_archive_test.dart
@@ -83,13 +83,22 @@ void main() {
         .create();
     await d.credentialsFile(server, 'access-token').create();
     await runPub(
-      args: ['lish', '--to-archive', p.join('..', 'archive.tar.gz')],
+      args: [
+        'lish',
+        '--skip-validation',
+        '--to-archive',
+        p.join('..', 'archive.tar.gz'),
+      ],
     );
 
+    final bundleContent = '{"mediaType": "sigstore"}';
     final bundlePath = p.join(d.sandbox, 'bundle.sigstore.json');
-    File(bundlePath).writeAsStringSync('{"mediaType": "sigstore"}');
+    File(bundlePath).writeAsStringSync(bundleContent);
 
-    server.expect('GET', '/create', (request) {
+    server.expect('POST', '/create', (request) async {
+      expect(request.headers['content-type'], startsWith('application/json'));
+      final body = jsonDecode(await request.readAsString());
+      expect(body, {'attestation': jsonDecode(bundleContent)});
       return Response.ok(
         jsonEncode({
           'success': {
@@ -113,11 +122,7 @@ void main() {
     expect(pub.stdout, emitsThrough('Publishing from archive: archive.tar.gz'));
     await confirmPublish(pub);
 
-    handleUploadForm(server, withAttestation: true);
-    server.handle('/upload-attestation', (request) async {
-      await request.read().drain<void>();
-      return Response(204);
-    });
+    handleUploadForm(server);
     server.handle('/upload', (request) async {
       await request.read().drain<void>();
       return Response.found(Uri.parse(server.url).resolve('/create'));
@@ -134,64 +139,72 @@ void main() {
     await pub.shouldExit(SUCCESS);
   });
 
-  test(
-    'Fails when publishing with attestation to a server that does not '
-    'support it',
-    () async {
-      final server = await servePackages();
-      await d
-          .validPackage(
-            pubspecExtras: {
-              'repository': 'https://github.com/dart-lang/test_pkg',
-            },
-          )
-          .create();
-      await d.credentialsFile(server, 'access-token').create();
-      await runPub(
-        args: ['lish', '--to-archive', p.join('..', 'archive.tar.gz')],
-      );
+  test('Fails when publishing with attestation to a server that does not '
+      'support it', () async {
+    final server = await servePackages();
+    await d
+        .validPackage(
+          pubspecExtras: {
+            'repository': 'https://github.com/dart-lang/test_pkg',
+          },
+        )
+        .create();
+    await d.credentialsFile(server, 'access-token').create();
+    await runPub(
+      args: [
+        'lish',
+        '--skip-validation',
+        '--to-archive',
+        p.join('..', 'archive.tar.gz'),
+      ],
+    );
 
-      final bundlePath = p.join(d.sandbox, 'bundle.sigstore.json');
-      File(bundlePath).writeAsStringSync('{"mediaType": "sigstore"}');
+    final bundlePath = p.join(d.sandbox, 'bundle.sigstore.json');
+    File(bundlePath).writeAsStringSync('{"mediaType": "sigstore"}');
 
-      final pub = await startPublish(
-        server,
-        args: [
-          '--from-archive',
-          'archive.tar.gz',
-          '--with-attestation',
-          bundlePath,
-        ],
-        workingDirectory: d.sandbox,
-      );
+    server.expect('POST', '/create', (request) {
+      return Response(405);
+    });
 
-      expect(
-        pub.stdout,
-        emitsThrough('Publishing from archive: archive.tar.gz'),
-      );
-      await confirmPublish(pub);
+    final pub = await startPublish(
+      server,
+      args: [
+        '--from-archive',
+        'archive.tar.gz',
+        '--with-attestation',
+        bundlePath,
+      ],
+      workingDirectory: d.sandbox,
+    );
 
-      handleUploadForm(server);
+    expect(pub.stdout, emitsThrough('Publishing from archive: archive.tar.gz'));
+    await confirmPublish(pub);
 
-      expect(pub.stdout, emitsThrough(startsWith('Uploading...')));
-      await pub.shouldExit(DATA);
-      expect(
-        pub.stderr,
-        emitsThrough(
-          contains(
-            'does not support uploading package attestations',
-          ),
-        ),
-      );
-    },
-  );
+    handleUploadForm(server);
+    server.handle('/upload', (request) async {
+      await request.read().drain<void>();
+      return Response.found(Uri.parse(server.url).resolve('/create'));
+    });
+
+    expect(pub.stdout, emitsThrough(startsWith('Uploading...')));
+    await pub.shouldExit(DATA);
+    expect(
+      pub.stderr,
+      emitsThrough(contains('does not support publishing with attestations')),
+    );
+  });
 
   test(
     'Fails when publishing with attestation without github repo in pubspec',
     () async {
       await d.validPackage().create();
       await runPub(
-        args: ['lish', '--to-archive', p.join('..', 'archive.tar.gz')],
+        args: [
+          'lish',
+          '--skip-validation',
+          '--to-archive',
+          p.join('..', 'archive.tar.gz'),
+        ],
       );
 
       final bundlePath = p.join(d.sandbox, 'bundle.sigstore.json');
@@ -227,4 +240,106 @@ void main() {
       );
     },
   );
+
+  test('Fails when attestation file is empty', () async {
+    await d
+        .validPackage(
+          pubspecExtras: {
+            'repository': 'https://github.com/dart-lang/test_pkg',
+          },
+        )
+        .create();
+    await runPub(
+      args: [
+        'lish',
+        '--skip-validation',
+        '--to-archive',
+        p.join('..', 'archive.tar.gz'),
+      ],
+    );
+
+    final bundlePath = p.join(d.sandbox, 'bundle.sigstore.json');
+    File(bundlePath).writeAsStringSync('');
+
+    await runPub(
+      args: [
+        'lish',
+        '--from-archive',
+        p.join(d.sandbox, 'archive.tar.gz'),
+        '--with-attestation',
+        bundlePath,
+      ],
+      error: contains('The attestation file "$bundlePath" is empty.'),
+      exitCode: DATA,
+      workingDirectory: d.sandbox,
+    );
+  });
+
+  test('Fails when attestation file is not valid JSON', () async {
+    await d
+        .validPackage(
+          pubspecExtras: {
+            'repository': 'https://github.com/dart-lang/test_pkg',
+          },
+        )
+        .create();
+    await runPub(
+      args: [
+        'lish',
+        '--skip-validation',
+        '--to-archive',
+        p.join('..', 'archive.tar.gz'),
+      ],
+    );
+
+    final bundlePath = p.join(d.sandbox, 'bundle.sigstore.json');
+    File(bundlePath).writeAsStringSync('not-json');
+
+    await runPub(
+      args: [
+        'lish',
+        '--from-archive',
+        p.join(d.sandbox, 'archive.tar.gz'),
+        '--with-attestation',
+        bundlePath,
+      ],
+      error: contains('is not valid JSON:'),
+      exitCode: DATA,
+      workingDirectory: d.sandbox,
+    );
+  });
+
+  test('Fails when attestation file is not a JSON object', () async {
+    await d
+        .validPackage(
+          pubspecExtras: {
+            'repository': 'https://github.com/dart-lang/test_pkg',
+          },
+        )
+        .create();
+    await runPub(
+      args: [
+        'lish',
+        '--skip-validation',
+        '--to-archive',
+        p.join('..', 'archive.tar.gz'),
+      ],
+    );
+
+    final bundlePath = p.join(d.sandbox, 'bundle.sigstore.json');
+    File(bundlePath).writeAsStringSync('["not", "a", "map"]');
+
+    await runPub(
+      args: [
+        'lish',
+        '--from-archive',
+        p.join(d.sandbox, 'archive.tar.gz'),
+        '--with-attestation',
+        bundlePath,
+      ],
+      error: contains('must contain a JSON object.'),
+      exitCode: DATA,
+      workingDirectory: d.sandbox,
+    );
+  });
 }

--- a/test/lish/publishing_to_and_from_archive_test.dart
+++ b/test/lish/publishing_to_and_from_archive_test.dart
@@ -195,7 +195,7 @@ void main() {
   });
 
   test(
-    'Fails when publishing with attestation without github repo in pubspec',
+    'Fails when publishing with attestation without repository in pubspec',
     () async {
       await d.validPackage().create();
       await runPub(
@@ -219,11 +219,74 @@ void main() {
           bundlePath,
         ],
         error: contains(
-          'A GitHub repository must be specified in the "repository" field',
+          'A repository must be specified in the "repository" field',
         ),
         exitCode: DATA,
         workingDirectory: d.sandbox,
       );
+    },
+  );
+
+  test(
+    'Allows publishing from archive with attestation and non-GitHub repository',
+    () async {
+      final server = await servePackages();
+      await d
+          .validPackage(
+            pubspecExtras: {
+              'repository': 'https://gitlab.com/dart-lang/test_pkg',
+            },
+          )
+          .create();
+      await d.credentialsFile(server, 'access-token').create();
+      await runPub(
+        args: [
+          'lish',
+          '--skip-validation',
+          '--to-archive',
+          p.join('..', 'archive.tar.gz'),
+        ],
+      );
+
+      final bundleContent = '{"mediaType": "sigstore"}';
+      final bundlePath = p.join(d.sandbox, 'bundle.sigstore.json');
+      File(bundlePath).writeAsStringSync(bundleContent);
+
+      server.expect('POST', '/create', (request) async {
+        return Response.ok(
+          jsonEncode({
+            'success': {
+              'message': 'Package test_pkg 1.0.0 with attestation uploaded!',
+            },
+          }),
+        );
+      });
+
+      final pub = await startPublish(
+        server,
+        args: [
+          '--from-archive',
+          'archive.tar.gz',
+          '--with-attestation',
+          bundlePath,
+        ],
+        workingDirectory: d.sandbox,
+      );
+
+      expect(
+        pub.stdout,
+        emitsThrough('Publishing from archive: archive.tar.gz'),
+      );
+      await confirmPublish(pub);
+
+      handleUploadForm(server);
+      server.handle('/upload', (request) async {
+        await request.read().drain<void>();
+        return Response.found(Uri.parse(server.url).resolve('/create'));
+      });
+
+      expect(pub.stdout, emitsThrough(startsWith('Uploading...')));
+      await pub.shouldExit(SUCCESS);
     },
   );
 

--- a/test/lish/utils.dart
+++ b/test/lish/utils.dart
@@ -9,7 +9,12 @@ import 'package:test/test.dart';
 
 import '../test_pub.dart';
 
-void handleUploadForm(PackageServer server, {Map? body, String path = ''}) {
+void handleUploadForm(
+  PackageServer server, {
+  Map? body,
+  String path = '',
+  bool withAttestation = false,
+}) {
   server.expect('GET', '$path/api/packages/versions/new', (request) {
     expect(
       request.headers,
@@ -19,6 +24,11 @@ void handleUploadForm(PackageServer server, {Map? body, String path = ''}) {
     body ??= {
       'url': Uri.parse(server.url).resolve('/upload').toString(),
       'fields': {'field1': 'value1', 'field2': 'value2'},
+      if (withAttestation) ...{
+        'attestationUrl':
+            Uri.parse(server.url).resolve('/upload-attestation').toString(),
+        'attestationFields': {'field1': 'value1', 'field2': 'value2'},
+      },
     };
 
     return shelf.Response.ok(

--- a/test/lish/utils.dart
+++ b/test/lish/utils.dart
@@ -9,12 +9,7 @@ import 'package:test/test.dart';
 
 import '../test_pub.dart';
 
-void handleUploadForm(
-  PackageServer server, {
-  Map? body,
-  String path = '',
-  bool withAttestation = false,
-}) {
+void handleUploadForm(PackageServer server, {Map? body, String path = ''}) {
   server.expect('GET', '$path/api/packages/versions/new', (request) {
     expect(
       request.headers,
@@ -24,11 +19,6 @@ void handleUploadForm(
     body ??= {
       'url': Uri.parse(server.url).resolve('/upload').toString(),
       'fields': {'field1': 'value1', 'field2': 'value2'},
-      if (withAttestation) ...{
-        'attestationUrl':
-            Uri.parse(server.url).resolve('/upload-attestation').toString(),
-        'attestationFields': {'field1': 'value1', 'field2': 'value2'},
-      },
     };
 
     return shelf.Response.ok(


### PR DESCRIPTION
Adds client support for publishing package attestations during `pub publish`:

- Adds `--with-attestation <bundle.sigstore.json>` flag to `dart pub publish --from-archive`.
- Enforces that a repository is specified in `pubspec.yaml` (`repository` field) when publishing with an attestation.
- Validates that `--with-attestation` can only be used with `--from-archive`, and that the file is non-empty and contains a JSON object, before asking the user to confirm the publication.
- Adds unit tests in `test/lish/publishing_to_and_from_archive_test.dart`.

### Protocol

`doc/repository-spec-v2.md` gets a new *Publishing with an Attestation* section:

- A repository that supports publishing with attestations returns an `<attestation-upload-url>` in the `attestationUrl` property of the response from `<hosted-url>/api/packages/versions/new`. A repository that does not support it simply omits the property.
- The client `POST`s the bundle as `application/json` to `<attestation-upload-url>` **before** uploading the package archive, attaching `Authorization` under the same prefix rule as `archive_url`.
- `<finalize-upload-url>` remains a plain `GET`.

`attestationUrl` is an opaque URL: a repository may point it at its own endpoint or at a signed URL on a storage service. On pub.dev it is an endpoint on the app server, so no second signed upload policy is needed (see dart-lang/pub-dev#9545).

The alternative considered was to `POST` the attestation to `<finalize-upload-url>` and use `405 Method Not Allowed` for feature detection. A separate URL was chosen because:

- the client learns that a repository cannot take attestations *before* uploading the archive, instead of after; a missing JSON property is also a more reliable signal than `405`, which proxies and frameworks do not produce consistently, and
- the spec keeps one method per URL. This matters here because the archive upload is allowed to answer with `303 See Other` pointing at `<finalize-upload-url>`, and a `303` is followed with a `GET` — any client that simply follows the redirect would drop the attestation body.

Server side: dart-lang/pub-dev#9545
