### PR TITLE
Validate that symlinks in git dependencies do not point outside repository

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -86,6 +86,19 @@ bool entryExists(String path) =>
 /// whether it's broken.
 bool linkExists(String link) => Link(link).existsSync();
 
+/// Returns the target of the symlink at [link].
+String readLink(String link) => Link(link).targetSync();
+
+/// Returns all symlink paths in [dir] recursively.
+List<String> listSymlinks(String dir) {
+  if (!dirExists(dir)) return const [];
+  return Directory(dir)
+      .listSync(recursive: true, followLinks: false)
+      .whereType<Link>()
+      .map((link) => link.path)
+      .toList();
+}
+
 /// Returns whether [file] exists on the file system.
 ///
 /// This returns `true` for a symlink only if that symlink is unbroken and

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -914,8 +914,7 @@ class GitSource extends CachedSource {
     required String packageName,
     required String url,
   }) {
-    final rootDir = Directory(repoRoot);
-    if (!rootDir.existsSync()) return;
+    if (!dirExists(repoRoot)) return;
 
     final normalizedRepoRoot = p.normalize(p.absolute(repoRoot));
 
@@ -929,8 +928,7 @@ class GitSource extends CachedSource {
         );
       }
 
-      final link = Link(linkPath);
-      final target = link.targetSync();
+      final target = readLink(linkPath);
       if (p.isAbsolute(target) ||
           target.startsWith('/') ||
           target.startsWith(r'\') ||
@@ -962,7 +960,7 @@ class GitSource extends CachedSource {
           }
         } else {
           final next = p.normalize(p.join(current, segment));
-          if (FileSystemEntity.isLinkSync(next)) {
+          if (linkExists(next)) {
             current = resolveLinkTarget(next, visited: Set.of(visited));
           } else {
             current = next;
@@ -982,12 +980,8 @@ class GitSource extends CachedSource {
       return current;
     }
 
-    for (final entity in rootDir.listSync(
-      recursive: true,
-      followLinks: false,
-    )) {
-      if (entity is! Link) continue;
-      resolveLinkTarget(entity.path, visited: {});
+    for (final linkPath in listSymlinks(repoRoot)) {
+      resolveLinkTarget(linkPath, visited: {});
     }
   }
 

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -908,7 +908,7 @@ class GitSource extends CachedSource {
   }
 
   /// Validates that no symbolic link in [repoRoot] points outside of
-  /// [repoRoot].
+  /// [repoRoot], resolving any intermediate symlinks or symlink chains.
   void _validateSymlinks(
     String repoRoot, {
     required String packageName,
@@ -917,28 +917,77 @@ class GitSource extends CachedSource {
     final rootDir = Directory(repoRoot);
     if (!rootDir.existsSync()) return;
 
-    for (final entity in rootDir.listSync(
-      recursive: true,
-      followLinks: false,
-    )) {
-      if (entity is! Link) continue;
+    final normalizedRepoRoot = p.normalize(p.absolute(repoRoot));
 
-      final target = entity.targetSync();
-      final linkDir = p.dirname(entity.path);
-      final resolvedTarget =
-          p.isAbsolute(target)
-              ? p.normalize(target)
-              : p.normalize(p.join(linkDir, target));
+    String resolveLinkTarget(String linkPath, {required Set<String> visited}) {
+      final canonicalLinkPath = p.normalize(p.absolute(linkPath));
+      if (!visited.add(canonicalLinkPath)) {
+        final relLinkPath = p.relative(linkPath, from: normalizedRepoRoot);
+        throw PackageNotFoundException(
+          'Package "$packageName" from "${GitDescription.prettyUri(url)}" '
+          'contains a circular symbolic link at "$relLinkPath".',
+        );
+      }
 
-      if (!p.isWithin(repoRoot, resolvedTarget) &&
-          !p.equals(repoRoot, resolvedTarget)) {
-        final relLinkPath = p.relative(entity.path, from: repoRoot);
+      final link = Link(linkPath);
+      final target = link.targetSync();
+      if (p.isAbsolute(target) ||
+          target.startsWith('/') ||
+          target.startsWith(r'\') ||
+          RegExp(r'^[a-zA-Z]:').hasMatch(target)) {
+        final relLinkPath = p.relative(linkPath, from: normalizedRepoRoot);
         throw PackageNotFoundException(
           'Package "$packageName" from "${GitDescription.prettyUri(url)}" '
           'contains a symbolic link "$relLinkPath" targeting "$target" '
           'which points outside the repository.',
         );
       }
+
+      final segments = target.split(RegExp(r'[/\\]'));
+      var current = p.normalize(p.absolute(p.dirname(linkPath)));
+
+      for (final segment in segments) {
+        if (segment == '' || segment == '.') {
+          continue;
+        } else if (segment == '..') {
+          current = p.dirname(current);
+          if (!p.isWithin(normalizedRepoRoot, current) &&
+              !p.equals(normalizedRepoRoot, current)) {
+            final relLinkPath = p.relative(linkPath, from: normalizedRepoRoot);
+            throw PackageNotFoundException(
+              'Package "$packageName" from "${GitDescription.prettyUri(url)}" '
+              'contains a symbolic link "$relLinkPath" targeting "$target" '
+              'which points outside the repository.',
+            );
+          }
+        } else {
+          final next = p.normalize(p.join(current, segment));
+          if (FileSystemEntity.isLinkSync(next)) {
+            current = resolveLinkTarget(next, visited: Set.of(visited));
+          } else {
+            current = next;
+          }
+          if (!p.isWithin(normalizedRepoRoot, current) &&
+              !p.equals(normalizedRepoRoot, current)) {
+            final relLinkPath = p.relative(linkPath, from: normalizedRepoRoot);
+            throw PackageNotFoundException(
+              'Package "$packageName" from "${GitDescription.prettyUri(url)}" '
+              'contains a symbolic link "$relLinkPath" targeting "$target" '
+              'which points outside the repository.',
+            );
+          }
+        }
+      }
+
+      return current;
+    }
+
+    for (final entity in rootDir.listSync(
+      recursive: true,
+      followLinks: false,
+    )) {
+      if (entity is! Link) continue;
+      resolveLinkTarget(entity.path, visited: {});
     }
   }
 

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -908,7 +908,24 @@ class GitSource extends CachedSource {
   }
 
   /// Validates that no symbolic link in [repoRoot] points outside of
-  /// [repoRoot], resolving any intermediate symlinks or symlink chains.
+  /// [repoRoot], including any intermediate symlinks, chained links, or
+  /// directory symlinks.
+  ///
+  /// For every symbolic link found in [repoRoot]:
+  /// - Absolute links (starting with `/`, `\`, or Windows drive letters) are
+  ///   rejected.
+  /// - Relative links are resolved segment-by-segment. If a path segment
+  ///   encounters an intermediate directory symlink, that link is recursively
+  ///   dereferenced and resolved to ensure no combination of symlinks and `..`
+  ///   traversals can escape [repoRoot].
+  /// - Cycles in symlink chains are detected and rejected.
+  /// - If any link or chain resolves to a location outside [repoRoot], a
+  ///   [PackageNotFoundException] is thrown.
+  ///
+  /// Note: Git repositories do not support hardlinks in tree objects or working
+  /// tree checkouts (Git tree entries are limited to regular files, executable
+  /// files, symlinks, and submodules), so only symbolic links need to be
+  /// validated here.
   void _validateSymlinks(
     String repoRoot, {
     required String packageName,

--- a/lib/src/source/git.dart
+++ b/lib/src/source/git.dart
@@ -496,6 +496,16 @@ class GitSource extends CachedSource {
               description.url,
             ], workingDir: revisionCachePath);
             await _checkOut(revisionCachePath, resolvedRef);
+            try {
+              _validateSymlinks(
+                revisionCachePath,
+                packageName: id.name,
+                url: description.url,
+              );
+            } catch (_) {
+              tryDeleteEntry(revisionCachePath);
+              rethrow;
+            }
             _writePackageList(revisionCachePath, [path]);
             didUpdate = true;
           } else {
@@ -604,10 +614,15 @@ class GitSource extends CachedSource {
         // Discard all changes to tracked files.
         await git.run(['reset', '--hard', 'HEAD'], workingDir: package.dir);
 
+        final repoRoot = git.repoRoot(package.dir);
+        if (repoRoot != null) {
+          _validateSymlinks(repoRoot, packageName: package.name, url: repoRoot);
+        }
+
         result.add(
           RepairResult(package.name, package.version, this, success: true),
         );
-      } on git.GitException catch (error, stackTrace) {
+      } catch (error, stackTrace) {
         log.error(
           'Failed to reset ${log.bold(package.name)} '
           '${package.version}. Error:\n$error',
@@ -890,6 +905,41 @@ class GitSource extends CachedSource {
     return git
         .run(['checkout', ref], workingDir: repoPath)
         .then((result) => null);
+  }
+
+  /// Validates that no symbolic link in [repoRoot] points outside of
+  /// [repoRoot].
+  void _validateSymlinks(
+    String repoRoot, {
+    required String packageName,
+    required String url,
+  }) {
+    final rootDir = Directory(repoRoot);
+    if (!rootDir.existsSync()) return;
+
+    for (final entity in rootDir.listSync(
+      recursive: true,
+      followLinks: false,
+    )) {
+      if (entity is! Link) continue;
+
+      final target = entity.targetSync();
+      final linkDir = p.dirname(entity.path);
+      final resolvedTarget =
+          p.isAbsolute(target)
+              ? p.normalize(target)
+              : p.normalize(p.join(linkDir, target));
+
+      if (!p.isWithin(repoRoot, resolvedTarget) &&
+          !p.equals(repoRoot, resolvedTarget)) {
+        final relLinkPath = p.relative(entity.path, from: repoRoot);
+        throw PackageNotFoundException(
+          'Package "$packageName" from "${GitDescription.prettyUri(url)}" '
+          'contains a symbolic link "$relLinkPath" targeting "$target" '
+          'which points outside the repository.',
+        );
+      }
+    }
   }
 
   String _revisionCachePath(PackageId id, SystemCache cache) => p.join(

--- a/test/descriptor/link_descriptor.dart
+++ b/test/descriptor/link_descriptor.dart
@@ -41,8 +41,8 @@ class LinkDescriptor extends d.Descriptor {
     try {
       final actualTarget = link.targetSync();
       expect(
-        actualTarget,
-        target,
+        p.normalize(actualTarget),
+        p.normalize(target),
         reason: 'Link doesn\'t point where expected.',
       );
     } on FileSystemException catch (e) {

--- a/test/get/git/symlink_test.dart
+++ b/test/get/git/symlink_test.dart
@@ -106,4 +106,87 @@ void main() {
       exitCode: exit_codes.UNAVAILABLE,
     );
   });
+
+  test('allows chained internal relative symlinks in a git package', () async {
+    ensureGit();
+
+    await d.git('foo.git', [
+      d.libPubspec('foo', '1.0.0'),
+      d.dir('lib', [
+        d.file('foo.dart', 'const foo = "foo";'),
+        d.link('link1.dart', 'foo.dart'),
+        d.link('link2.dart', 'link1.dart'),
+      ]),
+    ]).create();
+
+    await d
+        .appDir(
+          dependencies: {
+            'foo': {'git': '../foo.git'},
+          },
+        )
+        .create();
+
+    await pubGet();
+
+    expect(packageSpec('foo'), isNotNull);
+  });
+
+  test('rejects escaping symlinks created by combining symlinks', () async {
+    ensureGit();
+
+    await d.git('foo.git', [
+      d.libPubspec('foo', '1.0.0'),
+      d.dir('lib', [
+        d.file('foo.dart', 'const foo = "foo";'),
+        d.dir('sub', [
+          d.link('parent_link', '..'),
+          d.link('escape_link', 'parent_link/../../../../etc/passwd'),
+        ]),
+      ]),
+    ]).create();
+
+    await d
+        .appDir(
+          dependencies: {
+            'foo': {'git': '../foo.git'},
+          },
+        )
+        .create();
+
+    await pubGet(
+      error: contains(
+        'contains a symbolic link "lib/sub/escape_link" targeting "parent_link/../../../../etc/passwd" which points outside the repository.',
+      ),
+      exitCode: exit_codes.UNAVAILABLE,
+    );
+  });
+
+  test('rejects circular symlinks in a git package', () async {
+    ensureGit();
+
+    await d.git('foo.git', [
+      d.libPubspec('foo', '1.0.0'),
+      d.dir('lib', [
+        d.file('foo.dart', 'const foo = "foo";'),
+        d.link('circ1.dart', 'circ2.dart'),
+        d.link('circ2.dart', 'circ1.dart'),
+      ]),
+    ]).create();
+
+    await d
+        .appDir(
+          dependencies: {
+            'foo': {'git': '../foo.git'},
+          },
+        )
+        .create();
+
+    await pubGet(
+      error: matches(
+        r'contains a circular symbolic link at "lib/circ[12]\.dart"',
+      ),
+      exitCode: exit_codes.UNAVAILABLE,
+    );
+  });
 }

--- a/test/get/git/symlink_test.dart
+++ b/test/get/git/symlink_test.dart
@@ -1,0 +1,109 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+library;
+
+import 'package:pub/src/exit_codes.dart' as exit_codes;
+import 'package:test/test.dart';
+
+import '../../descriptor.dart' as d;
+import '../../test_pub.dart';
+
+void main() {
+  test('allows internal relative symlinks in a git package', () async {
+    ensureGit();
+
+    await d.git('foo.git', [
+      d.libPubspec('foo', '1.0.0'),
+      d.dir('lib', [
+        d.file('foo.dart', 'const foo = "foo";'),
+        d.link('foo_link.dart', 'foo.dart'),
+      ]),
+      d.dir('ios', [d.file('classes.h', '// header')]),
+      d.dir('macos', [d.link('classes.h', '../ios/classes.h')]),
+    ]).create();
+
+    await d
+        .appDir(
+          dependencies: {
+            'foo': {'git': '../foo.git'},
+          },
+        )
+        .create();
+
+    await pubGet();
+
+    await d.dir(cachePath, [
+      d.dir('git', [
+        d.dir('cache', [d.gitPackageRepoCacheDir('foo')]),
+        d.hashDir('foo', [
+          d.libPubspec('foo', '1.0.0'),
+          d.dir('lib', [
+            d.file('foo.dart', 'const foo = "foo";'),
+            d.link('foo_link.dart', 'foo.dart'),
+          ]),
+          d.dir('ios', [d.file('classes.h', '// header')]),
+          d.dir('macos', [d.link('classes.h', '../ios/classes.h')]),
+        ]),
+      ]),
+    ]).validate();
+
+    expect(packageSpec('foo'), isNotNull);
+  });
+
+  test('rejects symlinks that escape repository via relative path', () async {
+    ensureGit();
+
+    await d.git('foo.git', [
+      d.libPubspec('foo', '1.0.0'),
+      d.dir('lib', [
+        d.file('foo.dart', 'const foo = "foo";'),
+        d.link('escape_link', '../../../../etc/passwd'),
+      ]),
+    ]).create();
+
+    await d
+        .appDir(
+          dependencies: {
+            'foo': {'git': '../foo.git'},
+          },
+        )
+        .create();
+
+    await pubGet(
+      error: contains(
+        'contains a symbolic link "lib/escape_link" targeting "../../../../etc/passwd" which points outside the repository.',
+      ),
+      exitCode: exit_codes.UNAVAILABLE,
+    );
+  });
+
+  test('rejects absolute symlinks in a git package', () async {
+    ensureGit();
+
+    await d.git('foo.git', [
+      d.libPubspec('foo', '1.0.0'),
+      d.dir('lib', [
+        d.file('foo.dart', 'const foo = "foo";'),
+        d.link('abs_link', '/etc/passwd'),
+      ]),
+    ]).create();
+
+    await d
+        .appDir(
+          dependencies: {
+            'foo': {'git': '../foo.git'},
+          },
+        )
+        .create();
+
+    await pubGet(
+      error: contains(
+        'contains a symbolic link "lib/abs_link" targeting "/etc/passwd" which points outside the repository.',
+      ),
+      exitCode: exit_codes.UNAVAILABLE,
+    );
+  });
+}

--- a/test/get/git/symlink_test.dart
+++ b/test/get/git/symlink_test.dart
@@ -73,8 +73,8 @@ void main() {
         .create();
 
     await pubGet(
-      error: contains(
-        'contains a symbolic link "lib/escape_link" targeting "../../../../etc/passwd" which points outside the repository.',
+      error: matches(
+        r'contains a symbolic link "lib[/\\]escape_link" targeting "(\.\.[/\\]){4}etc[/\\]passwd" which points outside the repository\.',
       ),
       exitCode: exit_codes.UNAVAILABLE,
     );
@@ -100,8 +100,8 @@ void main() {
         .create();
 
     await pubGet(
-      error: contains(
-        'contains a symbolic link "lib/abs_link" targeting "/etc/passwd" which points outside the repository.',
+      error: matches(
+        r'contains a symbolic link "lib[/\\]abs_link" targeting "[/\\]etc[/\\]passwd" which points outside the repository\.',
       ),
       exitCode: exit_codes.UNAVAILABLE,
     );
@@ -155,8 +155,8 @@ void main() {
         .create();
 
     await pubGet(
-      error: contains(
-        'contains a symbolic link "lib/sub/escape_link" targeting "parent_link/../../../../etc/passwd" which points outside the repository.',
+      error: matches(
+        r'contains a symbolic link "lib[/\\]sub[/\\]escape_link" targeting "parent_link[/\\](\.\.[/\\]){4}etc[/\\]passwd" which points outside the repository\.',
       ),
       exitCode: exit_codes.UNAVAILABLE,
     );
@@ -184,7 +184,7 @@ void main() {
 
     await pubGet(
       error: matches(
-        r'contains a circular symbolic link at "lib/circ[12]\.dart"',
+        r'contains a circular symbolic link at "lib[/\\]circ[12]\.dart"',
       ),
       exitCode: exit_codes.UNAVAILABLE,
     );


### PR DESCRIPTION
## Summary
When cloning and checking out a Git dependency into the system cache, validate that any symbolic links contained within the repository point to locations inside the repository boundary.

- Fully resolves intermediate symbolic links and link chains recursively to ensure combining symlinks cannot be used to escape the repository boundary.
- Detects and rejects circular symlink loops.
- Preserves legitimate internal symlinks (e.g. `macos/Classes/foo.h -> ../../ios/Classes/foo.h` or `lib/b.dart -> a.dart`) commonly used across platforms by Flutter plugins and native packages.
- Rejects absolute symlinks (e.g. `/etc/passwd`) or relative symlinks traversing outside the repository (e.g. `../../../../etc/passwd` or combined directory link escapes like `parent_link/../outside`) by throwing a `PackageNotFoundException` and cleaning up the cache directory.
- Also validates symlinks during `repairCachedPackages`.

## Testing
- Added unit tests in `test/get/git/symlink_test.dart` testing:
  1. Allowing internal relative symlinks within the git repo.
  2. Allowing chained internal relative symlinks (`link1 -> link2 -> foo.dart`).
  3. Rejecting symlinks escaping the repository via relative path traversal.
  4. Rejecting escaping symlinks created by combining directory symlinks (`sub/parent_link -> ..`, `sub/escape_link -> parent_link/../../../../etc/passwd`).
  5. Rejecting absolute symlinks.
  6. Rejecting circular symlinks (`circ1 -> circ2 -> circ1`).