### PR TITLE
Improve help text and error reporting for `pub upgrade` target constraints

### DIFF
--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -25,21 +25,26 @@ class UpgradeCommand extends PubCommand {
   @override
   String get name => 'upgrade';
   @override
-  String get description =>
-      "Upgrade the current package's dependencies to latest versions.\n"
-      '\n'
-      'Append `@<constraint>` to a dependency to require a version '
-      'constraint.\n'
-      '\n'
-      'Append `@latest` to a dependency to require the latest available '
-      'version.\n'
-      '\n'
-      'Append `@resolvable` to require the newest version resolvable with the '
-      'rest of\n'
-      'the dependencies.';
+  String get description => '''
+Upgrade the current package's dependencies to latest versions.
+
+To upgrade specific packages, pass them as arguments. You can optionally
+specify a target version or constraint after `@`:
+  * Upgrade to the latest compatible version:
+    `$topLevelProgram pub upgrade foo`
+  * Upgrade within a version constraint (same syntax as pubspec.yaml):
+    `$topLevelProgram pub upgrade foo@^1.2.3`
+  * Upgrade to a specific version:
+    `$topLevelProgram pub upgrade foo@1.2.3`
+  * Upgrade within a version range (enclose in quotes if using `<`, `>`, or spaces):
+    `$topLevelProgram pub upgrade 'foo@>=1.2.0 <2.0.0'`
+  * Upgrade to the latest available version (even if breaking):
+    `$topLevelProgram pub upgrade foo@latest`
+  * Upgrade to the newest version resolvable with other dependencies:
+    `$topLevelProgram pub upgrade foo@resolvable`''';
   @override
   String get argumentsDescription =>
-      '[dependencies[@<constraint>|@latest|@resolvable]...]';
+      '[<package>[@<constraint>|@latest|@resolvable]...]';
   @override
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-upgrade';
 
@@ -510,11 +515,11 @@ Consider using the Dart 2.19 sdk to migrate to null safety.''');
           _UpgradeTargetKind.constraint,
           VersionConstraint.parse(suffix),
         );
-      } on FormatException catch (_) {
+      } on FormatException catch (e) {
         usageException(
-          'Unknown upgrade target `$argument`. Use `<package>`, '
-          '`<package>@<constraint>`, `<package>@latest`, or '
-          '`<package>@resolvable`.',
+          'Invalid version constraint "$suffix" for "$package": ${e.message}\n'
+          'Use standard pubspec.yaml constraint syntax (such as `^1.2.3`, '
+          '`1.2.3`, or `\'>=1.2.0 <2.0.0\'`).',
         );
       }
     }

--- a/lib/src/command/upgrade.dart
+++ b/lib/src/command/upgrade.dart
@@ -28,10 +28,13 @@ class UpgradeCommand extends PubCommand {
   String get description => '''
 Upgrade the current package's dependencies to latest versions.
 
-To upgrade specific packages, pass them as arguments. You can optionally
-specify a target version or constraint after `@`:
+To upgrade specific packages, pass one or more of them as arguments. You can
+optionally specify a target version or constraint after `@`:
   * Upgrade to the latest compatible version:
     `$topLevelProgram pub upgrade foo`
+  * Upgrade multiple packages:
+    `$topLevelProgram pub upgrade foo bar`
+    `$topLevelProgram pub upgrade foo 'bar@^2.0.0'`
   * Upgrade within a version constraint (same syntax as pubspec.yaml):
     `$topLevelProgram pub upgrade foo@^1.2.3`
   * Upgrade to a specific version:
@@ -44,7 +47,7 @@ specify a target version or constraint after `@`:
     `$topLevelProgram pub upgrade foo@resolvable`''';
   @override
   String get argumentsDescription =>
-      '[<package>[@<constraint>|@latest|@resolvable]...]';
+      '[<package>[@<constraint>|@latest|@resolvable] ...]';
   @override
   String get docUrl => 'https://dart.dev/tools/pub/cmd/pub-upgrade';
 

--- a/test/testdata/goldens/help_test/pub upgrade --help.txt
+++ b/test/testdata/goldens/help_test/pub upgrade --help.txt
@@ -4,10 +4,13 @@
 $ pub upgrade --help
 Upgrade the current package's dependencies to latest versions.
 
-To upgrade specific packages, pass them as arguments. You can optionally
-specify a target version or constraint after `@`:
+To upgrade specific packages, pass one or more of them as arguments. You can
+optionally specify a target version or constraint after `@`:
   * Upgrade to the latest compatible version:
     `dart pub upgrade foo`
+  * Upgrade multiple packages:
+    `dart pub upgrade foo bar`
+    `dart pub upgrade foo 'bar@^2.0.0'`
   * Upgrade within a version constraint (same syntax as pubspec.yaml):
     `dart pub upgrade foo@^1.2.3`
   * Upgrade to a specific version:
@@ -19,7 +22,7 @@ specify a target version or constraint after `@`:
   * Upgrade to the newest version resolvable with other dependencies:
     `dart pub upgrade foo@resolvable`
 
-Usage: pub upgrade [<package>[@<constraint>|@latest|@resolvable]...]
+Usage: pub upgrade [<package>[@<constraint>|@latest|@resolvable] ...]
 -h, --help                 Print this usage information.
     --[no-]offline         Use cached packages instead of accessing the network.
 -n, --dry-run              Report what dependencies would change but don't change any.

--- a/test/testdata/goldens/help_test/pub upgrade --help.txt
+++ b/test/testdata/goldens/help_test/pub upgrade --help.txt
@@ -4,14 +4,22 @@
 $ pub upgrade --help
 Upgrade the current package's dependencies to latest versions.
 
-Append `@<constraint>` to a dependency to require a version constraint.
+To upgrade specific packages, pass them as arguments. You can optionally
+specify a target version or constraint after `@`:
+  * Upgrade to the latest compatible version:
+    `dart pub upgrade foo`
+  * Upgrade within a version constraint (same syntax as pubspec.yaml):
+    `dart pub upgrade foo@^1.2.3`
+  * Upgrade to a specific version:
+    `dart pub upgrade foo@1.2.3`
+  * Upgrade within a version range (enclose in quotes if using `<`, `>`, or spaces):
+    `dart pub upgrade 'foo@>=1.2.0 <2.0.0'`
+  * Upgrade to the latest available version (even if breaking):
+    `dart pub upgrade foo@latest`
+  * Upgrade to the newest version resolvable with other dependencies:
+    `dart pub upgrade foo@resolvable`
 
-Append `@latest` to a dependency to require the latest available version.
-
-Append `@resolvable` to require the newest version resolvable with the rest of
-the dependencies.
-
-Usage: pub upgrade [dependencies[@<constraint>|@latest|@resolvable]...]
+Usage: pub upgrade [<package>[@<constraint>|@latest|@resolvable]...]
 -h, --help                 Print this usage information.
     --[no-]offline         Use cached packages instead of accessing the network.
 -n, --dry-run              Report what dependencies would change but don't change any.

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -789,15 +789,20 @@ void main() {
     await servePackages();
     await d.appDir(dependencies: {'foo': '^1.0.0'}).create();
 
-    for (final target in ['foo@', 'foo@Latest', 'foo@not-a-version']) {
+    for (final (target, suffix) in [
+      ('foo@', ''),
+      ('foo@Latest', 'Latest'),
+      ('foo@not-a-version', 'not-a-version'),
+    ]) {
       await pubUpgrade(
         args: [target],
         error: allOf(
-          contains('Unknown upgrade target `$target`.'),
-          contains('Use `<package>`'),
-          contains('`<package>@<constraint>`'),
-          contains('`<package>@latest`'),
-          contains('`<package>@resolvable`.'),
+          contains('Invalid version constraint "$suffix" for "foo":'),
+          contains('Use standard pubspec.yaml constraint syntax'),
+          contains(
+            'Usage: pub upgrade '
+            '[<package>[@<constraint>|@latest|@resolvable]...]',
+          ),
         ),
         exitCode: exit_codes.USAGE,
       );

--- a/test/upgrade/upgrade_transitive_test.dart
+++ b/test/upgrade/upgrade_transitive_test.dart
@@ -801,7 +801,7 @@ void main() {
           contains('Use standard pubspec.yaml constraint syntax'),
           contains(
             'Usage: pub upgrade '
-            '[<package>[@<constraint>|@latest|@resolvable]...]',
+            '[<package>[@<constraint>|@latest|@resolvable] ...]',
           ),
         ),
         exitCode: exit_codes.USAGE,


### PR DESCRIPTION
- Provide concrete examples in `pub upgrade --help` illustrating valid target formats and upgrading multiple dependencies in a single command (`dart pub upgrade foo bar`, `dart pub upgrade foo 'bar@^2.0.0'`).
- Clarify that constraints follow standard `pubspec.yaml` syntax and note the need to quote constraints containing `<`, `>`, or spaces.
- Clarify the `argumentsDescription` placeholder as `[<package>[@<constraint>|@latest|@resolvable] ...]`.
- Surface detailed `FormatException` messages with syntax hints when target constraints fail to parse.

Fixes #4896