### PR TITLE
Sanitize 'replacedBy' and advisory 'displayHandle' for terminal output

### DIFF
--- a/lib/src/source/hosted.dart
+++ b/lib/src/source/hosted.dart
@@ -436,7 +436,8 @@ class HostedSource extends CachedSource {
       }
       final status = PackageStatus(
         isDiscontinued: isDiscontinued,
-        discontinuedReplacedBy: replacedBy,
+        discontinuedReplacedBy:
+            replacedBy == null ? null : sanitizeForTerminal(replacedBy),
         isRetracted: retracted,
         advisoriesUpdated: advisoriesDate,
       );
@@ -2083,7 +2084,7 @@ class Advisory {
     this.pubDisplayUrl,
   });
 
-  String get displayHandle => pubDisplayUrl ?? id;
+  String get displayHandle => sanitizeForTerminal(pubDisplayUrl ?? id);
 }
 
 /// Given a URL, returns a "normalized" string to be used as a directory name

--- a/test/get/hosted/advisory_test.dart
+++ b/test/get/hosted/advisory_test.dart
@@ -530,4 +530,39 @@ Future<void> main() async {
     // the advisory warning, making zero network requests.
     await pubGet(output: contains('affected by advisory'));
   });
+
+  test('sanitizes escape sequences in displayUrl and id', () async {
+    final server = await servePackages();
+    server
+      ..serve('foo', '1.0.0')
+      ..serve('bar', '1.0.0');
+
+    await d.dir(appPath, [
+      d.pubspec({
+        'name': 'app',
+        'dependencies': {'foo': '^1.0.0', 'bar': '^1.0.0'},
+      }),
+    ]).create();
+
+    server.addAdvisory(
+      advisoryId: 'ID-1\x1b]52;c;evil\x07',
+      displayUrl: 'https://example.com/advisory/\x1b]52;c;evil\x07',
+      affectedPackages: [
+        AffectedPackage(name: 'foo', versions: ['1.0.0']),
+      ],
+    );
+    server.addAdvisory(
+      advisoryId: 'ID-2\x1b]52;c;evil\x07',
+      affectedPackages: [
+        AffectedPackage(name: 'bar', versions: ['1.0.0']),
+      ],
+    );
+
+    await pubGet(
+      output: allOf(
+        contains('https://example.com/advisory/ ]52;c;evil '),
+        contains('ID-2 ]52;c;evil '),
+      ),
+    );
+  });
 }

--- a/test/get/hosted/warn_about_discontinued_test.dart
+++ b/test/get/hosted/warn_about_discontinued_test.dart
@@ -236,4 +236,23 @@ Got dependencies!
     /// unlock.
     await pubGet();
   });
+
+  test(
+    'Warns about discontinued dependencies with replacement sanitized',
+    () async {
+      final server = await servePackages();
+      server
+        ..serve('foo', '1.2.3')
+        ..discontinue('foo', replacementText: 'bar\x1b]52;c;evil\x07baz');
+      await d.appDir(dependencies: {'foo': '1.2.3'}).create();
+      await pubGet(
+        output: '''
+Resolving dependencies...
+Downloading packages...
++ foo 1.2.3 (discontinued replaced by bar ]52;c;evil baz)
+Changed 1 dependency!
+1 package is discontinued.''',
+      );
+    },
+  );
 }

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -200,4 +200,20 @@ b: {}'''),
     expect(() => hexDecode('0p'), throwsA(isA<FormatException>()));
     expect(() => hexDecode('p0'), throwsA(isA<FormatException>()));
   });
+
+  group('sanitizeForTerminal', () {
+    test('neutralizes control characters and non-ascii', () {
+      expect(
+        sanitizeForTerminal('bar\x1b]52;c;evil\x07baz'),
+        'bar ]52;c;evil baz',
+      );
+      expect(sanitizeForTerminal('hello\x00world'), 'hello world');
+      expect(sanitizeForTerminal('unicode: 🚀'), 'unicode:  ');
+    });
+
+    test('truncates at 1024 characters', () {
+      final long = 'a' * 2000;
+      expect(sanitizeForTerminal(long), 'a' * 1024);
+    });
+  });
 }


### PR DESCRIPTION
Sanitizes the `replacedBy` field from hosted package listings and the security advisory `displayHandle` (`pubDisplayUrl ?? id`) using `sanitizeForTerminal` before displaying them in terminal output.

This prevents terminal escape sequence injection (e.g. OSC 52 clipboard hijacking or CSI cursor manipulation) from malicious or compromised third-party package repositories.
