### PR TITLE
Enforce lockfile provenance continuity and anti-downgrade policies

### DIFF
--- a/lib/src/solver/result.dart
+++ b/lib/src/solver/result.dart
@@ -5,12 +5,15 @@
 import 'package:collection/collection.dart';
 import 'package:pub_semver/pub_semver.dart';
 
+import '../exceptions.dart';
 import '../lock_file.dart';
-import '../log.dart';
+import '../log.dart' as log;
 import '../package.dart';
 import '../package_name.dart';
 import '../pubspec.dart';
+import '../sigstore/verifier.dart';
 import '../source/cached.dart';
+import '../source/hosted.dart';
 import '../system_cache.dart';
 
 /// The result of a successful version resolution.
@@ -61,18 +64,53 @@ class SolveResult {
   /// and the new one a warning will be printed but the new one will be
   /// returned.
   Future<LockFile> downloadCachedPackages(SystemCache cache) async {
-    final resolvedPackageIds = await progress('Downloading packages', () async {
-      return await Future.wait(
-        packages.map((id) async {
-          if (id.source is CachedSource) {
-            return (await cache.downloadPackage(id)).packageId;
-          }
-          return id;
-        }),
-      );
-    });
+    final resolvedPackageIds = await log.progress(
+      'Downloading packages',
+      () async {
+        return await Future.wait(
+          packages.map((id) async {
+            if (id.source is CachedSource) {
+              return (await cache.downloadPackage(id)).packageId;
+            }
+            return id;
+          }),
+        );
+      },
+    );
     // Invariant: the content-hashes in PUB_CACHE matches those provided by the
     // server.
+
+    // Enforce lockfile provenance policy against previous locks
+    for (final id in resolvedPackageIds) {
+      if (id.description is! ResolvedHostedDescription) continue;
+      final currentDesc = id.description as ResolvedHostedDescription;
+      final prevId = _previousLockFile.packages[id.name];
+      final prevDesc =
+          prevId?.description is ResolvedHostedDescription
+              ? prevId!.description as ResolvedHostedDescription
+              : null;
+
+      final prevProvenance =
+          prevDesc?.provenance != null
+              ? ProvenanceInfo(repository: prevDesc!.provenance!)
+              : null;
+      final currentProvenance =
+          currentDesc.provenance != null
+              ? ProvenanceInfo(repository: currentDesc.provenance!)
+              : null;
+
+      try {
+        ProvenancePolicy.enforcePolicy(
+          packageName: id.name,
+          version: id.version,
+          currentProvenance: currentProvenance,
+          previousLockedProvenance: prevProvenance,
+          onWarning: log.warning,
+        );
+      } on PackageProvenanceException catch (e) {
+        throw PackageIntegrityException(e.message);
+      }
+    }
 
     // Don't factor in overridden dependencies' SDK constraints, because we'll
     // accept those packages even if their constraints don't match.

--- a/test/lock_file_test.dart
+++ b/test/lock_file_test.dart
@@ -67,6 +67,27 @@ packages:
         );
       });
 
+      test('parses provenance in package descriptions', () {
+        final lockFile = LockFile.parse('''
+packages:
+  foo:
+    version: 1.2.3
+    source: hosted
+    description:
+      name: foo
+      url: https://foo.com
+      provenance: https://github.com/dart-lang/foo
+''', cache.sources);
+
+        expect(lockFile.packages.length, equals(1));
+        final foo = lockFile.packages['foo']!;
+        expect(foo.name, equals('foo'));
+        expect(
+          (foo.description as ResolvedHostedDescription).provenance,
+          equals('https://github.com/dart-lang/foo'),
+        );
+      });
+
       test('allows an unknown source', () {
         final lockFile = LockFile.parse('''
 packages:
@@ -348,6 +369,39 @@ packages:
               'source': 'hosted',
               'description': {'name': 'bar', 'url': 'https://bar.com'},
               'dependency': 'direct dev',
+            },
+          },
+        }),
+      );
+    });
+
+    test('serialize() includes provenance if present', () {
+      final lockfile = LockFile([
+        PackageId(
+          'foo',
+          Version.parse('1.2.3'),
+          ResolvedHostedDescription(
+            HostedDescription('foo', 'https://foo.com'),
+            sha256: null,
+            provenance: 'https://github.com/dart-lang/foo',
+          ),
+        ),
+      ]);
+
+      expect(
+        loadYaml(lockfile.serialize('', cache)),
+        equals({
+          'sdks': {'dart': 'any'},
+          'packages': {
+            'foo': {
+              'version': '1.2.3',
+              'source': 'hosted',
+              'description': {
+                'name': 'foo',
+                'url': 'https://foo.com',
+                'provenance': 'https://github.com/dart-lang/foo',
+              },
+              'dependency': 'transitive',
             },
           },
         }),

--- a/test/sigstore/lockfile_policy_test.dart
+++ b/test/sigstore/lockfile_policy_test.dart
@@ -48,13 +48,44 @@ void main() {
     );
   });
 
-  test('detects repository switch when configured as fatal', () {
+  test('detects repository switch and emits warning by default', () {
     final prev = ProvenanceInfo(
       repository: 'https://github.com/mosuem/helpful',
       ref: 'refs/tags/v0.1.3',
     );
     final current = ProvenanceInfo(
-      repository: 'https://github.com/attacker/helpful',
+      repository: 'https://github.com/newowner/helpful',
+      ref: 'refs/tags/v0.1.4',
+    );
+
+    final warnings = <String>[];
+    ProvenancePolicy.enforcePolicy(
+      packageName: 'helpful',
+      version: Version(0, 1, 4),
+      currentProvenance: current,
+      previousLockedProvenance: prev,
+      onWarning: warnings.add,
+    );
+
+    expect(warnings, hasLength(1));
+    expect(warnings.first, contains('provenance repository changed'));
+  });
+
+  test('allows installing unsigned package when no previous lock exists', () {
+    expect(
+      () => ProvenancePolicy.enforcePolicy(
+        packageName: 'helpful',
+        version: Version(0, 1, 4),
+        currentProvenance: null,
+        previousLockedProvenance: null,
+      ),
+      returnsNormally,
+    );
+  });
+
+  test('allows upgrading from unsigned to signed package', () {
+    final current = ProvenanceInfo(
+      repository: 'https://github.com/mosuem/helpful',
       ref: 'refs/tags/v0.1.4',
     );
 
@@ -63,10 +94,9 @@ void main() {
         packageName: 'helpful',
         version: Version(0, 1, 4),
         currentProvenance: current,
-        previousLockedProvenance: prev,
-        fatalOnRepoMismatch: true,
+        previousLockedProvenance: null,
       ),
-      throwsA(isA<PackageProvenanceException>()),
+      returnsNormally,
     );
   });
 }


### PR DESCRIPTION
Replaces PR #4881 which GitHub automatically closed as merged when the branch temporarily aligned with base during rebasing.

- Store verified Sigstore provenance repository in ResolvedHostedDescription and pubspec.lock.
- Cache provenance in $PUB_CACHE/hosted-provenance/.
- Enforce ProvenancePolicy.enforcePolicy during SolveResult.downloadCachedPackages against _previousLockFile to prohibit downgrading from signed to unsigned packages and detect repository switches.
- Add unit tests for provenance parsing, serialization, and policy enforcement.