### PR TITLE
Use dart build cli for integration test executable

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,8 @@
 name: Dart CI
 
+permissions:
+  contents: read
+
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
   push:
@@ -11,7 +14,7 @@ on:
 
 env:
   PUB_ENVIRONMENT: bot.github
-  _PUB_TEST_SNAPSHOT: ${{ github.workspace }}/.dart_tool/pub.dart.snapshot.dart2
+  _PUB_TEST_EXECUTABLE: ${{ github.workspace }}/.dart_tool/_pub_build/bundle/bin/pub
   _TESTS_FILE: .dart_tool/test_files
 
 jobs:
@@ -45,6 +48,9 @@ jobs:
   test:
     needs: analyze
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +64,9 @@ jobs:
           sdk: ${{ matrix.sdk }}
       - name: Install dependencies
         run: dart pub get
-      - name: Build snapshot
-        run: dart --snapshot=${{ env._PUB_TEST_SNAPSHOT }} bin/pub.dart
+      - name: Build executable
+        run: dart build cli -t bin/pub.dart -o .dart_tool/_pub_build
       - name: Run tests
-        run: dart test --preset ci --total-shards=7 --shard-index=${{ matrix.shard }}
+        env:
+          SHARD_INDEX: ${{ matrix.shard }}
+        run: dart test --preset ci --total-shards=7 --shard-index="${SHARD_INDEX}"

--- a/lib/src/dart.dart
+++ b/lib/src/dart.dart
@@ -19,7 +19,7 @@ import 'exceptions.dart';
 import 'io.dart';
 import 'log.dart' as log;
 import 'path.dart';
-import 'platform_info.dart';
+import 'sdk/dart.dart';
 
 class AnalysisContextManager {
   static final sessions = <String, AnalysisContextManager>{};
@@ -36,6 +36,7 @@ class AnalysisContextManager {
     : _session =
           AnalysisContextCollection(
             includedPaths: [packagePath],
+            sdkPath: DartSdk().rootDirectory,
           ).contextFor(packagePath).currentSession;
 
   /// Parse the file with the given [path] into AST.
@@ -116,7 +117,7 @@ Future<void> precompile({
   String? nativeAssets,
 }) async {
   const platformDill = 'lib/_internal/vm_platform_strong.dill';
-  final sdkRoot = p.relative(p.dirname(p.dirname(platform.resolvedExecutable)));
+  final sdkRoot = p.relative(DartSdk().rootDirectory);
   String? tempDir;
   FrontendServerClient? client;
   try {

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -20,6 +20,7 @@ import 'package_config.dart';
 import 'path.dart';
 import 'platform_info.dart';
 import 'sdk.dart';
+import 'sdk/dart.dart';
 import 'system_cache.dart';
 import 'utils.dart';
 
@@ -110,7 +111,7 @@ Future<int> runExecutable(
   final packageConfigAbsolute = p.absolute(entrypoint.packageConfigPath);
 
   try {
-    return await _runDartProgram(
+    final exitCode = await _runDartProgram(
       executablePath,
       args.toList(),
       packageConfigAbsolute,
@@ -118,6 +119,19 @@ Future<int> runExecutable(
       vmArgs: vmArgs,
       alwaysUseSubprocess: alwaysUseSubprocess,
     );
+    if (useSnapshot && exitCode == 253) {
+      log.fine('Built executable is out of date.');
+      await recompile(executable);
+      return await _runDartProgram(
+        entrypoint.pathOfSnapshot(executable),
+        args.toList(),
+        packageConfigAbsolute,
+        enableAsserts: enableAsserts,
+        vmArgs: vmArgs,
+        alwaysUseSubprocess: alwaysUseSubprocess,
+      );
+    }
+    return exitCode;
   } on IsolateSpawnException catch (error) {
     if (!useSnapshot ||
         !error.message.contains('Invalid kernel binary format version')) {
@@ -127,7 +141,7 @@ Future<int> runExecutable(
     log.fine('Built executable is out of date.');
     await recompile(executable);
     return await _runDartProgram(
-      executablePath,
+      entrypoint.pathOfSnapshot(executable),
       args.toList(),
       packageConfigAbsolute,
       enableAsserts: enableAsserts,
@@ -162,9 +176,15 @@ Future<int> _runDartProgram(
   path = p.absolute(path);
   packageConfig = p.absolute(packageConfig);
 
-  // We use Isolate.spawnUri when there are no extra vm-options.
-  // That provides better signal handling, and possibly faster startup.
-  if ((!alwaysUseSubprocess) && vmArgs.isEmpty) {
+  // We use Isolate.spawnUri when there are no extra vm-options and running
+  // under the Dart VM. Standalone AOT binaries cannot execute kernel dill
+  // snapshots in-process and must spawn the SDK dart executable.
+  final canUseIsolate =
+      (!alwaysUseSubprocess) &&
+      vmArgs.isEmpty &&
+      p.equals(DartSdk().executable, platform.resolvedExecutable);
+
+  if (canUseIsolate) {
     final argList = args.toList();
     return await isolate.runUri(
       p.toUri(path),
@@ -193,14 +213,29 @@ Future<int> _runDartProgram(
     // TODO(sigurdm) To handle signals better we would ideally have `exec`
     // semantics without `fork` for starting the subprocess.
     // https://github.com/dart-lang/sdk/issues/41966.
+    final environment = Map<String, String>.from(platform.environment);
+    if (environment['DART_ROOT'] case final root?) {
+      if (!fileExists(
+        p.join(root, 'bin', platform.isWindows ? 'dart.exe' : 'dart'),
+      )) {
+        environment.remove('DART_ROOT');
+      }
+    }
+
+    final process = await Process.start(
+      DartSdk().executable,
+      [
+        '--packages=$packageConfig',
+        ...vmArgs,
+        if (enableAsserts) '--enable-asserts',
+        p.toUri(path).toString(),
+        ...args,
+      ],
+      mode: ProcessStartMode.inheritStdio,
+      environment: environment,
+    );
+
     final subscription = ProcessSignal.sigint.watch().listen((e) {});
-    final process = await Process.start(platform.resolvedExecutable, [
-      '--packages=$packageConfig',
-      ...vmArgs,
-      if (enableAsserts) '--enable-asserts',
-      p.toUri(path).toString(),
-      ...args,
-    ], mode: ProcessStartMode.inheritStdio);
 
     final exitCode = await process.exitCode;
     await subscription.cancel();

--- a/lib/src/global_packages.dart
+++ b/lib/src/global_packages.dart
@@ -969,8 +969,23 @@ Try reactivating the package.
     }
     // When running tests we want the binstub to invoke the current pub, not the
     // one from the sdk.
-    final pubInvocation =
-        runningFromTest ? platform.script.toFilePath() : 'pub';
+    final String pubInvocation;
+    if (runningFromTest) {
+      final exeEnv = platform.environment['_PUB_TEST_EXECUTABLE'];
+      if (exeEnv != null && exeEnv.isNotEmpty) {
+        pubInvocation = '"${p.absolute(exeEnv)}" --verbosity=normal';
+      } else {
+        final isDartVm =
+            p.basenameWithoutExtension(platform.resolvedExecutable) == 'dart';
+        if (isDartVm) {
+          pubInvocation = 'dart "${platform.script.toFilePath()}"';
+        } else {
+          pubInvocation = '"${platform.resolvedExecutable}"';
+        }
+      }
+    } else {
+      pubInvocation = 'pub';
+    }
 
     final runPubGlobal = '${package.name}:$script';
 
@@ -1002,9 +1017,9 @@ ${header}if exist "$snapshot" $padding(
   if not errorlevel 253 (
     goto error
   )
-  call dart $pubInvocation global run $runPubGlobal %*
+  call $pubInvocation global run $runPubGlobal %*
 ) else (
-  call dart $pubInvocation global run $runPubGlobal %*
+  call $pubInvocation global run $runPubGlobal %*
 )
 goto eof
 :error
@@ -1013,7 +1028,7 @@ exit /b %errorlevel%
 ''';
       } else {
         binstub = '''
-${header}call dart $pubInvocation global run $runPubGlobal %*
+${header}call $pubInvocation global run $runPubGlobal %*
 ''';
       }
     } else {
@@ -1037,11 +1052,11 @@ ${header}if [ -f $snapshot ]; then
     exit \$exit_code
   fi
 fi
-dart $pubInvocation global run $runPubGlobal "\$@"
+$pubInvocation global run $runPubGlobal "\$@"
 ''';
       } else {
         binstub = '''
-${header}dart $pubInvocation global run $runPubGlobal "\$@"
+$header$pubInvocation global run $runPubGlobal "\$@"
 ''';
       }
     }

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -691,18 +691,7 @@ void createPackageSymlink(
 ///
 /// The "_PUB_TESTING" variable is automatically set for all the test code's
 /// invocations of pub.
-final bool runningFromTest =
-    platform.environment.containsKey('_PUB_TESTING') && _assertionsEnabled;
-
-final bool _assertionsEnabled = () {
-  try {
-    assert(false);
-    // ignore: avoid_catching_errors
-  } on AssertionError {
-    return true;
-  }
-  return false;
-}();
+final bool runningFromTest = platform.environment.containsKey('_PUB_TESTING');
 
 final bool runningFromFlutter =
     platform.environment.containsKey('PUB_ENVIRONMENT') &&

--- a/lib/src/sdk/dart.dart
+++ b/lib/src/sdk/dart.dart
@@ -30,14 +30,21 @@ class DartSdk extends Sdk {
       return root;
     }
 
+    if (platform.environment['_PUB_TEST_SDK_DIR'] case final dir?) {
+      return dir;
+    }
+
     if (runningFromDartRepo) return p.join(dartRepoRoot, 'sdk');
 
     // The Dart executable is in "/path/to/sdk/bin/dart", so two levels up is
     // "/path/to/sdk".
     final aboveExecutable = p.dirname(p.dirname(platform.resolvedExecutable));
-    assert(fileExists(p.join(aboveExecutable, 'version')));
     return aboveExecutable;
   }();
+
+  /// The path to the `dart` executable.
+  String get executable =>
+      p.join(_rootDirectory, 'bin', platform.isWindows ? 'dart.exe' : 'dart');
 
   /// The loaded `sdk_packages.yaml` file if present.
   static final SdkPackageConfig? _sdkPackages = () {

--- a/lib/src/validator/analyze.dart
+++ b/lib/src/validator/analyze.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 import '../io.dart';
 import '../log.dart';
 import '../path.dart';
-import '../platform_info.dart';
+import '../sdk/dart.dart';
 import '../validator.dart';
 
 /// Runs `dart analyze` and gives a warning if it returns non-zero.
@@ -25,7 +25,7 @@ class AnalyzeValidator extends Validator {
     final entries = _entriesToAnalyze
         .map((dir) => p.join(package.dir, dir))
         .where(entryExists);
-    final result = await runProcess(platform.resolvedExecutable, [
+    final result = await runProcess(DartSdk().executable, [
       'analyze',
       ...entries,
       p.join(package.dir, 'pubspec.yaml'),

--- a/test/test_pub.dart
+++ b/test/test_pub.dart
@@ -464,6 +464,9 @@ Map<String, String> getPubTestEnvironment([String? tokenEndpoint]) => {
 
   // Ensure a known SDK version is set for the tests that rely on that.
   '_PUB_TEST_SDK_VERSION': testVersion,
+  '_PUB_TEST_SDK_DIR': p.dirname(p.dirname(Platform.resolvedExecutable)),
+  if (Platform.environment['_PUB_TEST_EXECUTABLE'] case final exe?)
+    '_PUB_TEST_EXECUTABLE': p.absolute(exe),
   if (tokenEndpoint != null) '_PUB_TEST_TOKEN_ENDPOINT': tokenEndpoint,
   if (_globalServer?.port != null)
     'PUB_HOSTED_URL': 'http://localhost:${_globalServer?.port}',
@@ -503,22 +506,32 @@ Future<PubProcess> startPub({
 
   ensureDir(_pathInSandbox(appPath));
 
-  // If there's a snapshot for "pub" available we use it. If the snapshot is
-  // out-of-date local source the tests will be useless, therefore it is
-  // recommended to use a temporary file with a unique name for each test run.
-  // Note: running tests without a snapshot is significantly slower, use
-  // tool/test.dart to generate the snapshot.
-  var pubPath = Platform.environment['_PUB_TEST_SNAPSHOT'] ?? '';
-  if (pubPath.isEmpty || !fileExists(pubPath)) {
-    pubPath = p.absolute(p.join(_pubRoot, 'bin/pub.dart'));
+  var pubExecutable = Platform.environment['_PUB_TEST_EXECUTABLE'] ?? '';
+  if (pubExecutable.isNotEmpty) {
+    pubExecutable = p.absolute(pubExecutable);
+    if (Platform.isWindows &&
+        !pubExecutable.endsWith('.exe') &&
+        fileExists('$pubExecutable.exe')) {
+      pubExecutable = '$pubExecutable.exe';
+    }
   }
 
-  final dotPackagesPath = (await Isolate.packageConfig).toString();
-
-  final dartArgs = ['--packages=$dotPackagesPath', '--enable-asserts'];
-  dartArgs
-    ..addAll([pubPath, if (!verbose) '--verbosity=normal'])
-    ..addAll(args);
+  final String executable;
+  final List<String> processArgs;
+  if (pubExecutable.isNotEmpty && fileExists(pubExecutable)) {
+    executable = pubExecutable;
+    processArgs = [if (!verbose) '--verbosity=normal', ...args];
+  } else {
+    executable = Platform.resolvedExecutable;
+    final dotPackagesPath = (await Isolate.packageConfig).toString();
+    processArgs = [
+      '--packages=$dotPackagesPath',
+      '--enable-asserts',
+      p.absolute(p.join(_pubRoot, 'bin/pub.dart')),
+      if (!verbose) '--verbosity=normal',
+      ...args,
+    ];
+  }
 
   final systemRoot = Platform.environment['SYSTEMROOT'];
   final tmp = Platform.environment['TMP'];
@@ -546,8 +559,8 @@ Future<PubProcess> startPub({
   }
 
   return await PubProcess.start(
-    Platform.resolvedExecutable,
-    dartArgs,
+    executable,
+    processArgs,
     environment: mergedEnvironment,
     workingDirectory: workingDirectory ?? _pathInSandbox(appPath),
     description: args.isEmpty ? 'pub' : 'pub ${args.join(' ')}',

--- a/tool/test-bin/pub
+++ b/tool/test-bin/pub
@@ -3,10 +3,10 @@
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-# Runs bin/pub.dart with dart from PATH (or the snapshot if present).
+# Runs bin/pub.dart with dart from PATH (or the built pub executable if present).
 
-if [ -n "$_PUB_TEST_SNAPSHOT" ]; then
-    dart $_PUB_TEST_SNAPSHOT $*
+if [ -n "$_PUB_TEST_EXECUTABLE" ]; then
+    exec "$_PUB_TEST_EXECUTABLE" "$@"
 else
-    dart `dirname "$0"`/../../bin/pub.dart $*
+    exec dart `dirname "$0"`/../../bin/pub.dart "$@"
 fi

--- a/tool/test-bin/pub.bat
+++ b/tool/test-bin/pub.bat
@@ -3,10 +3,10 @@ rem Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
 rem for details. All rights reserved. Use of this source code is governed by a
 rem BSD-style license that can be found in the LICENSE file.
 
-rem Runs bin/pub.dart with dart from PATH (or the snapshot if present).
+rem Runs bin/pub.dart with dart from PATH (or the built pub executable if present).
 
-if "%_PUB_TEST_SNAPSHOT%"=="" (
-    dart %~p0\..\..\..\bin\pub.dart %*
+if "%_PUB_TEST_EXECUTABLE%"=="" (
+    dart %~p0\..\..\bin\pub.dart %*
 ) else (
-    dart %_PUB_TEST_SNAPSHOT% %*
+    call %_PUB_TEST_EXECUTABLE% %*
 )

--- a/tool/test.dart
+++ b/tool/test.dart
@@ -7,16 +7,13 @@
 /// Test wrapper script.
 /// Many of the integration tests runs the `pub` command, this is slow if every
 /// invocation requires the dart compiler to load all the sources. This script
-/// will create a `pub.XXX.dart.snapshot.dart2` which the tests can utilize.
-/// After creating the snapshot this script will forward arguments to
-/// `pub run test`, and ensure that the snapshot is deleted after tests have
-/// been run.
+/// will build `pub` executable using `dart build cli` which the tests can
+/// utilize.
 library;
 
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:pub/src/dart.dart';
 import 'package:pub/src/exceptions.dart';
 
 Future<void> main(List<String> args) async {
@@ -30,28 +27,43 @@ Future<void> main(List<String> args) async {
   final sub = ProcessSignal.sigint.watch().listen((signal) {
     testProcess?.kill(signal);
   });
-  final pubSnapshotFilename = p.absolute(
-    p.join('.dart_tool', '_pub', 'pub.dart.snapshot.dart2'),
+  final pubBuildDir = p.absolute(p.join('.dart_tool', '_pub_build'));
+  final pubExecutable = p.join(
+    pubBuildDir,
+    'bundle',
+    'bin',
+    Platform.isWindows ? 'pub.exe' : 'pub',
   );
   try {
     final stopwatch = Stopwatch()..start();
-    stderr.write('Building snapshot...');
-    await precompile(
-      executablePath: p.join('bin', 'pub.dart'),
-      outputPath: pubSnapshotFilename,
-      name: 'bin/pub.dart',
-      packageConfigPath: p.join('.dart_tool', 'package_config.json'),
-    );
+    stderr.write('Building pub executable with `dart build cli`...');
+    final buildResult = await Process.run(Platform.resolvedExecutable, [
+      'build',
+      'cli',
+      '-t',
+      p.join('bin', 'pub.dart'),
+      '-o',
+      pubBuildDir,
+    ]);
+    if (buildResult.exitCode != 0) {
+      throw ApplicationException(
+        'Failed to build pub executable:\n'
+        '${buildResult.stderr}\n${buildResult.stdout}',
+      );
+    }
     stderr.writeln(' (${stopwatch.elapsed.inMilliseconds}ms)');
     testProcess = await Process.start(
       Platform.resolvedExecutable,
       ['run', 'test', ...args],
-      environment: {'_PUB_TEST_SNAPSHOT': pubSnapshotFilename},
+      environment: {
+        '_PUB_TEST_EXECUTABLE': pubExecutable,
+        '_PUB_TEST_SDK_DIR': p.dirname(p.dirname(Platform.resolvedExecutable)),
+      },
       mode: ProcessStartMode.inheritStdio,
     );
     exitCode = await testProcess.exitCode;
   } on ApplicationException catch (e) {
-    stderr.writeln('Failed building snapshot: $e');
+    stderr.writeln('Failed building pub: $e');
     exitCode = 1;
   } finally {
     await sub.cancel();


### PR DESCRIPTION
This PR replaces the legacy `dart --snapshot` step with `dart build cli`.

- Uses `dart build cli -t bin/pub.dart -o .dart_tool/_pub_build` to create an AOT-compiled CLI bundle for integration tests.
- Automatically compiles and bundles Native Assets (e.g. `package:sigstore` dynamic libraries) in `bundle/lib/`.
- Updates `test/test_pub.dart` to support directly executing the precompiled binary.
- Updates `tool/test.dart` and GitHub Actions CI workflow to use `dart build cli`.