### PR TITLE
Ensure git dependency path cannot escape repository via percent-encoding

### DIFF
--- a/lib/src/path.dart
+++ b/lib/src/path.dart
@@ -23,6 +23,9 @@ extension PathContextExt on path.Context {
   /// A default context for manipulating POSIX paths.
   path.Context get posix => path.posix;
 
+  /// A default context for manipulating Windows paths.
+  path.Context get windows => path.windows;
+
   /// A default context for manipulating URLs.
   ///
   /// URL path equality is undefined for paths that differ only in their

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -257,13 +257,20 @@ class GitSource extends CachedSource {
         "The 'path' field of the description must be a relative path URL.",
       );
     }
-    if (!p.url.isWithin('.', path) && !p.url.equals('.', path)) {
+    final normalized = p.url.normalize(parsed.toString());
+    final posixDecoded = p.posix.fromUri(normalized);
+    final windowsDecoded = p.windows.fromUri(normalized);
+    if ((!p.url.isWithin('.', normalized) && !p.url.equals('.', normalized)) ||
+        (!p.posix.isWithin('.', posixDecoded) &&
+            !p.posix.equals('.', posixDecoded)) ||
+        (!p.windows.isWithin('.', windowsDecoded) &&
+            !p.windows.equals('.', windowsDecoded))) {
       throw const FormatException(
         "The 'path' field of the description must not reach outside the "
         'repository.',
       );
     }
-    return p.url.normalize(parsed.toString());
+    return normalized;
   }
 
   /// Given a Git repo that contains a pub package, gets the name of the pub

--- a/test/get/git/path_test.dart
+++ b/test/get/git/path_test.dart
@@ -210,6 +210,92 @@ void main() {
     });
   });
 
+  group('cannot reach outside repository', () {
+    test('parent directory traversal', () async {
+      await d
+          .appDir(
+            dependencies: {
+              'sub': {
+                'git': {'url': '../foo.git', 'path': '../outside'},
+              },
+            },
+          )
+          .create();
+
+      await pubGet(
+        error: contains(
+          'Invalid description in the "myapp" pubspec on the "sub" dependency: '
+          "The 'path' field of the description must not reach outside the "
+          'repository.',
+        ),
+        exitCode: exit_codes.DATA,
+      );
+    });
+
+    test('percent-encoded parent directory traversal', () async {
+      await d
+          .appDir(
+            dependencies: {
+              'sub': {
+                'git': {'url': '../foo.git', 'path': '%2e%2e/%2e%2e/outside'},
+              },
+            },
+          )
+          .create();
+
+      await pubGet(
+        error: contains(
+          'Invalid description in the "myapp" pubspec on the "sub" dependency: '
+          "The 'path' field of the description must not reach outside the "
+          'repository.',
+        ),
+        exitCode: exit_codes.DATA,
+      );
+    });
+
+    test('percent-encoded slash traversal', () async {
+      await d
+          .appDir(
+            dependencies: {
+              'sub': {
+                'git': {'url': '../foo.git', 'path': '..%2f..'},
+              },
+            },
+          )
+          .create();
+
+      await pubGet(
+        error: contains(
+          'Invalid description in the "myapp" pubspec on the "sub" dependency: '
+          "The 'path' field of the description must not reach outside the "
+          'repository.',
+        ),
+        exitCode: exit_codes.DATA,
+      );
+    });
+
+    test('percent-encoded backslash traversal', () async {
+      await d
+          .appDir(
+            dependencies: {
+              'sub': {
+                'git': {'url': '../foo.git', 'path': '%5c..%5c..'},
+              },
+            },
+          )
+          .create();
+
+      await pubGet(
+        error: contains(
+          'Invalid description in the "myapp" pubspec on the "sub" dependency: '
+          "The 'path' field of the description must not reach outside the "
+          'repository.',
+        ),
+        exitCode: exit_codes.DATA,
+      );
+    });
+  });
+
   test(
     'depends on a package in a deep subdirectory, non-relative uri',
     () async {


### PR DESCRIPTION
In `GitSource._validatedPath`, the check preventing git dependency paths from reaching outside the repository was executed against the raw input path string (`p.url.isWithin('.', path)`), while returning `p.url.normalize(parsed.toString())`.

Because `Uri.parse` decodes percent-encoded unreserved characters (such as `%2e` for `.`), an input like `'%2e%2e/%2e%2e/outside'` passed `p.url.isWithin` (which treated `%2e%2e` as a literal folder segment) while returning `'../../outside'`.

This change:
- Computes `normalized = p.url.normalize(parsed.toString())`.
- Validates that `normalized` does not escape `.` using `p.url`.
- Validates that the URI-decoded filesystem paths (both POSIX and Windows) do not reach outside `.` (blocking `%2e%2e`, `%2f`, and `%5c` encoded traversals).
- Exposes `windows` on `PathContextExt` in `lib/src/path.dart` for Windows path context operations.
- Adds test coverage in `test/get/git/path_test.dart` covering plain, percent-encoded, and slash-encoded path traversal attempts.

Fixes b/528619299