### PR TITLE
Disallow symlinks in extractTarGz and harden archive extraction against path traversal

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -1175,48 +1175,84 @@ Future<Uint8List> extractFileFromTarGz(
   throw FormatException('Could not find $filename in archive');
 }
 
+/// Regex matching Windows reserved DOS device names: CON, PRN, AUX, NUL,
+/// COM1-9, LPT1-9 (case-insensitive, with any extension).
+final _windowsDeviceName = RegExp(
+  r'^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$',
+  caseSensitive: false,
+);
+
 /// Extracts a `.tar.gz` file from [stream] to [destination].
+///
+/// Only regular files and directories are extracted; symlinks, hardlinks, and
+/// special files are safely ignored.
 Future<void> extractTarGz(Stream<List<int>> stream, String destination) async {
   log.fine('Extracting .tar.gz stream to $destination.');
 
-  destination = p.absolute(destination);
+  destination = p.normalize(p.absolute(destination));
   final reader = TarReader(stream.transform(gzipDecoder));
   final paths = <String>{};
+  final normalizedPaths = <String>{};
+  final isCaseInsensitive = platform.isWindows || platform.isMacOS;
+
   while (await reader.moveNext()) {
     final entry = reader.current;
 
-    final filePath = p.normalize(
-      p.joinAll([
-        destination,
-        // Tar file names always use forward slashes
-        ...p.posix.split(entry.name),
-      ]),
-    );
-    if (!paths.add(filePath)) {
-      // The tar file contained the same entry twice. Assume it is broken.
+    // Reject illegal characters (backslashes, colons, null bytes, control
+    // chars).
+    if (entry.name.contains('\\') ||
+        entry.name.contains(':') ||
+        entry.name.contains('\x00')) {
       await reader.cancel();
-      throw FormatException('Tar file contained duplicate path ${entry.name}');
+      throw FormatException('Invalid tar entry name: `${entry.name}`');
     }
 
-    if (!(p.isWithin(destination, filePath) ||
-        // allow including '.' as an entry in the tar.gz archive.
-        (entry.type == TypeFlag.dir && p.equals(destination, filePath)))) {
-      // The tar contains entries that would be written outside of the
-      // destination. That doesn't happen by accident, assume that the tar file
-      // is malicious.
+    for (var i = 0; i < entry.name.length; i++) {
+      final code = entry.name.codeUnitAt(i);
+      if (code < 32 || code == 127) {
+        await reader.cancel();
+        throw FormatException(
+          'Invalid tar entry name with control character: `${entry.name}`',
+        );
+      }
+    }
+
+    final segments =
+        p.posix
+            .split(entry.name)
+            .where((s) => s.isNotEmpty && s != '.')
+            .toList();
+
+    if (p.posix.isAbsolute(entry.name) || segments.contains('..')) {
       await reader.cancel();
       throw FormatException('Invalid tar entry: `${entry.name}`');
     }
 
-    final parentDirectory = p.dirname(filePath);
-
-    bool checkValidTarget(String linkTarget) {
-      final isValid = p.isWithin(destination, linkTarget);
-      if (!isValid) {
-        log.fine('Skipping ${entry.name}: Invalid link target');
+    // Reject Windows DOS device names and trailing dots/spaces.
+    for (final segment in segments) {
+      if (_windowsDeviceName.hasMatch(segment) ||
+          segment.endsWith('.') ||
+          segment.endsWith(' ')) {
+        await reader.cancel();
+        throw FormatException(
+          'Invalid filename segment `$segment` in `${entry.name}`',
+        );
       }
+    }
 
-      return isValid;
+    final filePath = p.normalize(p.joinAll([destination, ...segments]));
+
+    if (!p.isWithin(destination, filePath) &&
+        !(entry.type == TypeFlag.dir && p.equals(destination, filePath))) {
+      await reader.cancel();
+      throw FormatException('Invalid tar entry: `${entry.name}`');
+    }
+
+    // Guard against duplicate paths and case-folding collisions.
+    final pathKey = isCaseInsensitive ? filePath.toLowerCase() : filePath;
+    if (!paths.add(filePath) || !normalizedPaths.add(pathKey)) {
+      await reader.cancel();
+      throw FormatException('Tar file contained duplicate path ${entry.name}');
     }
 
     switch (entry.type) {
@@ -1225,54 +1261,20 @@ Future<void> extractTarGz(Stream<List<int>> stream, String destination) async {
         break;
       case TypeFlag.reg:
       case TypeFlag.regA:
-        // Regular file
-        deleteIfLink(filePath);
-        ensureDir(parentDirectory);
+        ensureDir(p.dirname(filePath));
         await createFileFromStream(entry.contents, filePath);
 
         if (platform.isLinux || platform.isMacOS) {
-          // Apply executable bits from tar header, but don't change r/w bits
-          // from the default
           final mode = _defaultMode | (entry.header.mode & _executableMask);
-
-          if (mode != _defaultMode) {
-            _chmod(mode, filePath);
-          }
+          if (mode != _defaultMode) _chmod(mode, filePath);
         }
-        break;
-      case TypeFlag.symlink:
-        // Link to another file in this tar, relative from this entry.
-        final resolvedTarget = p.joinAll([
-          parentDirectory,
-          ...p.posix.split(entry.header.linkName!),
-        ]);
-        if (!checkValidTarget(resolvedTarget)) {
-          // Don't allow links to files outside of this tar.
-          break;
-        }
-
-        ensureDir(parentDirectory);
-        createSymlink(
-          p.relative(resolvedTarget, from: parentDirectory),
-          filePath,
-        );
-        break;
-      case TypeFlag.link:
-        // We generate hardlinks as symlinks too, but their linkName is relative
-        // to the root of the tar file (unlike symlink entries, whose linkName
-        // is relative to the entry itself).
-        final fromDestination = p.join(destination, entry.header.linkName);
-        if (!checkValidTarget(fromDestination)) {
-          break; // Link points outside of the tar file.
-        }
-
-        final fromFile = p.relative(fromDestination, from: parentDirectory);
-        ensureDir(parentDirectory);
-        createSymlink(fromFile, filePath);
         break;
       default:
-        // Only extract files
-        continue;
+        // Ignore symlinks, hardlinks, and special files.
+        log.fine(
+          'Skipping non-regular tar entry: ${entry.name} (${entry.type})',
+        );
+        break;
     }
   }
 

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -429,7 +429,7 @@ void main() {
       testOn: 'linux || mac-os',
     );
 
-    test('extracts files and links', () {
+    test('extracts regular files and ignores symlinks and hardlinks', () {
       return withTempDir((tempDir) async {
         final entries = Stream<TarEntry>.fromIterable([
           TarEntry.data(
@@ -453,7 +453,6 @@ void main() {
             TarHeader(
               name: 'test/main.txt',
               typeFlag: TypeFlag.link,
-              // TypeFlag.link is resolved against the root of the tar file
               linkName: 'lib/main.txt',
               mode: _defaultMode,
             ),
@@ -469,8 +468,8 @@ void main() {
         await d
             .dir('.', [
               d.file('lib/main.txt', 'text content'),
-              d.file('bin/main.txt', 'text content'),
-              d.file('test/main.txt', 'text content'),
+              d.nothing('bin/main.txt'),
+              d.nothing('test/main.txt'),
             ])
             .validate(tempDir);
       });
@@ -532,9 +531,134 @@ void main() {
       });
     });
 
-    test('skips symlinks escaping the tar file', () {
+    test('throws on backslash path traversal in entry name', () {
       return withTempDir((tempDir) async {
         final entry = Stream<TarEntry>.value(
+          TarEntry.data(
+            TarHeader(
+              name: r'nested\..\..\outside.txt',
+              typeFlag: TypeFlag.reg,
+              mode: _defaultMode,
+            ),
+            utf8.encode('payload'),
+          ),
+        );
+
+        await expectLater(
+          extractTarGz(
+            entry.transform(tarWriter).transform(gzip.encoder),
+            tempDir,
+          ),
+          throwsA(isA<FormatException>()),
+        );
+      });
+    });
+
+    test('throws on colon in entry name', () {
+      return withTempDir((tempDir) async {
+        final entry = Stream<TarEntry>.value(
+          TarEntry.data(
+            TarHeader(
+              name: 'lib/file.dart:stream',
+              typeFlag: TypeFlag.reg,
+              mode: _defaultMode,
+            ),
+            utf8.encode('payload'),
+          ),
+        );
+
+        await expectLater(
+          extractTarGz(
+            entry.transform(tarWriter).transform(gzip.encoder),
+            tempDir,
+          ),
+          throwsA(isA<FormatException>()),
+        );
+      });
+    });
+
+    test('throws on Windows reserved DOS device names', () {
+      return withTempDir((tempDir) async {
+        final entry = Stream<TarEntry>.value(
+          TarEntry.data(
+            TarHeader(
+              name: 'lib/aux.dart',
+              typeFlag: TypeFlag.reg,
+              mode: _defaultMode,
+            ),
+            utf8.encode('payload'),
+          ),
+        );
+
+        await expectLater(
+          extractTarGz(
+            entry.transform(tarWriter).transform(gzip.encoder),
+            tempDir,
+          ),
+          throwsA(isA<FormatException>()),
+        );
+      });
+    });
+
+    test('throws on trailing dot or space in segment', () {
+      return withTempDir((tempDir) async {
+        final entry = Stream<TarEntry>.value(
+          TarEntry.data(
+            TarHeader(
+              name: 'lib/file.dart.',
+              typeFlag: TypeFlag.reg,
+              mode: _defaultMode,
+            ),
+            utf8.encode('payload'),
+          ),
+        );
+
+        await expectLater(
+          extractTarGz(
+            entry.transform(tarWriter).transform(gzip.encoder),
+            tempDir,
+          ),
+          throwsA(isA<FormatException>()),
+        );
+      });
+    });
+
+    test('throws on case collision on case-insensitive platforms', () {
+      return withTempDir((tempDir) async {
+        final entry = Stream<TarEntry>.fromIterable([
+          TarEntry.data(
+            TarHeader(
+              name: 'lib/FILE.dart',
+              typeFlag: TypeFlag.reg,
+              mode: _defaultMode,
+            ),
+            utf8.encode('content 1'),
+          ),
+          TarEntry.data(
+            TarHeader(
+              name: 'lib/file.dart',
+              typeFlag: TypeFlag.reg,
+              mode: _defaultMode,
+            ),
+            utf8.encode('content 2'),
+          ),
+        ]);
+
+        if (Platform.isWindows || Platform.isMacOS) {
+          await expectLater(
+            extractTarGz(
+              entry.transform(tarWriter).transform(gzip.encoder),
+              tempDir,
+            ),
+            throwsA(isA<FormatException>()),
+          );
+        }
+      });
+    });
+
+    test('skips symlinks and hardlinks', () {
+      return withTempDir((tempDir) async {
+        final entry = Stream<TarEntry>.fromIterable([
           TarEntry.data(
             TarHeader(
               name: 'nested/bad_link',
@@ -544,7 +668,16 @@ void main() {
             ),
             const [],
           ),
-        );
+          TarEntry.data(
+            TarHeader(
+              name: 'nested/bad_hardlink',
+              typeFlag: TypeFlag.link,
+              linkName: '../outside.txt',
+              mode: _defaultMode,
+            ),
+            const [],
+          ),
+        ]);
 
         await extractTarGz(
           entry.transform(tarWriter).transform(gzip.encoder),
@@ -555,21 +688,30 @@ void main() {
       });
     });
 
-    test('avoid zip slip using combined symlink and ../', () {
+    test('disallows symlink depth confusion and directory symlink escape', () {
       return withTempDir((tempDir) async {
         final entry = Stream<TarEntry>.fromIterable([
           TarEntry.data(
             TarHeader(
-              name: 'nested/bad_link',
+              name: 'd1/d2/d3/sym_up',
               typeFlag: TypeFlag.symlink,
-              linkName: '../nested',
+              linkName: '../..',
               mode: _defaultMode,
             ),
             const [],
           ),
           TarEntry.data(
             TarHeader(
-              name: 'nested/bad_link/../../payload.txt',
+              name: 'd1/d2/d3/sym_up/escape',
+              typeFlag: TypeFlag.symlink,
+              linkName: '../../../outside',
+              mode: _defaultMode,
+            ),
+            const [],
+          ),
+          TarEntry.data(
+            TarHeader(
+              name: 'd1/d2/d3/sym_up/escape/pwned.txt',
               typeFlag: TypeFlag.reg,
               mode: _defaultMode,
             ),
@@ -581,35 +723,13 @@ void main() {
           entry.transform(tarWriter).transform(gzip.encoder),
           tempDir,
         );
-        // Make sure that the payload did not slip outside the destination via
-        // the symlink.
+
+        // Directory symlinks are not created, and files are not written
+        // outside tempDir.
         expect(
-          Directory(tempDir).listSync().map((x) => x.path),
-          contains(endsWith('payload.txt')),
+          linkExists(p.join(tempDir, 'd1', 'd2', 'd3', 'sym_up')),
+          isFalse,
         );
-      });
-    });
-
-    test('skips hardlinks escaping the tar file', () {
-      return withTempDir((tempDir) async {
-        final entry = Stream<TarEntry>.value(
-          TarEntry.data(
-            TarHeader(
-              name: 'nested/bad_link',
-              typeFlag: TypeFlag.link,
-              linkName: '../outside.txt',
-              mode: _defaultMode,
-            ),
-            const [],
-          ),
-        );
-
-        await extractTarGz(
-          entry.transform(tarWriter).transform(gzip.encoder),
-          tempDir,
-        );
-
-        await expectLater(Directory(tempDir).list(), emitsDone);
       });
     });
   });


### PR DESCRIPTION
### Summary
1. **Disallow symlink and hardlink creation**: In `extractTarGz`, extract only regular files and directories. Symlinks, hardlinks, and special files are safely ignored. This eliminates symlink depth-confusion and symlink-based Zip Slip attacks, avoids Windows privilege issues (`OS Error 1314`), and aligns with `pub publish` (which already flattens symlinks to copies on upload).
2. **Reject invalid & dangerous entry names**: Abort extraction on entry names containing backslashes (`\`), colons (`:`), NUL bytes, or ASCII control characters.
3. **Protect against Windows DOS device names**: Reject path segments matching `CON`, `PRN`, `AUX`, `NUL`, `COM1-9`, or `LPT1-9`.
4. **Protect against Win32 trailing dot/space stripping**: Reject segments ending with `.` or space.
5. **Enforce case-insensitive collision checks**: Detect and reject casing collisions on Windows and macOS.

Fixes https://buganizer.corp.google.com/issues/528619187