### PR TITLE
Prepare for default branch migration to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-BUG.md
+++ b/.github/ISSUE_TEMPLATE/2-BUG.md
@@ -11,7 +11,7 @@ Describe anything relevant to the issue you are seeing. Consider including:
 - Dart/Flutter version (run `dart --version` or `flutter --version`):
 - OS kind and version (e.g. "Windows 10, version 1809" or "macOS 12.4"):
 - In case of network issues
-  * consider running https://github.com/dart-lang/pub-dev/blob/master/app/bin/tools/check_domain_access.dart
+  * consider running https://github.com/dart-lang/pub-dev/blob/main/app/bin/tools/check_domain_access.dart
   and adding the output.
 - Are you using the Chinese community mirror or a corporate firewall?
 

--- a/.github/workflows/sync_master.yaml
+++ b/.github/workflows/sync_master.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'dart-lang' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sync_master.yaml
+++ b/.github/workflows/sync_master.yaml
@@ -1,0 +1,22 @@
+name: Sync master with main
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  sync-master:
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'dart-lang' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fast-forward master to main
+        run: |
+          git push origin HEAD:refs/heads/master --force

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,9 +6,9 @@ permissions:
 on:
   # Run CI on pushes to the main branch, and on PRs against main.
   push:
-    branches: [master]
+    branches: [main, master]
   pull_request:
-    branches: [master]
+    branches: [main, master]
   schedule:
     - cron: '0 0 * * 0'
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/dart-lang/pub/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/pub/actions/workflows/test.yaml?query=workflow%3A%22Dart+CI%22+branch%3Amaster)
+[![Build Status](https://github.com/dart-lang/pub/workflows/Dart%20CI/badge.svg)](https://github.com/dart-lang/pub/actions/workflows/test.yaml?query=workflow%3A%22Dart+CI%22+branch%3Amain)
 
 Pub is the package manager for Dart.
 

--- a/lib/src/solver/failure.dart
+++ b/lib/src/solver/failure.dart
@@ -55,7 +55,7 @@ class SolveFailure implements ApplicationException {
 /// A class that writes a human-readable description of the cause of a
 /// [SolveFailure].
 ///
-/// See https://github.com/dart-lang/pub/tree/master/doc/solver.md#error-reporting
+/// See https://github.com/dart-lang/pub/tree/main/doc/solver.md#error-reporting
 /// for details on how this algorithm works.
 class _Writer {
   /// The root incompatibility.

--- a/lib/src/solver/incompatibility.dart
+++ b/lib/src/solver/incompatibility.dart
@@ -8,7 +8,7 @@ import 'term.dart';
 
 /// A set of mutually-incompatible terms.
 ///
-/// See https://github.com/dart-lang/pub/tree/master/doc/solver.md#incompatibility.
+/// See https://github.com/dart-lang/pub/tree/main/doc/solver.md#incompatibility.
 class Incompatibility {
   /// The mutually-incompatible terms.
   final List<Term> terms;

--- a/lib/src/solver/partial_solution.dart
+++ b/lib/src/solver/partial_solution.dart
@@ -12,7 +12,7 @@ import 'term.dart';
 /// what's true for the eventual set of package versions that will comprise the
 /// total solution.
 ///
-/// See https://github.com/dart-lang/pub/tree/master/doc/solver.md#partial-solution.
+/// See https://github.com/dart-lang/pub/tree/main/doc/solver.md#partial-solution.
 class PartialSolution {
   /// The canonical [PackageRef]s of workspace root packages, keyed by package
   /// name.

--- a/lib/src/solver/term.dart
+++ b/lib/src/solver/term.dart
@@ -10,7 +10,7 @@ import 'set_relation.dart';
 /// A statement about a package which is true or false for a given selection of
 /// package versions.
 ///
-/// See https://github.com/dart-lang/pub/tree/master/doc/solver.md#term.
+/// See https://github.com/dart-lang/pub/tree/main/doc/solver.md#term.
 class Term {
   /// Whether the term is positive or not.
   ///

--- a/lib/src/solver/version_solver.dart
+++ b/lib/src/solver/version_solver.dart
@@ -37,7 +37,7 @@ import 'type.dart';
 /// The version solver that finds a set of package versions that satisfy the
 /// root package's dependencies.
 ///
-/// See https://github.com/dart-lang/pub/tree/master/doc/solver.md for details
+/// See https://github.com/dart-lang/pub/tree/main/doc/solver.md for details
 /// on how this solver works.
 class VersionSolver {
   /// All known incompatibilities, indexed by package name.
@@ -150,7 +150,7 @@ class VersionSolver {
   /// Performs [unit propagation][] on incompatibilities transitively related to
   /// [package] to derive new assignments for [_solution].
   ///
-  /// [unit propagation]: https://github.com/dart-lang/pub/tree/master/doc/solver.md#unit-propagation
+  /// [unit propagation]: https://github.com/dart-lang/pub/tree/main/doc/solver.md#unit-propagation
   void _propagate(String package) {
     final changed = {package};
 
@@ -188,7 +188,7 @@ class VersionSolver {
   /// If [incompatibility] is [almost satisfied][] by [_solution], adds the
   /// negation of the unsatisfied term to [_solution].
   ///
-  /// [almost satisfied]: https://github.com/dart-lang/pub/tree/master/doc/solver.md#incompatibility
+  /// [almost satisfied]: https://github.com/dart-lang/pub/tree/main/doc/solver.md#incompatibility
   ///
   /// If [incompatibility] is satisfied by [_solution], returns `#conflict`. If
   /// [incompatibility] is almost satisfied by [_solution], returns the
@@ -244,7 +244,7 @@ class VersionSolver {
   /// incompatibility will allow [_propagate] to deduce new assignments.
   ///
   /// [conflict resolution]:
-  /// https://github.com/dart-lang/pub/tree/master/doc/solver.md#conflict-resolution
+  /// https://github.com/dart-lang/pub/tree/main/doc/solver.md#conflict-resolution
   ///
   /// Adds the new incompatibility to [_incompatibilities] and returns it.
   Incompatibility _resolveConflict(Incompatibility incompatibility) {
@@ -349,7 +349,7 @@ class VersionSolver {
       // the incompatibility as well, See [the algorithm documentation][] for
       // details.
       //
-      // [the algorithm documentation]: https://github.com/dart-lang/pub/tree/master/doc/solver.md#conflict-resolution
+      // [the algorithm documentation]: https://github.com/dart-lang/pub/tree/main/doc/solver.md#conflict-resolution
       if (difference != null) newTerms.add(difference.inverse);
 
       incompatibility = Incompatibility(


### PR DESCRIPTION
This PR prepares the repository for migrating the default branch from `master` to `main`:

- Adds `.github/workflows/sync_master.yaml` to continuously fast-forward `master` to `main` on every push to `main`.
- Updates CI workflow triggers to run on both `[main, master]`.
- Updates README badge and internal doc links from `master` to `main`.