### PR TITLE
Restrict permissions on credential files (0600) and config dir (0700)

### DIFF
--- a/lib/src/authentication/token_store.dart
+++ b/lib/src/authentication/token_store.dart
@@ -34,6 +34,7 @@ class TokenStore {
     if (path == null || !fileExists(path)) {
       return result;
     }
+    protectExistingFile(path);
 
     try {
       dynamic json;
@@ -106,8 +107,7 @@ class TokenStore {
     if (tokensFile == null) {
       throw AssertionError('Bad state');
     }
-    ensureDir(p.dirname(tokensFile));
-    writeTextFile(
+    writeProtectedTextFile(
       tokensFile,
       jsonEncode(<String, dynamic>{
         'version': 1,

--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -73,6 +73,15 @@ final _descriptorPool = Pool(32);
 /// The assumed default file mode on Linux and macOS
 const _defaultMode = 420; // 644₈
 
+/// Permission mode for owner-only files (read & write).
+const _ownerOnlyFileMode = 384; // 600₈
+
+/// Permission mode for owner-only directories (read, write & search).
+const _ownerOnlyDirMode = 448; // 700₈
+
+/// Mask for group and other permission bits.
+const _groupAndOtherMask = 63; // 077₈
+
 /// Mask for executable bits in file modes.
 const _executableMask = 0x49; // 001 001 001
 
@@ -264,6 +273,46 @@ void writeTextFile(
   File(file).writeAsStringSync(contents, encoding: encoding);
 }
 
+/// Creates [file] and writes [contents] to it, ensuring that on POSIX systems
+/// the containing directory has owner-only permissions (`0700`) and the file
+/// has owner-only read/write permissions (`0600`).
+///
+/// The file contents will not be logged.
+void writeProtectedTextFile(
+  String file,
+  String contents, {
+  Encoding encoding = utf8,
+}) {
+  final dir = p.dirname(file);
+  ensureDir(dir);
+  chmod(_ownerOnlyDirMode, dir);
+  writeTextFile(file, contents, dontLogContents: true, encoding: encoding);
+  chmod(_ownerOnlyFileMode, file);
+}
+
+/// Checks if [path] (or its parent directory) is accessible by group or others
+/// on POSIX systems, and tightens the permissions to `0600` for the file and
+/// `0700` for the directory if needed.
+void protectExistingFile(String path) {
+  if (platform.isLinux || platform.isMacOS) {
+    try {
+      final stat = tryStatFile(path);
+      if (stat != null && (stat.mode & _groupAndOtherMask) != 0) {
+        chmod(_ownerOnlyFileMode, path);
+      }
+      final dir = p.dirname(path);
+      if (dirExists(dir)) {
+        final dirStat = Directory(dir).statSync();
+        if ((dirStat.mode & _groupAndOtherMask) != 0) {
+          chmod(_ownerOnlyDirMode, dir);
+        }
+      }
+    } on Exception catch (e) {
+      log.fine('Failed to protect existing file "$path": $e');
+    }
+  }
+}
+
 /// Reads the file at [path] and writes [newContent] to it, if it is different
 /// from the existing content.
 ///
@@ -340,8 +389,24 @@ Future<String> createFileFromStream(Stream<List<int>> stream, String file) {
   });
 }
 
-void _chmod(int mode, String file) {
-  runProcessSync('chmod', [mode.toRadixString(8), file]);
+/// Changes the permissions of [path] to [mode] using `chmod`.
+///
+/// On Windows, this is a no-op since Windows uses NTFS ACLs.
+/// Any exceptions or non-zero exit codes are logged at fine level.
+void chmod(int mode, String path) {
+  if (platform.isLinux || platform.isMacOS) {
+    try {
+      final result = runProcessSync('chmod', [mode.toRadixString(8), path]);
+      if (result.exitCode != 0) {
+        log.fine(
+          'chmod ${mode.toRadixString(8)} "$path" exited with '
+          'code ${result.exitCode}: ${result.stderr}',
+        );
+      }
+    } on Exception catch (e) {
+      log.fine('Failed to run chmod on "$path": $e');
+    }
+  }
 }
 
 /// Deletes [file] if it's a symlink.
@@ -1236,7 +1301,7 @@ Future<void> extractTarGz(Stream<List<int>> stream, String destination) async {
           final mode = _defaultMode | (entry.header.mode & _executableMask);
 
           if (mode != _defaultMode) {
-            _chmod(mode, filePath);
+            chmod(mode, filePath);
           }
         }
         break;

--- a/lib/src/oauth2.dart
+++ b/lib/src/oauth2.dart
@@ -185,6 +185,8 @@ Credentials? loadCredentials() {
     final path = _credentialsFile();
     if (path == null || !fileExists(path)) return null;
 
+    protectExistingFile(path);
+
     final credentials = Credentials.fromJson(readTextFile(path));
     if (credentials.isExpired && !credentials.canRefresh) {
       log.error(
@@ -213,8 +215,7 @@ void _saveCredentials(Credentials credentials) {
   _credentials = credentials;
   final credentialsPath = _credentialsFile();
   if (credentialsPath != null) {
-    ensureDir(p.dirname(credentialsPath));
-    writeTextFile(credentialsPath, credentials.toJson(), dontLogContents: true);
+    writeProtectedTextFile(credentialsPath, credentials.toJson());
   }
 }
 

--- a/test/oauth2/credentials_permissions_test.dart
+++ b/test/oauth2/credentials_permissions_test.dart
@@ -1,0 +1,115 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:pub/src/io.dart';
+import 'package:pub/src/path.dart';
+import 'package:shelf/shelf.dart' as shelf;
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+import 'utils.dart';
+
+void main() {
+  test(
+    'saving credentials creates pub-credentials.json with mode 0600',
+    () async {
+      await d.validPackage().create();
+      await servePackages();
+      final pub = await startPublish(globalServer);
+      await confirmPublish(pub);
+      await authorizePub(pub, globalServer);
+
+      globalServer.expect('GET', '/api/packages/versions/new', (request) {
+        expect(
+          request.headers,
+          containsPair('authorization', 'Bearer access-token'),
+        );
+        return shelf.Response(200);
+      });
+
+      await pub.shouldExit(1);
+
+      await d.credentialsFile(globalServer, 'access-token').validate();
+
+      if (Platform.isLinux || Platform.isMacOS) {
+        final credentialsPath = p.join(
+          d.sandbox,
+          configPath,
+          'dart',
+          'pub-credentials.json',
+        );
+        final dartDirPath = p.join(d.sandbox, configPath, 'dart');
+
+        final fileMode = File(credentialsPath).statSync().mode & 0x1ff;
+        expect(
+          fileMode,
+          equals(384), // 0600
+          reason:
+              'pub-credentials.json should have owner-only permissions (0600)',
+        );
+
+        final dirMode = Directory(dartDirPath).statSync().mode & 0x1ff;
+        expect(
+          dirMode,
+          equals(448), // 0700
+          reason: 'dart config dir should have owner-only permissions (0700)',
+        );
+      }
+    },
+  );
+
+  test(
+    'loading credentials tightens permissions on existing pub-credentials.json',
+    () async {
+      await d.validPackage().create();
+      final server = await PackageServer.start();
+
+      // Pre-create credentials file
+      await d.credentialsFile(server, 'access-token').create();
+
+      if (Platform.isLinux || Platform.isMacOS) {
+        final credentialsPath = p.join(
+          d.sandbox,
+          configPath,
+          'dart',
+          'pub-credentials.json',
+        );
+        final dartDirPath = p.join(d.sandbox, configPath, 'dart');
+
+        chmod(420, credentialsPath); // 0644
+        chmod(493, dartDirPath); // 0755
+
+        expect(File(credentialsPath).statSync().mode & 0x1ff, equals(420));
+        expect(Directory(dartDirPath).statSync().mode & 0x1ff, equals(493));
+
+        // Running publish with existing credentials will load them
+        final pub = await startPublish(server);
+        await confirmPublish(pub);
+
+        server.expect('GET', '/api/packages/versions/new', (request) {
+          return shelf.Response(200);
+        });
+
+        await pub.shouldExit(1);
+
+        expect(
+          File(credentialsPath).statSync().mode & 0x1ff,
+          equals(384), // 0600
+          reason: 'pub-credentials.json should be tightened to 0600',
+        );
+        expect(
+          Directory(dartDirPath).statSync().mode & 0x1ff,
+          equals(448), // 0700
+          reason: 'dart config dir should be tightened to 0700',
+        );
+      }
+    },
+  );
+}

--- a/test/token/token_permissions_test.dart
+++ b/test/token/token_permissions_test.dart
@@ -1,0 +1,101 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:pub/src/io.dart';
+import 'package:pub/src/path.dart';
+import 'package:test/test.dart';
+
+import '../descriptor.dart' as d;
+import '../test_pub.dart';
+
+void main() {
+  test(
+    'pub token add creates pub-tokens.json with mode 0600 and dir with 0700',
+    () async {
+      await runPub(
+        args: ['token', 'add', 'https://server.demo/'],
+        input: ['auth-token'],
+      );
+
+      await d.tokensFile({
+        'version': 1,
+        'hosted': [
+          {'url': 'https://server.demo', 'token': 'auth-token'},
+        ],
+      }).validate();
+
+      if (Platform.isLinux || Platform.isMacOS) {
+        final tokensFilePath = p.join(
+          d.sandbox,
+          configPath,
+          'dart',
+          'pub-tokens.json',
+        );
+        final dartDirPath = p.join(d.sandbox, configPath, 'dart');
+
+        final fileMode = File(tokensFilePath).statSync().mode & 0x1ff;
+        expect(
+          fileMode,
+          equals(384), // 0600 in octal
+          reason: 'pub-tokens.json should have owner-only permissions (0600)',
+        );
+
+        final dirMode = Directory(dartDirPath).statSync().mode & 0x1ff;
+        expect(
+          dirMode,
+          equals(448), // 0700 in octal
+          reason: 'dart config dir should have owner-only permissions (0700)',
+        );
+      }
+    },
+  );
+
+  test(
+    'pub token list tightens permissions on existing pub-tokens.json to 0600',
+    () async {
+      await d.tokensFile({
+        'version': 1,
+        'hosted': [
+          {'url': 'https://server.demo', 'token': 'auth-token'},
+        ],
+      }).create();
+
+      if (Platform.isLinux || Platform.isMacOS) {
+        final tokensFilePath = p.join(
+          d.sandbox,
+          configPath,
+          'dart',
+          'pub-tokens.json',
+        );
+        final dartDirPath = p.join(d.sandbox, configPath, 'dart');
+
+        // Intentionally make them world-readable/traversable (0644 / 0755)
+        chmod(420, tokensFilePath); // 0644
+        chmod(493, dartDirPath); // 0755
+
+        expect(File(tokensFilePath).statSync().mode & 0x1ff, equals(420));
+        expect(Directory(dartDirPath).statSync().mode & 0x1ff, equals(493));
+
+        // Running any command that loads tokens should tighten permissions
+        await runPub(args: ['token', 'list']);
+
+        expect(
+          File(tokensFilePath).statSync().mode & 0x1ff,
+          equals(384), // 0600
+          reason: 'Existing pub-tokens.json should be tightened to 0600',
+        );
+        expect(
+          Directory(dartDirPath).statSync().mode & 0x1ff,
+          equals(448), // 0700
+          reason: 'Containing dart config dir should be tightened to 0700',
+        );
+      }
+    },
+  );
+}


### PR DESCRIPTION
Ensure `pub-credentials.json` and `pub-tokens.json` are created and written with owner-only permissions (`0600` / `-rw-------`) on POSIX systems (Linux and macOS), and that the containing configuration directory is created/restricted to `0700` (`drwx------`).

In addition:
- Automatically tighten permissions on pre-existing credential files and the containing configuration directory when loaded.
- Catch and log any `chmod` failures so non-standard environments or filesystems do not crash `pub`.
- Keep Windows behavior unchanged (NTFS ACLs under `%APPDATA%` already restrict access to the user).
- Add unit/integration tests verifying permission bits on POSIX platforms.
