### PR TITLE
Pass --no-resolve to pub unpack in pubcommand_test

### DIFF
--- a/test/overrides/pubcommand_test.dart
+++ b/test/overrides/pubcommand_test.dart
@@ -62,7 +62,7 @@ environment:
       expect(await pub(['outdated']), 0);
       expect(await pub(['upgrade']), 0);
       expect(await pub(['remove', 'retry']), 0);
-      expect(await pub(['unpack', 'retry']), 0);
+      expect(await pub(['unpack', 'retry', '--no-resolve']), 0);
     } catch (_) {
       printOnFailure(utf8.decode(bs.bytes));
       rethrow;


### PR DESCRIPTION
In `test/overrides/pubcommand_test.dart`, `pub(['unpack', 'retry'])` runs `pub unpack` which defaults to `--resolve`.

`retry` specifies dev-dependencies on `test` and `lints`. Because `retry` is unpacked as a new root package into an empty in-memory cache, `pub get` resolves and downloads all 45+ transitive dependencies of `package:test` from `pub.dev`. In CI runners, this regularly exceeds the 90s test timeout.

Passing `--no-resolve` tests `unpack` in memory without resolving dev dependencies of the unpacked package.