### PR TITLE
Make package archives reproducible with deterministic timestamps and entry ordering

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure reproducible test fixtures have exact LF line endings across all operating systems.
+tool/sample_reproducible_pkg/** text eol=lf

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,3 +70,58 @@ jobs:
         env:
           SHARD_INDEX: ${{ matrix.shard }}
         run: dart test --preset ci --total-shards=7 --shard-index="${SHARD_INDEX}"
+
+  # Build a reproducible package archive across Linux, macOS, and Windows.
+  build-reproducible-archive:
+    needs: analyze
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        sdk: [dev]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
+        with:
+          sdk: ${{ matrix.sdk }}
+      - name: Install dependencies
+        run: dart pub get
+      - name: Create reproducible archive
+        env:
+          ARCHIVE_OS: ${{ matrix.os }}
+        shell: bash
+        run: dart bin/pub.dart publish -C tool/sample_reproducible_pkg --to-archive="archive-${ARCHIVE_OS}.tar.gz" --skip-validation
+      - name: Upload archive
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: archive-${{ matrix.os }}
+          path: archive-${{ matrix.os }}.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+  # Verify that archives built on Linux, macOS, and Windows are bit-for-bit identical.
+  verify-cross-os-reproducibility:
+    needs: build-reproducible-archive
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Ubuntu archive
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: archive-ubuntu-latest
+          path: archives/archive-ubuntu-latest
+      - name: Download macOS archive
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: archive-macos-latest
+          path: archives/archive-macos-latest
+      - name: Download Windows archive
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: archive-windows-latest
+          path: archives/archive-windows-latest
+      - name: Verify identical archives
+        run: |
+          sha256sum archives/*/*.tar.gz
+          cmp archives/archive-ubuntu-latest/*.tar.gz archives/archive-macos-latest/*.tar.gz
+          cmp archives/archive-ubuntu-latest/*.tar.gz archives/archive-windows-latest/*.tar.gz

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -1268,10 +1268,12 @@ Future<void> extractTarGz(Stream<List<int>> stream, String destination) async {
   log.fine('Extracted .tar.gz to $destination.');
 }
 
-/// Create a .tar.gz archive from a list of entries.
+/// Creates a .tar.gz archive of [contents] relative to [baseDir].
 ///
-/// Each entry is the path to a directory or file. The root of the archive is
-/// considered to be [baseDir], which defaults to the current working directory.
+/// Archives are bit-for-bit deterministic and reproducible: timestamps are
+/// normalized to Unix epoch 0 (1970-01-01 00:00:00 UTC), entries are sorted
+/// lexicographically by normalized POSIX path, and file permissions and GZIP
+/// headers are normalized.
 ///
 /// Returns a [ByteStream] that emits the contents of the archive.
 ByteStream createTarGz(List<String> contents, {required String baseDir}) {
@@ -1283,27 +1285,35 @@ ByteStream createTarGz(List<String> contents, {required String baseDir}) {
   ArgumentError.checkNotNull(baseDir, 'baseDir');
   baseDir = p.normalize(p.absolute(baseDir));
 
+  final epoch = DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+
+  final normalizedEntries = <(String fullPath, String archivePath)>[];
+  for (final entry in contents) {
+    final normalized = p.normalize(p.absolute(entry));
+    if (p.equals(baseDir, normalized)) {
+      continue;
+    }
+    if (!p.isWithin(baseDir, normalized)) {
+      throw ArgumentError('Entry $entry is not inside $baseDir.');
+    }
+    final relative = p.relative(normalized, from: baseDir);
+    final archivePath = p.url.joinAll(p.split(relative));
+    normalizedEntries.add((normalized, archivePath));
+  }
+
+  // Sort entries deterministically by normalized POSIX path in the archive.
+  normalizedEntries.sort((a, b) => a.$2.compareTo(b.$2));
+
   final tarContents = Stream.fromIterable(
-    contents.map((entry) {
-      entry = p.normalize(p.absolute(entry));
-      if (p.equals(baseDir, entry)) {
-        return null;
-      }
-      if (!p.isWithin(baseDir, entry)) {
-        throw ArgumentError('Entry $entry is not inside $baseDir.');
-      }
-
-      final relative = p.relative(entry, from: baseDir);
+    normalizedEntries.map((entry) {
+      final (fullPath, name) = entry;
       // On Windows, we can't open some files without normalizing them
-      final file = File(p.normalize(entry));
+      final file = File(fullPath);
       final stat = file.statSync();
-
-      // Ensure paths in tar files use forward slashes
-      final name = p.url.joinAll(p.split(relative));
 
       if (stat.type == FileSystemEntityType.link) {
         log.message(
-          '$entry is a link locally, but will be uploaded as a '
+          '$fullPath is a link locally, but will be uploaded as a '
           'duplicate file.',
         );
       }
@@ -1313,6 +1323,7 @@ ByteStream createTarGz(List<String> contents, {required String baseDir}) {
             name: name,
             mode: _defaultMode | _executableMask,
             typeFlag: TypeFlag.dir,
+            modified: epoch,
             userName: 'pub',
             groupName: 'pub',
           ),
@@ -1326,20 +1337,57 @@ ByteStream createTarGz(List<String> contents, {required String baseDir}) {
             // file mode
             mode: _defaultMode | (stat.mode & _executableMask),
             size: stat.size,
-            modified: stat.changed,
+            modified: epoch,
             userName: 'pub',
             groupName: 'pub',
           ),
           file.openRead(),
         );
       }
-    }).nonNulls,
+    }),
   );
 
-  return ByteStream(
-    tarContents
-        .transform(tarWriterWith(format: OutputFormat.gnuLongName))
-        .transform(gzip.encoder),
+  final stream = tarContents
+      .transform(tarWriterWith(format: OutputFormat.gnuLongName))
+      .transform(gzip.encoder)
+      .transform(normalizeGzipHeader());
+
+  return ByteStream(stream);
+}
+
+/// Normalizes the GZIP header (RFC 1952) so that `.tar.gz` archives are
+/// bit-for-bit identical across operating systems (normalizing MTIME to 0 and
+/// OS byte to 255).
+StreamTransformer<List<int>, List<int>> normalizeGzipHeader() {
+  var isHeaderHandled = false;
+  final headerBuffer = <int>[];
+  return StreamTransformer.fromHandlers(
+    handleData: (data, sink) {
+      if (isHeaderHandled) {
+        sink.add(data);
+        return;
+      }
+      headerBuffer.addAll(data);
+      if (headerBuffer.length >= 10) {
+        isHeaderHandled = true;
+        if (headerBuffer[0] == 0x1f && headerBuffer[1] == 0x8b) {
+          // RFC 1952: byte 4..7 is MTIME, byte 8 is XFL, byte 9 is OS
+          headerBuffer[4] = 0;
+          headerBuffer[5] = 0;
+          headerBuffer[6] = 0;
+          headerBuffer[7] = 0;
+          headerBuffer[8] = 0;
+          headerBuffer[9] = 255; // 255 = unknown OS (gzip -n)
+        }
+        sink.add(headerBuffer);
+      }
+    },
+    handleDone: (sink) {
+      if (!isHeaderHandled && headerBuffer.isNotEmpty) {
+        sink.add(headerBuffer);
+      }
+      sink.close();
+    },
   );
 }
 

--- a/test/lish/reproducible_archive_test.dart
+++ b/test/lish/reproducible_archive_test.dart
@@ -1,0 +1,88 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:pub/src/path.dart';
+import 'package:tar/tar.dart';
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+const _defaultMode = 420; // 644₈
+const _executableMask = 0x49; // 001 001 001
+
+void main() {
+  test('creates byte-for-byte identical archives regardless '
+      'of file mtime or creation order', () async {
+    await d.validPackage().create();
+    await d.dir(appPath, [
+      d.dir('lib', [
+        d.file('z.dart', 'void z() {}'),
+        d.file('a.dart', 'void a() {}'),
+        d.file('m.dart', 'void m() {}'),
+      ]),
+      d.dir('bin', [d.file('tool.dart', 'void main() {}')]),
+    ]).create();
+
+    // Generate first archive
+    await runPub(args: ['publish', '--to-archive=../archive1.tar.gz']);
+
+    final archive1File = File(p.join(d.sandbox, 'archive1.tar.gz'));
+    expect(archive1File.existsSync(), isTrue);
+    final bytes1 = archive1File.readAsBytesSync();
+    final digest1 = sha256.convert(bytes1).toString();
+
+    // Alter file timestamps on disk
+    final aFile = File(p.join(d.sandbox, appPath, 'lib', 'a.dart'));
+    final zFile = File(p.join(d.sandbox, appPath, 'lib', 'z.dart'));
+    aFile.setLastModifiedSync(DateTime(2030, 5, 12, 10, 30));
+    zFile.setLastModifiedSync(DateTime(1995, 3, 4, 12));
+
+    // Wait a brief moment and generate second archive
+    await runPub(args: ['publish', '--to-archive=../archive2.tar.gz']);
+
+    final archive2File = File(p.join(d.sandbox, 'archive2.tar.gz'));
+    expect(archive2File.existsSync(), isTrue);
+    final bytes2 = archive2File.readAsBytesSync();
+    final digest2 = sha256.convert(bytes2).toString();
+
+    // Digests must match identically
+    expect(digest2, equals(digest1));
+    expect(bytes2, equals(bytes1));
+
+    // Inspect TAR entries
+    final tarReader = TarReader(gzip.decoder.bind(archive1File.openRead()));
+    final entryNames = <String>[];
+    while (await tarReader.moveNext()) {
+      final entry = tarReader.current;
+      entryNames.add(entry.name);
+      // Verify normalized epoch timestamp
+      expect(
+        entry.header.modified,
+        equals(DateTime.fromMillisecondsSinceEpoch(0, isUtc: true)),
+      );
+      expect(entry.header.userName, equals('pub'));
+      expect(entry.header.groupName, equals('pub'));
+      if (entry.type == TypeFlag.dir) {
+        if (!Platform.isWindows) {
+          expect(entry.header.mode, equals(_defaultMode | _executableMask));
+        }
+      } else {
+        if (!Platform.isWindows) {
+          expect(entry.header.mode, equals(_defaultMode));
+        }
+      }
+    }
+
+    // Verify entries are sorted deterministically
+    final sortedNames = List<String>.from(entryNames)..sort();
+    expect(entryNames, equals(sortedNames));
+  });
+}

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -14,7 +14,6 @@ import 'dart:core';
 import 'dart:io' hide BytesBuilder;
 import 'dart:isolate';
 import 'dart:math';
-import 'dart:typed_data';
 
 import 'package:async/async.dart';
 import 'package:pub/src/entrypoint.dart';
@@ -1102,27 +1101,10 @@ Stream<List<int>> tarFromDescriptors(Iterable<d.Descriptor> contents) {
   for (final e in contents) {
     addDescriptor(e, '');
   }
-  return _replaceOs(
-    Stream.fromIterable(entries)
-        .transform(tarWriterWith(format: OutputFormat.gnuLongName))
-        .transform(gzip.encoder),
-  );
-}
-
-/// Replaces the entry at index 9 in [stream] with a 0. This replaces the os
-/// entry of a gzip stream, giving us the same stream and this stable testing
-/// on all platforms.
-///
-/// See https://www.rfc-editor.org/rfc/rfc1952 section 2.3 for information
-/// about the OS header.
-Stream<List<int>> _replaceOs(Stream<List<int>> stream) async* {
-  final bytesBuilder = BytesBuilder();
-  await for (final t in stream) {
-    bytesBuilder.add(t);
-  }
-  final result = bytesBuilder.toBytes();
-  result[9] = 0;
-  yield result;
+  return Stream.fromIterable(entries)
+      .transform(tarWriterWith(format: OutputFormat.gnuLongName))
+      .transform(gzip.encoder)
+      .transform(normalizeGzipHeader());
 }
 
 /// Utility for indexing json data structures.

--- a/tool/sample_reproducible_pkg/CHANGELOG.md
+++ b/tool/sample_reproducible_pkg/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 1.0.0
+- Initial release.

--- a/tool/sample_reproducible_pkg/LICENSE
+++ b/tool/sample_reproducible_pkg/LICENSE
@@ -1,0 +1,1 @@
+Sample License

--- a/tool/sample_reproducible_pkg/README.md
+++ b/tool/sample_reproducible_pkg/README.md
@@ -1,0 +1,1 @@
+# Sample Reproducible Package

--- a/tool/sample_reproducible_pkg/bin/tool.dart
+++ b/tool/sample_reproducible_pkg/bin/tool.dart
@@ -1,0 +1,1 @@
+void main() {}

--- a/tool/sample_reproducible_pkg/lib/sample_reproducible_pkg.dart
+++ b/tool/sample_reproducible_pkg/lib/sample_reproducible_pkg.dart
@@ -1,0 +1,1 @@
+void sample() {}

--- a/tool/sample_reproducible_pkg/lib/src/internal.dart
+++ b/tool/sample_reproducible_pkg/lib/src/internal.dart
@@ -1,0 +1,1 @@
+class Internal {}

--- a/tool/sample_reproducible_pkg/pubspec.yaml
+++ b/tool/sample_reproducible_pkg/pubspec.yaml
@@ -1,0 +1,6 @@
+name: sample_reproducible_pkg
+version: 1.0.0
+description: A sample package for verifying reproducible archives.
+repository: https://github.com/dart-lang/pub
+environment:
+  sdk: ^3.0.0


### PR DESCRIPTION
## Summary
Makes `dart pub publish --to-archive` bit-for-bit deterministic and reproducible across all operating systems:
1. Normalizing TAR entry timestamps (`modified`) unconditionally to Unix Epoch 0 (`DateTime.fromMillisecondsSinceEpoch(0, isUtc: true)`).
2. Normalizing GZIP headers (RFC 1952 `MTIME = 0`, `OS = 255`) via `normalizeGzipHeader()`.
3. Sorting archive entries deterministically by normalized relative path.
4. Normalizing TAR directory and file permissions/modes.
5. Adding multi-OS integration tests verifying reproducible archives regardless of file mtime and directory iteration order.