### PR TITLE
Document ETag conditional requests in repository specification

### DIFF
--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -303,10 +303,6 @@ Content-Type: application/vnd.pub.v2+json
 ETag: W/"123456789"
 ```
 
-The ETag value may be either a strong entity-tag (e.g. `"123456789"`) or a weak
-entity-tag (e.g. `W/"123456789"`), formatted in accordance with [RFC 9110
-Section 8.8.3](https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.3).
-
 When the `dart pub` client has a cached package listing that was saved with an
 ETag, subsequent requests to `<hosted-url>/api/packages/<package>` will include
 an `If-None-Match` header carrying that ETag:
@@ -326,8 +322,6 @@ HTTP/1.1 304 Not Modified
 ETag: W/"123456789"
 ```
 
-(The `ETag` header in a `304` response is optional, but recommended.)
-
 When receiving `304 Not Modified`, the client reuses its previously cached
 version listing document without downloading or parsing the JSON body again.
 
@@ -335,29 +329,9 @@ If the package listing has changed (or if no `If-None-Match` header was sent, or
 the tag does not match), the server returns `200 OK` with the complete JSON
 listing and an updated `ETag` header.
 
-#### ETag Invalidation Requirements
-
-If a package repository supports ETags, the server **must** guarantee that the
-ETag changes whenever any part of the package listing response changes. This
-includes:
-* A new version of the package is published,
-* An existing version is retracted or un-retracted,
-* Metadata for any version is updated (e.g. `pubspec`, `archive_url`, or
-  `archive_sha256`),
-* Package-level attributes change (such as `isDiscontinued` or `replacedBy`),
-* The `advisoriesUpdated` timestamp changes.
-
-#### Backwards Compatibility
-
-ETag support is **optional** for package repositories. If a server does not
-support ETags or ignores the `If-None-Match` header, it should simply return
-`200 OK` with the full listing as usual. The `dart pub` client operates
-normally with such servers.
-
-Repositories are nevertheless strongly encouraged to implement ETag support.
-Version listing requests represent a significant portion of network requests
-during dependency resolution, and enabling conditional caching reduces latency,
-bandwidth, and server resource usage.
+ETag support is optional for package repositories; servers that do not support
+conditional requests can simply ignore `If-None-Match` and return `200 OK` as
+usual.
 
 ## Publishing Packages
 

--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -220,9 +220,11 @@ server, this could work in many different ways.
 
 **Headers:**
 * `Accept: application/vnd.pub.v2+json`
+* `If-None-Match: <etag>` (optional)
 
 **Response**
 * `Content-Type: application/vnd.pub.v2+json`
+* `ETag: <etag>` (optional)
 
 ```js
 {
@@ -284,6 +286,78 @@ The `advisoriesUpdated` property is optional, if specified the client may assume
 that the advisories end-point is supported by the server. If present this must
 be a timestamp of when the result from the advisories end-point for this package
 changed.
+
+### Conditional Requests (ETags)
+
+Package repositories may support conditional HTTP requests using
+[ETags](https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.3) to allow
+clients to cache version listings and avoid transferring the full payload when
+no changes have occurred.
+
+When returning a `200 OK` response for the package listing, the repository may
+include an `ETag` HTTP response header:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/vnd.pub.v2+json
+ETag: W/"123456789"
+```
+
+The ETag value may be either a strong entity-tag (e.g. `"123456789"`) or a weak
+entity-tag (e.g. `W/"123456789"`), formatted in accordance with [RFC 9110
+Section 8.8.3](https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.3).
+
+When the `dart pub` client has a cached package listing that was saved with an
+ETag, subsequent requests to `<hosted-url>/api/packages/<package>` will include
+an `If-None-Match` header carrying that ETag:
+
+```http
+GET /api/packages/<package> HTTP/1.1
+Host: <hosted-url>
+Accept: application/vnd.pub.v2+json
+If-None-Match: W/"123456789"
+```
+
+If the package listing has not changed on the server, the repository should
+respond with `304 Not Modified` and an empty response body:
+
+```http
+HTTP/1.1 304 Not Modified
+ETag: W/"123456789"
+```
+
+(The `ETag` header in a `304` response is optional, but recommended.)
+
+When receiving `304 Not Modified`, the client reuses its previously cached
+version listing document without downloading or parsing the JSON body again.
+
+If the package listing has changed (or if no `If-None-Match` header was sent, or
+the tag does not match), the server returns `200 OK` with the complete JSON
+listing and an updated `ETag` header.
+
+#### ETag Invalidation Requirements
+
+If a package repository supports ETags, the server **must** guarantee that the
+ETag changes whenever any part of the package listing response changes. This
+includes:
+* A new version of the package is published,
+* An existing version is retracted or un-retracted,
+* Metadata for any version is updated (e.g. `pubspec`, `archive_url`, or
+  `archive_sha256`),
+* Package-level attributes change (such as `isDiscontinued` or `replacedBy`),
+* The `advisoriesUpdated` timestamp changes.
+
+#### Backwards Compatibility
+
+ETag support is **optional** for package repositories. If a server does not
+support ETags or ignores the `If-None-Match` header, it should simply return
+`200 OK` with the full listing as usual. The `dart pub` client operates
+normally with such servers.
+
+Repositories are nevertheless strongly encouraged to implement ETag support.
+Version listing requests represent a significant portion of network requests
+during dependency resolution, and enabling conditional caching reduces latency,
+bandwidth, and server resource usage.
 
 ## Publishing Packages
 

--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -292,7 +292,7 @@ changed.
 Package repositories may optionally support standard HTTP conditional requests
 using [ETags](https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.3)
 (`If-None-Match` / `304 Not Modified`). When an `ETag` response header is
-provided, the `dart pub` client caches it and validates the cached listing on
+provided, the `dart pub` client may cache it and validates the cached listing on
 subsequent requests.
 
 ## Publishing Packages

--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -329,10 +329,6 @@ If the package listing has changed (or if no `If-None-Match` header was sent, or
 the tag does not match), the server returns `200 OK` with the complete JSON
 listing and an updated `ETag` header.
 
-ETag support is optional for package repositories; servers that do not support
-conditional requests can simply ignore `If-None-Match` and return `200 OK` as
-usual.
-
 ## Publishing Packages
 
 **GET** `<hosted-url>/api/packages/versions/new`

--- a/doc/repository-spec-v2.md
+++ b/doc/repository-spec-v2.md
@@ -289,45 +289,11 @@ changed.
 
 ### Conditional Requests (ETags)
 
-Package repositories may support conditional HTTP requests using
-[ETags](https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.3) to allow
-clients to cache version listings and avoid transferring the full payload when
-no changes have occurred.
-
-When returning a `200 OK` response for the package listing, the repository may
-include an `ETag` HTTP response header:
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/vnd.pub.v2+json
-ETag: W/"123456789"
-```
-
-When the `dart pub` client has a cached package listing that was saved with an
-ETag, subsequent requests to `<hosted-url>/api/packages/<package>` will include
-an `If-None-Match` header carrying that ETag:
-
-```http
-GET /api/packages/<package> HTTP/1.1
-Host: <hosted-url>
-Accept: application/vnd.pub.v2+json
-If-None-Match: W/"123456789"
-```
-
-If the package listing has not changed on the server, the repository should
-respond with `304 Not Modified` and an empty response body:
-
-```http
-HTTP/1.1 304 Not Modified
-ETag: W/"123456789"
-```
-
-When receiving `304 Not Modified`, the client reuses its previously cached
-version listing document without downloading or parsing the JSON body again.
-
-If the package listing has changed (or if no `If-None-Match` header was sent, or
-the tag does not match), the server returns `200 OK` with the complete JSON
-listing and an updated `ETag` header.
+Package repositories may optionally support standard HTTP conditional requests
+using [ETags](https://datatracker.ietf.org/doc/html/rfc9110#section-8.8.3)
+(`If-None-Match` / `304 Not Modified`). When an `ETag` response header is
+provided, the `dart pub` client caches it and validates the cached listing on
+subsequent requests.
 
 ## Publishing Packages
 


### PR DESCRIPTION
## Summary

Documents support for HTTP conditional requests (`If-None-Match` with `ETag`) and `304 Not Modified` responses for the package versions listing endpoint (`GET <hosted-url>/api/packages/<package>`) in `doc/repository-spec-v2.md`.

This reflects the client functionality implemented in #4890.

## Details

- Documents the optional `If-None-Match` request header and `ETag` response header for `<hosted-url>/api/packages/<package>`.
- Notes that package repositories may optionally support standard HTTP conditional requests using ETags (`If-None-Match` / `304 Not Modified`) to validate cached version listings.